### PR TITLE
Update APIs for m139

### DIFF
--- a/api/CoreApi.ts
+++ b/api/CoreApi.ts
@@ -75,7 +75,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "b4f70219-e18b-42c5-abe3-98b07d35525e",
                     routeValues);
@@ -117,7 +117,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "b4f70219-e18b-42c5-abe3-98b07d35525e",
                     routeValues);
@@ -162,7 +162,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "b4f70219-e18b-42c5-abe3-98b07d35525e",
                     routeValues,
@@ -204,7 +204,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "5ead0b70-2572-4697-97e9-f341069a783a",
                     routeValues);
@@ -245,7 +245,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "5ead0b70-2572-4697-97e9-f341069a783a",
                     routeValues);
@@ -284,7 +284,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "5ead0b70-2572-4697-97e9-f341069a783a",
                     routeValues);
@@ -325,7 +325,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "5ead0b70-2572-4697-97e9-f341069a783a",
                     routeValues);
@@ -378,7 +378,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "294c494c-2600-4d7e-b76c-3dd50c3c95be",
                     routeValues,
@@ -420,7 +420,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "93878975-88c5-4e6a-8abb-7ddd77a8a7d8",
                     routeValues);
@@ -458,7 +458,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "93878975-88c5-4e6a-8abb-7ddd77a8a7d8",
                     routeValues);
@@ -499,7 +499,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "8031090f-ef1d-4af6-85fc-698cd75d42bf",
                     routeValues);
@@ -546,7 +546,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "8031090f-ef1d-4af6-85fc-698cd75d42bf",
                     routeValues,
@@ -589,7 +589,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "6488a877-4749-4954-82ea-7340d36be9f2",
                     routeValues,
@@ -640,7 +640,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "core",
                     "603fe2ac-9723-48b9-88ad-09305aa6c6e1",
                     routeValues,
@@ -667,7 +667,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
     }
 
     /**
-     * Get project references with the specified state
+     * Get all projects in the organization that the authenticated user has access to.
      * 
      * @param {any} stateFilter - Filter on team projects in a specific team project state (default: WellFormed).
      * @param {number} top
@@ -694,7 +694,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "core",
                     "603fe2ac-9723-48b9-88ad-09305aa6c6e1",
                     routeValues,
@@ -721,7 +721,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
     }
 
     /**
-     * Queue a project creation.
+     * Queues a project to be created. Use the [GetOperation](../../operations/operations/get) to periodically check for create project status.
      * 
      * @param {CoreInterfaces.TeamProject} projectToCreate - The project to create.
      */
@@ -735,7 +735,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "core",
                     "603fe2ac-9723-48b9-88ad-09305aa6c6e1",
                     routeValues);
@@ -761,7 +761,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
     }
 
     /**
-     * Queue a project deletion.
+     * Queues a project to be deleted. Use the [GetOperation](../../operations/operations/get) to periodically check for delete project status.
      * 
      * @param {string} projectId - The project id of the project to delete.
      */
@@ -776,7 +776,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "core",
                     "603fe2ac-9723-48b9-88ad-09305aa6c6e1",
                     routeValues);
@@ -819,7 +819,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "core",
                     "603fe2ac-9723-48b9-88ad-09305aa6c6e1",
                     routeValues);
@@ -866,7 +866,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "4976a71a-4487-49aa-8aab-a1eda469037a",
                     routeValues,
@@ -914,7 +914,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "core",
                     "4976a71a-4487-49aa-8aab-a1eda469037a",
                     routeValues);
@@ -953,7 +953,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "ec1f4311-f2b4-4c15-b2b8-8990b80d2908",
                     routeValues);
@@ -998,7 +998,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "ec1f4311-f2b4-4c15-b2b8-8990b80d2908",
                     routeValues,
@@ -1041,7 +1041,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "ec1f4311-f2b4-4c15-b2b8-8990b80d2908",
                     routeValues,
@@ -1092,7 +1092,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "7a4d9ee9-3433-4347-b47a-7a80f1cf307e",
                     routeValues,
@@ -1136,7 +1136,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "d30a3dd1-f8ba-442a-b86a-bd0c0c383e59",
                     routeValues);
@@ -1180,7 +1180,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "d30a3dd1-f8ba-442a-b86a-bd0c0c383e59",
                     routeValues);
@@ -1224,7 +1224,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "d30a3dd1-f8ba-442a-b86a-bd0c0c383e59",
                     routeValues);
@@ -1277,7 +1277,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "d30a3dd1-f8ba-442a-b86a-bd0c0c383e59",
                     routeValues,
@@ -1324,7 +1324,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "core",
                     "d30a3dd1-f8ba-442a-b86a-bd0c0c383e59",
                     routeValues);

--- a/api/DashboardApi.ts
+++ b/api/DashboardApi.ts
@@ -31,14 +31,16 @@ export interface IDashboardApi extends basem.ClientApiBase {
     getWidget(teamContext: TfsCoreInterfaces.TeamContext, dashboardId: string, widgetId: string): Promise<DashboardInterfaces.Widget>;
     replaceWidget(widget: DashboardInterfaces.Widget, teamContext: TfsCoreInterfaces.TeamContext, dashboardId: string, widgetId: string): Promise<DashboardInterfaces.Widget>;
     updateWidget(widget: DashboardInterfaces.Widget, teamContext: TfsCoreInterfaces.TeamContext, dashboardId: string, widgetId: string): Promise<DashboardInterfaces.Widget>;
-    getWidgetMetadata(contributionId: string): Promise<DashboardInterfaces.WidgetMetadataResponse>;
-    getWidgetTypes(scope: DashboardInterfaces.WidgetScope): Promise<DashboardInterfaces.WidgetTypesResponse>;
+    getWidgetMetadata(contributionId: string, project?: string): Promise<DashboardInterfaces.WidgetMetadataResponse>;
+    getWidgetTypes(scope: DashboardInterfaces.WidgetScope, project?: string): Promise<DashboardInterfaces.WidgetTypesResponse>;
 }
 
 export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-Dashboard-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "31c84e0a-3ece-48fd-a29d-100849af99ba";
 
     /**
      * Create the supplied dashboard.
@@ -62,7 +64,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -110,7 +112,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -158,7 +160,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -203,7 +205,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -229,7 +231,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
     }
 
     /**
-     * Replace configuration for the specified dashboard.
+     * Replace configuration for the specified dashboard. Replaces Widget list on Dashboard, only if property is supplied.
      * 
      * @param {DashboardInterfaces.Dashboard} dashboard - The Configuration of the dashboard to replace.
      * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
@@ -253,7 +255,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -300,7 +302,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "454b3e51-2e6e-48d4-ad81-978154089351",
                     routeValues);
@@ -350,7 +352,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "bdcff53a-8355-4172-a00a-40497ea23afc",
                     routeValues);
@@ -401,7 +403,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "bdcff53a-8355-4172-a00a-40497ea23afc",
                     routeValues);
@@ -452,7 +454,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "bdcff53a-8355-4172-a00a-40497ea23afc",
                     routeValues);
@@ -505,7 +507,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "bdcff53a-8355-4172-a00a-40497ea23afc",
                     routeValues);
@@ -558,7 +560,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Dashboard",
                     "bdcff53a-8355-4172-a00a-40497ea23afc",
                     routeValues);
@@ -587,19 +589,22 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
      * Get the widget metadata satisfying the specified contribution ID.
      * 
      * @param {string} contributionId - The ID of Contribution for the Widget
+     * @param {string} project - Project ID or project name
      */
     public async getWidgetMetadata(
-        contributionId: string
+        contributionId: string,
+        project?: string
         ): Promise<DashboardInterfaces.WidgetMetadataResponse> {
 
         return new Promise<DashboardInterfaces.WidgetMetadataResponse>(async (resolve, reject) => {
             let routeValues: any = {
+                project: project,
                 contributionId: contributionId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Dashboard",
                     "6b3628d3-e96f-4fc7-b176-50240b03b515",
                     routeValues);
@@ -628,13 +633,16 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
      * Get all available widget metadata in alphabetical order.
      * 
      * @param {DashboardInterfaces.WidgetScope} scope
+     * @param {string} project - Project ID or project name
      */
     public async getWidgetTypes(
-        scope: DashboardInterfaces.WidgetScope
+        scope: DashboardInterfaces.WidgetScope,
+        project?: string
         ): Promise<DashboardInterfaces.WidgetTypesResponse> {
 
         return new Promise<DashboardInterfaces.WidgetTypesResponse>(async (resolve, reject) => {
             let routeValues: any = {
+                project: project
             };
 
             let queryValues: any = {
@@ -643,7 +651,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Dashboard",
                     "6b3628d3-e96f-4fc7-b176-50240b03b515",
                     routeValues,

--- a/api/ExtensionManagementApi.ts
+++ b/api/ExtensionManagementApi.ts
@@ -20,7 +20,7 @@ import ExtensionManagementInterfaces = require("./interfaces/ExtensionManagement
 import GalleryInterfaces = require("./interfaces/GalleryInterfaces");
 
 export interface IExtensionManagementApi extends basem.ClientApiBase {
-    getAcquisitionOptions(itemId: string, testCommerce?: boolean, isFreeOrTrialInstall?: boolean, isAccountOwner?: boolean): Promise<ExtensionManagementInterfaces.AcquisitionOptions>;
+    getAcquisitionOptions(itemId: string, testCommerce?: boolean, isFreeOrTrialInstall?: boolean, isAccountOwner?: boolean, isLinked?: boolean, isConnectedServer?: boolean, isBuyOperationValid?: boolean): Promise<ExtensionManagementInterfaces.AcquisitionOptions>;
     requestAcquisition(acquisitionRequest: ExtensionManagementInterfaces.ExtensionAcquisitionRequest): Promise<ExtensionManagementInterfaces.ExtensionAcquisitionRequest>;
     registerAuthorization(publisherName: string, extensionName: string, registrationId: string): Promise<ExtensionManagementInterfaces.ExtensionAuthorization>;
     createDocumentByName(doc: any, publisherName: string, extensionName: string, scopeType: string, scopeValue: string, collectionName: string): Promise<any>;
@@ -58,12 +58,18 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
      * @param {boolean} testCommerce
      * @param {boolean} isFreeOrTrialInstall
      * @param {boolean} isAccountOwner
+     * @param {boolean} isLinked
+     * @param {boolean} isConnectedServer
+     * @param {boolean} isBuyOperationValid
      */
     public async getAcquisitionOptions(
         itemId: string,
         testCommerce?: boolean,
         isFreeOrTrialInstall?: boolean,
-        isAccountOwner?: boolean
+        isAccountOwner?: boolean,
+        isLinked?: boolean,
+        isConnectedServer?: boolean,
+        isBuyOperationValid?: boolean
         ): Promise<ExtensionManagementInterfaces.AcquisitionOptions> {
 
         return new Promise<ExtensionManagementInterfaces.AcquisitionOptions>(async (resolve, reject) => {
@@ -75,11 +81,14 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 testCommerce: testCommerce,
                 isFreeOrTrialInstall: isFreeOrTrialInstall,
                 isAccountOwner: isAccountOwner,
+                isLinked: isLinked,
+                isConnectedServer: isConnectedServer,
+                isBuyOperationValid: isBuyOperationValid,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "288dff58-d13b-468e-9671-0fb754e9398c",
                     routeValues,
@@ -118,7 +127,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "da616457-eed3-4672-92d7-18d21f5c1658",
                     routeValues);
@@ -163,7 +172,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "f21cfc80-d2d2-4248-98bb-7820c74c4606",
                     routeValues);
@@ -216,7 +225,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -270,7 +279,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -324,7 +333,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -375,7 +384,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -428,7 +437,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -481,7 +490,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "bbe06c18-1c8b-4fcd-b9c6-1535aaab8749",
                     routeValues);
@@ -527,7 +536,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "56c331f1-ce53-4318-adfd-4db5c52a7a2e",
                     routeValues);
@@ -577,7 +586,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "92755d3d-9a8a-42b3-8a4d-87359fe5aa93",
                     routeValues,
@@ -616,7 +625,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "046c980f-1345-4ce2-bf85-b46d10ff4cfd",
                     routeValues);
@@ -669,7 +678,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "275424d0-c844-4fe2-bda6-04933a1357d8",
                     routeValues,
@@ -710,7 +719,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "275424d0-c844-4fe2-bda6-04933a1357d8",
                     routeValues);
@@ -760,7 +769,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "fb0da285-f23e-4b56-8b53-3ef5f9f6de66",
                     routeValues,
@@ -808,7 +817,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "fb0da285-f23e-4b56-8b53-3ef5f9f6de66",
                     routeValues);
@@ -861,7 +870,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "fb0da285-f23e-4b56-8b53-3ef5f9f6de66",
                     routeValues,
@@ -901,7 +910,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "e5cc8c09-407b-4867-8319-2ae3338cbf6f",
                     routeValues);
@@ -954,7 +963,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "aa93e1f3-511c-4364-8b9c-eb98818f2e0b",
                     routeValues,
@@ -991,7 +1000,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "216b978f-b164-424e-ada2-b77561e842b7",
                     routeValues);
@@ -1041,7 +1050,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "ba93e1f3-511c-4364-8b9c-eb98818f2e0b",
                     routeValues,
@@ -1084,7 +1093,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "f5afca1e-a728-4294-aa2d-4af0173431b5",
                     routeValues);
@@ -1128,7 +1137,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "f5afca1e-a728-4294-aa2d-4af0173431b5",
                     routeValues);
@@ -1164,7 +1173,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "ExtensionManagement",
                     "3a2e24ed-1d6f-4cb2-9f3b-45a96bbfaf50",
                     routeValues);

--- a/api/FeatureManagementApi.ts
+++ b/api/FeatureManagementApi.ts
@@ -51,7 +51,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "c4209f25-7a27-41dd-9f04-06080c7b6afd",
                     routeValues);
@@ -95,7 +95,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "c4209f25-7a27-41dd-9f04-06080c7b6afd",
                     routeValues,
@@ -140,7 +140,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "98911314-3f9b-4eaf-80e8-83900d8e85d9",
                     routeValues);
@@ -195,7 +195,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "98911314-3f9b-4eaf-80e8-83900d8e85d9",
                     routeValues,
@@ -246,7 +246,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "dd291e43-aa9f-4cee-8465-a93c78e414a4",
                     routeValues);
@@ -307,7 +307,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "dd291e43-aa9f-4cee-8465-a93c78e414a4",
                     routeValues,
@@ -348,7 +348,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "2b4486ad-122b-400c-ae65-17b6672c1f9d",
                     routeValues);
@@ -391,7 +391,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "3f810f28-03e2-4239-b0bc-788add3005e5",
                     routeValues);
@@ -440,7 +440,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "FeatureManagement",
                     "f29e997b-c2da-4d15-8380-765788a1a74c",
                     routeValues);

--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -23,10 +23,10 @@ import VSSInterfaces = require("./interfaces/common/VSSInterfaces");
 export interface IGitApi extends basem.ClientApiBase {
     createAnnotatedTag(tagObject: GitInterfaces.GitAnnotatedTag, project: string, repositoryId: string): Promise<GitInterfaces.GitAnnotatedTag>;
     getAnnotatedTag(project: string, repositoryId: string, objectId: string): Promise<GitInterfaces.GitAnnotatedTag>;
-    getBlob(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string): Promise<GitInterfaces.GitBlobRef>;
-    getBlobContent(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string): Promise<NodeJS.ReadableStream>;
+    getBlob(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string, resolveLfs?: boolean): Promise<GitInterfaces.GitBlobRef>;
+    getBlobContent(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string, resolveLfs?: boolean): Promise<NodeJS.ReadableStream>;
     getBlobsZip(blobIds: string[], repositoryId: string, project?: string, filename?: string): Promise<NodeJS.ReadableStream>;
-    getBlobZip(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string): Promise<NodeJS.ReadableStream>;
+    getBlobZip(repositoryId: string, sha1: string, project?: string, download?: boolean, fileName?: string, resolveLfs?: boolean): Promise<NodeJS.ReadableStream>;
     getBranch(repositoryId: string, name: string, project?: string, baseVersionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<GitInterfaces.GitBranchStats>;
     getBranches(repositoryId: string, project?: string, baseVersionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<GitInterfaces.GitBranchStats[]>;
     getBranchStatsBatch(searchCriteria: GitInterfaces.GitQueryBranchStatsCriteria, repositoryId: string, project?: string): Promise<GitInterfaces.GitBranchStats[]>;
@@ -48,11 +48,11 @@ export interface IGitApi extends basem.ClientApiBase {
     getImportRequest(project: string, repositoryId: string, importRequestId: number): Promise<GitInterfaces.GitImportRequest>;
     queryImportRequests(project: string, repositoryId: string, includeAbandoned?: boolean): Promise<GitInterfaces.GitImportRequest[]>;
     updateImportRequest(importRequestToUpdate: GitInterfaces.GitImportRequest, project: string, repositoryId: string, importRequestId: number): Promise<GitInterfaces.GitImportRequest>;
-    getItem(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<GitInterfaces.GitItem>;
-    getItemContent(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<NodeJS.ReadableStream>;
+    getItem(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor, includeContent?: boolean, resolveLfs?: boolean): Promise<GitInterfaces.GitItem>;
+    getItemContent(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor, includeContent?: boolean, resolveLfs?: boolean): Promise<NodeJS.ReadableStream>;
     getItems(repositoryId: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, includeLinks?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<GitInterfaces.GitItem[]>;
-    getItemText(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<NodeJS.ReadableStream>;
-    getItemZip(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor): Promise<NodeJS.ReadableStream>;
+    getItemText(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor, includeContent?: boolean, resolveLfs?: boolean): Promise<NodeJS.ReadableStream>;
+    getItemZip(repositoryId: string, path: string, project?: string, scopePath?: string, recursionLevel?: GitInterfaces.VersionControlRecursionType, includeContentMetadata?: boolean, latestProcessedChange?: boolean, download?: boolean, versionDescriptor?: GitInterfaces.GitVersionDescriptor, includeContent?: boolean, resolveLfs?: boolean): Promise<NodeJS.ReadableStream>;
     getItemsBatch(requestData: GitInterfaces.GitItemRequestData, repositoryId: string, project?: string): Promise<GitInterfaces.GitItem[][]>;
     getMergeBases(repositoryNameOrId: string, commitId: string, otherCommitId: string, project?: string, otherCollectionId?: string, otherRepositoryId?: string): Promise<GitInterfaces.GitCommitRef[]>;
     createAttachment(customHeaders: any, contentStream: NodeJS.ReadableStream, fileName: string, repositoryId: string, pullRequestId: number, project?: string): Promise<GitInterfaces.Attachment>;
@@ -90,7 +90,7 @@ export interface IGitApi extends basem.ClientApiBase {
     getPullRequestReviewer(repositoryId: string, pullRequestId: number, reviewerId: string, project?: string): Promise<GitInterfaces.IdentityRefWithVote>;
     getPullRequestReviewers(repositoryId: string, pullRequestId: number, project?: string): Promise<GitInterfaces.IdentityRefWithVote[]>;
     updatePullRequestReviewers(patchVotes: GitInterfaces.IdentityRefWithVote[], repositoryId: string, pullRequestId: number, project?: string): Promise<void>;
-    getPullRequestById(pullRequestId: number): Promise<GitInterfaces.GitPullRequest>;
+    getPullRequestById(pullRequestId: number, project?: string): Promise<GitInterfaces.GitPullRequest>;
     getPullRequestsByProject(project: string, searchCriteria: GitInterfaces.GitPullRequestSearchCriteria, maxCommentLength?: number, skip?: number, top?: number): Promise<GitInterfaces.GitPullRequest[]>;
     createPullRequest(gitPullRequestToCreate: GitInterfaces.GitPullRequest, repositoryId: string, project?: string, supportsIterations?: boolean): Promise<GitInterfaces.GitPullRequest>;
     getPullRequest(repositoryId: string, pullRequestId: number, project?: string, maxCommentLength?: number, skip?: number, top?: number, includeCommits?: boolean, includeWorkItemRefs?: boolean): Promise<GitInterfaces.GitPullRequest>;
@@ -111,11 +111,14 @@ export interface IGitApi extends basem.ClientApiBase {
     getPullRequestThread(repositoryId: string, pullRequestId: number, threadId: number, project?: string, iteration?: number, baseIteration?: number): Promise<GitInterfaces.GitPullRequestCommentThread>;
     getThreads(repositoryId: string, pullRequestId: number, project?: string, iteration?: number, baseIteration?: number): Promise<GitInterfaces.GitPullRequestCommentThread[]>;
     updateThread(commentThread: GitInterfaces.GitPullRequestCommentThread, repositoryId: string, pullRequestId: number, threadId: number, project?: string): Promise<GitInterfaces.GitPullRequestCommentThread>;
-    getPullRequestWorkItems(repositoryId: string, pullRequestId: number, project?: string): Promise<GitInterfaces.AssociatedWorkItem[]>;
+    getPullRequestWorkItemRefs(repositoryId: string, pullRequestId: number, project?: string): Promise<VSSInterfaces.ResourceRef[]>;
     createPush(push: GitInterfaces.GitPush, repositoryId: string, project?: string): Promise<GitInterfaces.GitPush>;
     getPush(repositoryId: string, pushId: number, project?: string, includeCommits?: number, includeRefUpdates?: boolean): Promise<GitInterfaces.GitPush>;
     getPushes(repositoryId: string, project?: string, skip?: number, top?: number, searchCriteria?: GitInterfaces.GitPushSearchCriteria): Promise<GitInterfaces.GitPush[]>;
-    getRefs(repositoryId: string, project?: string, filter?: string, includeLinks?: boolean, latestStatusesOnly?: boolean): Promise<GitInterfaces.GitRef[]>;
+    deleteRepositoryFromRecycleBin(project: string, repositoryId: string): Promise<void>;
+    getRecycleBinRepositories(project: string): Promise<GitInterfaces.GitDeletedRepository[]>;
+    restoreRepositoryFromRecycleBin(repositoryDetails: GitInterfaces.GitRecycleBinRepositoryDetails, project: string, repositoryId: string): Promise<GitInterfaces.GitRepository>;
+    getRefs(repositoryId: string, project?: string, filter?: string, includeLinks?: boolean, includeStatuses?: boolean, includeMyBranches?: boolean, latestStatusesOnly?: boolean, peelTags?: boolean): Promise<GitInterfaces.GitRef[]>;
     updateRef(newRefInfo: GitInterfaces.GitRefUpdate, repositoryId: string, filter: string, project?: string, projectId?: string): Promise<GitInterfaces.GitRef>;
     updateRefs(refUpdates: GitInterfaces.GitRefUpdate[], repositoryId: string, project?: string, projectId?: string): Promise<GitInterfaces.GitRefUpdateResult[]>;
     createFavorite(favorite: GitInterfaces.GitRefFavorite, project: string): Promise<GitInterfaces.GitRefFavorite>;
@@ -125,7 +128,8 @@ export interface IGitApi extends basem.ClientApiBase {
     createRepository(gitRepositoryToCreate: GitInterfaces.GitRepositoryCreateOptions, project?: string, sourceRef?: string): Promise<GitInterfaces.GitRepository>;
     deleteRepository(repositoryId: string, project?: string): Promise<void>;
     getRepositories(project?: string, includeLinks?: boolean, includeAllUrls?: boolean, includeHidden?: boolean): Promise<GitInterfaces.GitRepository[]>;
-    getRepository(repositoryId: string, project?: string, includeParent?: boolean): Promise<GitInterfaces.GitRepository>;
+    getRepository(repositoryId: string, project?: string): Promise<GitInterfaces.GitRepository>;
+    getRepositoryWithParent(repositoryId: string, includeParent: boolean, project?: string): Promise<GitInterfaces.GitRepository>;
     updateRepository(newRepositoryInfo: GitInterfaces.GitRepository, repositoryId: string, project?: string): Promise<GitInterfaces.GitRepository>;
     createRevert(revertToCreate: GitInterfaces.GitAsyncRefOperationParameters, project: string, repositoryId: string): Promise<GitInterfaces.GitRevert>;
     getRevert(project: string, revertId: number, repositoryId: string): Promise<GitInterfaces.GitRevert>;
@@ -165,7 +169,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5e8a8081-3851-4626-b677-9891cc04102e",
                     routeValues);
@@ -212,7 +216,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5e8a8081-3851-4626-b677-9891cc04102e",
                     routeValues);
@@ -241,17 +245,19 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * Get a single blob.
      * 
      * @param {string} repositoryId - The name or ID of the repository.
-     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the “Git/Items/Get Item” endpoint.
+     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the "Git/Items/Get Item" endpoint.
      * @param {string} project - Project ID or project name
      * @param {boolean} download - If true, prompt for a download rather than rendering in a browser. Note: this value defaults to true if $format is zip
      * @param {string} fileName - Provide a fileName to use for a download.
+     * @param {boolean} resolveLfs - If true, try to resolve a blob to its LFS contents, if it's an LFS pointer file. Only compatible with octet-stream Accept headers or $format types
      */
     public async getBlob(
         repositoryId: string,
         sha1: string,
         project?: string,
         download?: boolean,
-        fileName?: string
+        fileName?: string,
+        resolveLfs?: boolean
         ): Promise<GitInterfaces.GitBlobRef> {
 
         return new Promise<GitInterfaces.GitBlobRef>(async (resolve, reject) => {
@@ -264,11 +270,12 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             let queryValues: any = {
                 download: download,
                 fileName: fileName,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "7b28e929-2c99-405d-9c5c-6167a06e6816",
                     routeValues,
@@ -298,17 +305,19 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * Get a single blob.
      * 
      * @param {string} repositoryId - The name or ID of the repository.
-     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the “Git/Items/Get Item” endpoint.
+     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the "Git/Items/Get Item" endpoint.
      * @param {string} project - Project ID or project name
      * @param {boolean} download - If true, prompt for a download rather than rendering in a browser. Note: this value defaults to true if $format is zip
      * @param {string} fileName - Provide a fileName to use for a download.
+     * @param {boolean} resolveLfs - If true, try to resolve a blob to its LFS contents, if it's an LFS pointer file. Only compatible with octet-stream Accept headers or $format types
      */
     public async getBlobContent(
         repositoryId: string,
         sha1: string,
         project?: string,
         download?: boolean,
-        fileName?: string
+        fileName?: string,
+        resolveLfs?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -321,11 +330,12 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             let queryValues: any = {
                 download: download,
                 fileName: fileName,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "7b28e929-2c99-405d-9c5c-6167a06e6816",
                     routeValues,
@@ -370,7 +380,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "7b28e929-2c99-405d-9c5c-6167a06e6816",
                     routeValues,
@@ -392,17 +402,19 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * Get a single blob.
      * 
      * @param {string} repositoryId - The name or ID of the repository.
-     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the “Git/Items/Get Item” endpoint.
+     * @param {string} sha1 - SHA1 hash of the file. You can get the SHA1 of a file using the "Git/Items/Get Item" endpoint.
      * @param {string} project - Project ID or project name
      * @param {boolean} download - If true, prompt for a download rather than rendering in a browser. Note: this value defaults to true if $format is zip
      * @param {string} fileName - Provide a fileName to use for a download.
+     * @param {boolean} resolveLfs - If true, try to resolve a blob to its LFS contents, if it's an LFS pointer file. Only compatible with octet-stream Accept headers or $format types
      */
     public async getBlobZip(
         repositoryId: string,
         sha1: string,
         project?: string,
         download?: boolean,
-        fileName?: string
+        fileName?: string,
+        resolveLfs?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -415,11 +427,12 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             let queryValues: any = {
                 download: download,
                 fileName: fileName,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "7b28e929-2c99-405d-9c5c-6167a06e6816",
                     routeValues,
@@ -465,7 +478,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d5b216de-d8d5-4d32-ae76-51df755b16d3",
                     routeValues,
@@ -516,7 +529,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d5b216de-d8d5-4d32-ae76-51df755b16d3",
                     routeValues,
@@ -561,7 +574,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d5b216de-d8d5-4d32-ae76-51df755b16d3",
                     routeValues);
@@ -617,7 +630,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5bf884f5-3e07-42e9-afb8-1b872267bf16",
                     routeValues,
@@ -671,7 +684,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "8af142a4-27c2-4168-9e82-46b8629aaa0d",
                     routeValues,
@@ -718,7 +731,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "033bad68-9a14-43d1-90e0-59cb8856fef6",
                     routeValues);
@@ -765,7 +778,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "033bad68-9a14-43d1-90e0-59cb8856fef6",
                     routeValues);
@@ -815,7 +828,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "033bad68-9a14-43d1-90e0-59cb8856fef6",
                     routeValues,
@@ -869,7 +882,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "c2570c3b-5b3f-41b8-98bf-5407bfde8d58",
                     routeValues,
@@ -926,7 +939,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "c2570c3b-5b3f-41b8-98bf-5407bfde8d58",
                     routeValues,
@@ -960,7 +973,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {string} project - Project ID or project name
      * @param {number} top - The maximum number of commits to return ("get the top x commits").
      * @param {number} skip - The number of commits to skip.
-     * @param {boolean} includeLinks
+     * @param {boolean} includeLinks - Set to false to avoid including REST Url links for resources. Defaults to true.
      */
     public async getPushCommits(
         repositoryId: string,
@@ -986,7 +999,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "c2570c3b-5b3f-41b8-98bf-5407bfde8d58",
                     routeValues,
@@ -1045,7 +1058,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "6400dfb2-0bcb-462b-b992-5a57f8f1416c",
                     routeValues,
@@ -1087,7 +1100,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "2b6869c4-cb25-42b5-b7a3-0d3e6be0a11a",
                     routeValues);
@@ -1140,7 +1153,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "158c0340-bf6f-489c-9625-d572a1480d57",
                     routeValues,
@@ -1193,7 +1206,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "1703f858-b9d1-46af-ab62-483e9e1055b5",
                     routeValues,
@@ -1247,7 +1260,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "1703f858-b9d1-46af-ab62-483e9e1055b5",
                     routeValues,
@@ -1301,7 +1314,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "1703f858-b9d1-46af-ab62-483e9e1055b5",
                     routeValues,
@@ -1348,7 +1361,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "01828ddc-3600-4a41-8633-99b3a73a0eb3",
                     routeValues);
@@ -1395,7 +1408,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "01828ddc-3600-4a41-8633-99b3a73a0eb3",
                     routeValues);
@@ -1445,7 +1458,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "01828ddc-3600-4a41-8633-99b3a73a0eb3",
                     routeValues,
@@ -1495,7 +1508,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "01828ddc-3600-4a41-8633-99b3a73a0eb3",
                     routeValues);
@@ -1523,7 +1536,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Get Item Metadata and/or Content for a single item. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content, which is always returned as a download.
      * 
-     * @param {string} repositoryId - The Id of the repository.
+     * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} path - The item path.
      * @param {string} project - Project ID or project name
      * @param {string} scopePath - The path scope.  The default is null.
@@ -1532,6 +1545,8 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {boolean} latestProcessedChange - Set to true to include the lastest changes.  Default is false.
      * @param {boolean} download - Set to true to download the response as a file.  Default is false.
      * @param {GitInterfaces.GitVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
+     * @param {boolean} resolveLfs - Set to true to resolve Git LFS pointer files to return actual content from Git LFS.  Default is false.
      */
     public async getItem(
         repositoryId: string,
@@ -1542,7 +1557,9 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
         includeContentMetadata?: boolean,
         latestProcessedChange?: boolean,
         download?: boolean,
-        versionDescriptor?: GitInterfaces.GitVersionDescriptor
+        versionDescriptor?: GitInterfaces.GitVersionDescriptor,
+        includeContent?: boolean,
+        resolveLfs?: boolean
         ): Promise<GitInterfaces.GitItem> {
 
         return new Promise<GitInterfaces.GitItem>(async (resolve, reject) => {
@@ -1559,11 +1576,13 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 latestProcessedChange: latestProcessedChange,
                 download: download,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "fb93c0db-47ed-4a31-8c20-47552878fb44",
                     routeValues,
@@ -1592,7 +1611,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Get Item Metadata and/or Content for a single item. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content, which is always returned as a download.
      * 
-     * @param {string} repositoryId - The Id of the repository.
+     * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} path - The item path.
      * @param {string} project - Project ID or project name
      * @param {string} scopePath - The path scope.  The default is null.
@@ -1601,6 +1620,8 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {boolean} latestProcessedChange - Set to true to include the lastest changes.  Default is false.
      * @param {boolean} download - Set to true to download the response as a file.  Default is false.
      * @param {GitInterfaces.GitVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
+     * @param {boolean} resolveLfs - Set to true to resolve Git LFS pointer files to return actual content from Git LFS.  Default is false.
      */
     public async getItemContent(
         repositoryId: string,
@@ -1611,7 +1632,9 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
         includeContentMetadata?: boolean,
         latestProcessedChange?: boolean,
         download?: boolean,
-        versionDescriptor?: GitInterfaces.GitVersionDescriptor
+        versionDescriptor?: GitInterfaces.GitVersionDescriptor,
+        includeContent?: boolean,
+        resolveLfs?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -1628,11 +1651,13 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 latestProcessedChange: latestProcessedChange,
                 download: download,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "fb93c0db-47ed-4a31-8c20-47552878fb44",
                     routeValues,
@@ -1653,7 +1678,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Get Item Metadata and/or Content for a collection of items. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content which is always returned as a download.
      * 
-     * @param {string} repositoryId - The Id of the repository.
+     * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} project - Project ID or project name
      * @param {string} scopePath - The path scope.  The default is null.
      * @param {GitInterfaces.VersionControlRecursionType} recursionLevel - The recursion level of this request. The default is 'none', no recursion.
@@ -1693,7 +1718,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "fb93c0db-47ed-4a31-8c20-47552878fb44",
                     routeValues,
@@ -1722,7 +1747,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Get Item Metadata and/or Content for a single item. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content, which is always returned as a download.
      * 
-     * @param {string} repositoryId - The Id of the repository.
+     * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} path - The item path.
      * @param {string} project - Project ID or project name
      * @param {string} scopePath - The path scope.  The default is null.
@@ -1731,6 +1756,8 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {boolean} latestProcessedChange - Set to true to include the lastest changes.  Default is false.
      * @param {boolean} download - Set to true to download the response as a file.  Default is false.
      * @param {GitInterfaces.GitVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
+     * @param {boolean} resolveLfs - Set to true to resolve Git LFS pointer files to return actual content from Git LFS.  Default is false.
      */
     public async getItemText(
         repositoryId: string,
@@ -1741,7 +1768,9 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
         includeContentMetadata?: boolean,
         latestProcessedChange?: boolean,
         download?: boolean,
-        versionDescriptor?: GitInterfaces.GitVersionDescriptor
+        versionDescriptor?: GitInterfaces.GitVersionDescriptor,
+        includeContent?: boolean,
+        resolveLfs?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -1758,11 +1787,13 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 latestProcessedChange: latestProcessedChange,
                 download: download,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "fb93c0db-47ed-4a31-8c20-47552878fb44",
                     routeValues,
@@ -1783,7 +1814,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Get Item Metadata and/or Content for a single item. The download parameter is to indicate whether the content should be available as a download or just sent as a stream in the response. Doesn't apply to zipped content, which is always returned as a download.
      * 
-     * @param {string} repositoryId - The Id of the repository.
+     * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} path - The item path.
      * @param {string} project - Project ID or project name
      * @param {string} scopePath - The path scope.  The default is null.
@@ -1792,6 +1823,8 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {boolean} latestProcessedChange - Set to true to include the lastest changes.  Default is false.
      * @param {boolean} download - Set to true to download the response as a file.  Default is false.
      * @param {GitInterfaces.GitVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
+     * @param {boolean} resolveLfs - Set to true to resolve Git LFS pointer files to return actual content from Git LFS.  Default is false.
      */
     public async getItemZip(
         repositoryId: string,
@@ -1802,7 +1835,9 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
         includeContentMetadata?: boolean,
         latestProcessedChange?: boolean,
         download?: boolean,
-        versionDescriptor?: GitInterfaces.GitVersionDescriptor
+        versionDescriptor?: GitInterfaces.GitVersionDescriptor,
+        includeContent?: boolean,
+        resolveLfs?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -1819,11 +1854,13 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 latestProcessedChange: latestProcessedChange,
                 download: download,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
+                resolveLfs: resolveLfs,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "fb93c0db-47ed-4a31-8c20-47552878fb44",
                     routeValues,
@@ -1862,7 +1899,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "630fd2e4-fb88-4f85-ad21-13f3fd1fbca9",
                     routeValues);
@@ -1921,7 +1958,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "7cf2abb6-c964-4f7e-9872-f78c66e72e9c",
                     routeValues,
@@ -1978,7 +2015,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965d9361-878b-413b-a494-45d5b5fd8ab7",
                     routeValues);
@@ -2029,7 +2066,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965d9361-878b-413b-a494-45d5b5fd8ab7",
                     routeValues);
@@ -2079,7 +2116,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965d9361-878b-413b-a494-45d5b5fd8ab7",
                     routeValues);
@@ -2118,7 +2155,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965d9361-878b-413b-a494-45d5b5fd8ab7",
                     routeValues);
@@ -2168,7 +2205,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965d9361-878b-413b-a494-45d5b5fd8ab7",
                     routeValues);
@@ -2213,7 +2250,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5f2e2851-1389-425b-a00b-fb2adb3ef31b",
                     routeValues);
@@ -2266,7 +2303,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5f2e2851-1389-425b-a00b-fb2adb3ef31b",
                     routeValues);
@@ -2319,7 +2356,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "5f2e2851-1389-425b-a00b-fb2adb3ef31b",
                     routeValues);
@@ -2369,7 +2406,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "e7ea0883-095f-4926-b5fb-f24691c26fb9",
                     routeValues);
@@ -2416,7 +2453,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "52823034-34a8-4576-922c-8d8b77e9e4c4",
                     routeValues);
@@ -2466,7 +2503,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d840fb74-bbef-42d3-b250-564604c054a4",
                     routeValues);
@@ -2531,7 +2568,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d840fb74-bbef-42d3-b250-564604c054a4",
                     routeValues,
@@ -2584,7 +2621,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d840fb74-bbef-42d3-b250-564604c054a4",
                     routeValues);
@@ -2633,7 +2670,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d840fb74-bbef-42d3-b250-564604c054a4",
                     routeValues);
@@ -2695,7 +2732,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4216bdcf-b6b1-4d59-8b82-c34cc183fc8b",
                     routeValues,
@@ -2746,7 +2783,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d43911ee-6958-46b0-a42b-8445b8a0d004",
                     routeValues);
@@ -2799,7 +2836,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "d43911ee-6958-46b0-a42b-8445b8a0d004",
                     routeValues,
@@ -2852,7 +2889,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "75cf11c5-979f-4038-a76e-058a06adf2bf",
                     routeValues);
@@ -2905,7 +2942,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "75cf11c5-979f-4038-a76e-058a06adf2bf",
                     routeValues);
@@ -2958,7 +2995,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "75cf11c5-979f-4038-a76e-058a06adf2bf",
                     routeValues);
@@ -3008,7 +3045,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "75cf11c5-979f-4038-a76e-058a06adf2bf",
                     routeValues);
@@ -3064,7 +3101,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "75cf11c5-979f-4038-a76e-058a06adf2bf",
                     routeValues);
@@ -3120,7 +3157,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "f22387e3-984e-4c52-9c6d-fbb8f14c812d",
                     routeValues,
@@ -3177,7 +3214,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "f22387e3-984e-4c52-9c6d-fbb8f14c812d",
                     routeValues,
@@ -3234,7 +3271,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "f22387e3-984e-4c52-9c6d-fbb8f14c812d",
                     routeValues,
@@ -3288,7 +3325,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "f22387e3-984e-4c52-9c6d-fbb8f14c812d",
                     routeValues,
@@ -3336,7 +3373,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "48a52185-5b9e-4736-9dc1-bb1e2feac80b",
                     routeValues);
@@ -3389,7 +3426,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "48a52185-5b9e-4736-9dc1-bb1e2feac80b",
                     routeValues);
@@ -3436,7 +3473,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b3a6eebe-9cf0-49ea-b6cb-1a4c5f5007b0",
                     routeValues);
@@ -3488,7 +3525,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3537,7 +3574,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3587,7 +3624,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3637,7 +3674,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3684,7 +3721,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3733,7 +3770,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "4b6702c7-aa35-4b89-9c96-b9abf6d3e540",
                     routeValues);
@@ -3762,19 +3799,22 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * Retrieve a pull request.
      * 
      * @param {number} pullRequestId - The ID of the pull request to retrieve.
+     * @param {string} project - Project ID or project name
      */
     public async getPullRequestById(
-        pullRequestId: number
+        pullRequestId: number,
+        project?: string
         ): Promise<GitInterfaces.GitPullRequest> {
 
         return new Promise<GitInterfaces.GitPullRequest>(async (resolve, reject) => {
             let routeValues: any = {
+                project: project,
                 pullRequestId: pullRequestId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "01a46dea-7d46-4d40-bc84-319e7c260d99",
                     routeValues);
@@ -3830,7 +3870,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "a5d28130-9cd2-40fa-9f08-902e7daa9efb",
                     routeValues,
@@ -3883,7 +3923,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "9946fd70-0d40-406e-b686-b4744cbbcc37",
                     routeValues,
@@ -3949,7 +3989,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "9946fd70-0d40-406e-b686-b4744cbbcc37",
                     routeValues,
@@ -4009,7 +4049,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "9946fd70-0d40-406e-b686-b4744cbbcc37",
                     routeValues,
@@ -4059,7 +4099,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "9946fd70-0d40-406e-b686-b4744cbbcc37",
                     routeValues);
@@ -4108,7 +4148,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "696f3a82-47c9-487f-9117-b9d00972ca84",
                     routeValues);
@@ -4157,7 +4197,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b5f6bb4f-8d1e-4d79-8d11-4c9172c99c35",
                     routeValues);
@@ -4207,7 +4247,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b5f6bb4f-8d1e-4d79-8d11-4c9172c99c35",
                     routeValues);
@@ -4257,7 +4297,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b5f6bb4f-8d1e-4d79-8d11-4c9172c99c35",
                     routeValues);
@@ -4304,7 +4344,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b5f6bb4f-8d1e-4d79-8d11-4c9172c99c35",
                     routeValues);
@@ -4357,7 +4397,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "b5f6bb4f-8d1e-4d79-8d11-4c9172c99c35",
                     routeValues);
@@ -4410,7 +4450,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965a3ec7-5ed8-455a-bdcb-835a5ea7fe7b",
                     routeValues);
@@ -4463,7 +4503,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965a3ec7-5ed8-455a-bdcb-835a5ea7fe7b",
                     routeValues);
@@ -4516,7 +4556,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965a3ec7-5ed8-455a-bdcb-835a5ea7fe7b",
                     routeValues);
@@ -4566,7 +4606,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965a3ec7-5ed8-455a-bdcb-835a5ea7fe7b",
                     routeValues);
@@ -4621,7 +4661,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "965a3ec7-5ed8-455a-bdcb-835a5ea7fe7b",
                     routeValues);
@@ -4670,7 +4710,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "ab6e2e5d-a0b7-4153-b64a-a4efe0d49449",
                     routeValues);
@@ -4729,7 +4769,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "ab6e2e5d-a0b7-4153-b64a-a4efe0d49449",
                     routeValues,
@@ -4786,7 +4826,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "ab6e2e5d-a0b7-4153-b64a-a4efe0d49449",
                     routeValues,
@@ -4839,7 +4879,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "ab6e2e5d-a0b7-4153-b64a-a4efe0d49449",
                     routeValues);
@@ -4871,13 +4911,13 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {number} pullRequestId - ID of the pull request.
      * @param {string} project - Project ID or project name
      */
-    public async getPullRequestWorkItems(
+    public async getPullRequestWorkItemRefs(
         repositoryId: string,
         pullRequestId: number,
         project?: string
-        ): Promise<GitInterfaces.AssociatedWorkItem[]> {
+        ): Promise<VSSInterfaces.ResourceRef[]> {
 
-        return new Promise<GitInterfaces.AssociatedWorkItem[]>(async (resolve, reject) => {
+        return new Promise<VSSInterfaces.ResourceRef[]>(async (resolve, reject) => {
             let routeValues: any = {
                 project: project,
                 repositoryId: repositoryId,
@@ -4886,7 +4926,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "0a637fcc-5370-4ce8-b0e8-98091f5f9482",
                     routeValues);
@@ -4895,8 +4935,8 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<GitInterfaces.AssociatedWorkItem[]>;
-                res = await this.rest.get<GitInterfaces.AssociatedWorkItem[]>(url, options);
+                let res: restm.IRestResponse<VSSInterfaces.ResourceRef[]>;
+                res = await this.rest.get<VSSInterfaces.ResourceRef[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -4932,7 +4972,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "git",
                     "ea98d07b-3c87-4971-8ede-a613694ffb55",
                     routeValues);
@@ -4988,7 +5028,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "git",
                     "ea98d07b-3c87-4971-8ede-a613694ffb55",
                     routeValues,
@@ -5045,7 +5085,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "git",
                     "ea98d07b-3c87-4971-8ede-a613694ffb55",
                     routeValues,
@@ -5072,20 +5112,157 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     }
 
     /**
+     * Destroy (hard delete) a soft-deleted Git repository.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} repositoryId - The ID of the repository.
+     */
+    public async deleteRepositoryFromRecycleBin(
+        project: string,
+        repositoryId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repositoryId: repositoryId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "git",
+                    "a663da97-81db-4eb3-8b83-287670f63073",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Retrieve soft-deleted git repositories from the recycle bin.
+     * 
+     * @param {string} project - Project ID or project name
+     */
+    public async getRecycleBinRepositories(
+        project: string
+        ): Promise<GitInterfaces.GitDeletedRepository[]> {
+
+        return new Promise<GitInterfaces.GitDeletedRepository[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "git",
+                    "a663da97-81db-4eb3-8b83-287670f63073",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<GitInterfaces.GitDeletedRepository[]>;
+                res = await this.rest.get<GitInterfaces.GitDeletedRepository[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              GitInterfaces.TypeInfo.GitDeletedRepository,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Recover a soft-deleted Git repository. Recently deleted repositories go into a soft-delete state for a period of time before they are hard deleted and become unrecoverable.
+     * 
+     * @param {GitInterfaces.GitRecycleBinRepositoryDetails} repositoryDetails
+     * @param {string} project - Project ID or project name
+     * @param {string} repositoryId - The ID of the repository.
+     */
+    public async restoreRepositoryFromRecycleBin(
+        repositoryDetails: GitInterfaces.GitRecycleBinRepositoryDetails,
+        project: string,
+        repositoryId: string
+        ): Promise<GitInterfaces.GitRepository> {
+
+        return new Promise<GitInterfaces.GitRepository>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repositoryId: repositoryId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "git",
+                    "a663da97-81db-4eb3-8b83-287670f63073",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<GitInterfaces.GitRepository>;
+                res = await this.rest.update<GitInterfaces.GitRepository>(url, repositoryDetails, options);
+
+                let ret = this.formatResponse(res.result,
+                                              GitInterfaces.TypeInfo.GitRepository,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
      * Queries the provided repository for its refs and returns them.
      * 
      * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} project - Project ID or project name
      * @param {string} filter - [optional] A filter to apply to the refs.
      * @param {boolean} includeLinks - [optional] Specifies if referenceLinks should be included in the result. default is false.
+     * @param {boolean} includeStatuses - [optional] Includes up to the first 1000 commit statuses for each ref. The default value is false.
+     * @param {boolean} includeMyBranches - [optional] Includes only branches that the user owns, the branches the user favorites, and the default branch. The default value is false. Cannot be combined with the filter parameter.
      * @param {boolean} latestStatusesOnly - [optional] True to include only the tip commit status for each ref. This option requires `includeStatuses` to be true. The default value is false.
+     * @param {boolean} peelTags - [optional] Annotated tags will populate the PeeledObjectId property. default is false.
      */
     public async getRefs(
         repositoryId: string,
         project?: string,
         filter?: string,
         includeLinks?: boolean,
-        latestStatusesOnly?: boolean
+        includeStatuses?: boolean,
+        includeMyBranches?: boolean,
+        latestStatusesOnly?: boolean,
+        peelTags?: boolean
         ): Promise<GitInterfaces.GitRef[]> {
 
         return new Promise<GitInterfaces.GitRef[]>(async (resolve, reject) => {
@@ -5097,12 +5274,15 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             let queryValues: any = {
                 filter: filter,
                 includeLinks: includeLinks,
+                includeStatuses: includeStatuses,
+                includeMyBranches: includeMyBranches,
                 latestStatusesOnly: latestStatusesOnly,
+                peelTags: peelTags,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "2d874a60-a811-4f62-9c9f-963a6ea0a55b",
                     routeValues,
@@ -5135,7 +5315,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} filter - The name of the branch to lock/unlock
      * @param {string} project - Project ID or project name
-     * @param {string} projectId - ID or name of the team project. Optional if specifying an ID for repository.
+     * @param {string} projectId - ID or name of the team project. Optional if specifying an ID for repository.
      */
     public async updateRef(
         newRefInfo: GitInterfaces.GitRefUpdate,
@@ -5158,7 +5338,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "2d874a60-a811-4f62-9c9f-963a6ea0a55b",
                     routeValues,
@@ -5190,7 +5370,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * @param {GitInterfaces.GitRefUpdate[]} refUpdates - List of ref updates to attempt to perform
      * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} project - Project ID or project name
-     * @param {string} projectId - ID or name of the team project. Optional if specifying an ID for repository.
+     * @param {string} projectId - ID or name of the team project. Optional if specifying an ID for repository.
      */
     public async updateRefs(
         refUpdates: GitInterfaces.GitRefUpdate[],
@@ -5211,7 +5391,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "2d874a60-a811-4f62-9c9f-963a6ea0a55b",
                     routeValues,
@@ -5255,7 +5435,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "876f70af-5792-485a-a1c7-d0a7b2f42bbb",
                     routeValues);
@@ -5299,7 +5479,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "876f70af-5792-485a-a1c7-d0a7b2f42bbb",
                     routeValues);
@@ -5343,7 +5523,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "876f70af-5792-485a-a1c7-d0a7b2f42bbb",
                     routeValues);
@@ -5393,7 +5573,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "876f70af-5792-485a-a1c7-d0a7b2f42bbb",
                     routeValues,
@@ -5422,7 +5602,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     /**
      * Create a git repository in a team project.
      * 
-     * @param {GitInterfaces.GitRepositoryCreateOptions} gitRepositoryToCreate - Specify the repo name, team project and/or parent repository
+     * @param {GitInterfaces.GitRepositoryCreateOptions} gitRepositoryToCreate - Specify the repo name, team project and/or parent repository. Team project information can be ommitted from gitRepositoryToCreate if the request is project-scoped (i.e., includes project Id).
      * @param {string} project - Project ID or project name
      * @param {string} sourceRef - [optional] Specify the source refs to use while creating a fork repo
      */
@@ -5443,7 +5623,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
                     routeValues,
@@ -5488,7 +5668,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
                     routeValues);
@@ -5541,7 +5721,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
                     routeValues,
@@ -5572,12 +5752,56 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
      * 
      * @param {string} repositoryId - The name or ID of the repository.
      * @param {string} project - Project ID or project name
-     * @param {boolean} includeParent - [optional] True to include parent repository. The default value is false.
      */
     public async getRepository(
         repositoryId: string,
-        project?: string,
-        includeParent?: boolean
+        project?: string
+        ): Promise<GitInterfaces.GitRepository> {
+
+        return new Promise<GitInterfaces.GitRepository>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repositoryId: repositoryId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "git",
+                    "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<GitInterfaces.GitRepository>;
+                res = await this.rest.get<GitInterfaces.GitRepository>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              GitInterfaces.TypeInfo.GitRepository,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Retrieve a git repository.
+     * 
+     * @param {string} repositoryId - The name or ID of the repository.
+     * @param {boolean} includeParent - True to include parent repository. Only available in authenticated calls.
+     * @param {string} project - Project ID or project name
+     */
+    public async getRepositoryWithParent(
+        repositoryId: string,
+        includeParent: boolean,
+        project?: string
         ): Promise<GitInterfaces.GitRepository> {
 
         return new Promise<GitInterfaces.GitRepository>(async (resolve, reject) => {
@@ -5592,7 +5816,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
                     routeValues,
@@ -5639,7 +5863,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "225f7195-f9c7-4d14-ab28-a83f7ff77e1f",
                     routeValues);
@@ -5685,7 +5909,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "bc866058-5449-4715-9cf1-a510b6ff193c",
                     routeValues);
@@ -5732,7 +5956,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "bc866058-5449-4715-9cf1-a510b6ff193c",
                     routeValues);
@@ -5782,7 +6006,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "bc866058-5449-4715-9cf1-a510b6ff193c",
                     routeValues,
@@ -5832,7 +6056,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "428dd4fb-fda5-4722-af02-9313b80305da",
                     routeValues);
@@ -5891,7 +6115,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "428dd4fb-fda5-4722-af02-9313b80305da",
                     routeValues,
@@ -5936,7 +6160,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "9393b4fb-4445-4919-972b-9ad16f442d83",
                     routeValues);
@@ -5995,7 +6219,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "729f6437-6f92-44ec-8bee-273a7111063c",
                     routeValues,
@@ -6055,7 +6279,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "git",
                     "729f6437-6f92-44ec-8bee-273a7111063c",
                     routeValues,

--- a/api/LocationsApi.ts
+++ b/api/LocationsApi.ts
@@ -61,7 +61,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "00d9565f-ed9c-4a06-9a50-00e7896ccab4",
                     routeValues,
@@ -110,7 +110,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "e81700f7-3be2-46de-8624-2eb35882fcaa",
                     routeValues,
@@ -156,7 +156,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "e81700f7-3be2-46de-8624-2eb35882fcaa",
                     routeValues,
@@ -202,7 +202,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "e81700f7-3be2-46de-8624-2eb35882fcaa",
                     routeValues,
@@ -245,7 +245,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "e81700f7-3be2-46de-8624-2eb35882fcaa",
                     routeValues,
@@ -288,7 +288,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "d810a47d-f4f4-4a62-a03f-fa1860585c4c",
                     routeValues);
@@ -341,7 +341,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "d810a47d-f4f4-4a62-a03f-fa1860585c4c",
                     routeValues,
@@ -381,7 +381,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "d810a47d-f4f4-4a62-a03f-fa1860585c4c",
                     routeValues);
@@ -419,7 +419,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Location",
                     "d810a47d-f4f4-4a62-a03f-fa1860585c4c",
                     routeValues);

--- a/api/NotificationApi.ts
+++ b/api/NotificationApi.ts
@@ -21,14 +21,18 @@ import VSSInterfaces = require("./interfaces/common/VSSInterfaces");
 
 export interface INotificationApi extends basem.ClientApiBase {
     performBatchNotificationOperations(operation: NotificationInterfaces.BatchNotificationOperation): Promise<void>;
-    getNotificationTracing(subscriptionId: string): Promise<NotificationInterfaces.NotificationTracing>;
-    updateNotificationTracing(setParameters: NotificationInterfaces.NotificationTracingSetParameters, subscriptionId: string): Promise<NotificationInterfaces.NotificationTracing>;
+    listLogs(source: string, entryId?: string, startTime?: Date, endTime?: Date): Promise<NotificationInterfaces.INotificationDiagnosticLog[]>;
+    getSubscriptionDiagnostics(subscriptionId: string): Promise<NotificationInterfaces.SubscriptionDiagnostics>;
+    updateSubscriptionDiagnostics(updateParameters: NotificationInterfaces.UpdateSubscripitonDiagnosticsParameters, subscriptionId: string): Promise<NotificationInterfaces.SubscriptionDiagnostics>;
     publishEvent(notificationEvent: VSSInterfaces.VssNotificationEvent): Promise<VSSInterfaces.VssNotificationEvent>;
+    transformEvent(transformRequest: NotificationInterfaces.EventTransformRequest): Promise<NotificationInterfaces.EventTransformResult>;
     queryEventTypes(inputValuesQuery: NotificationInterfaces.FieldValuesQuery, eventType: string): Promise<NotificationInterfaces.NotificationEventField[]>;
     getEventType(eventType: string): Promise<NotificationInterfaces.NotificationEventType>;
     listEventTypes(publisherId?: string): Promise<NotificationInterfaces.NotificationEventType[]>;
     getNotificationReasons(notificationId: number): Promise<NotificationInterfaces.NotificationReason>;
     listNotificationReasons(notificationIds?: number): Promise<NotificationInterfaces.NotificationReason[]>;
+    getSettings(): Promise<NotificationInterfaces.NotificationAdminSettings>;
+    updateSettings(updateParameters: NotificationInterfaces.NotificationAdminSettingsUpdateParameters): Promise<NotificationInterfaces.NotificationAdminSettings>;
     getSubscriber(subscriberId: string): Promise<NotificationInterfaces.NotificationSubscriber>;
     updateSubscriber(updateParameters: NotificationInterfaces.NotificationSubscriberUpdateParameters, subscriberId: string): Promise<NotificationInterfaces.NotificationSubscriber>;
     querySubscriptions(subscriptionQuery: NotificationInterfaces.SubscriptionQuery): Promise<NotificationInterfaces.NotificationSubscription[]>;
@@ -59,7 +63,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "8f3c6ab2-5bae-4537-b16e-f84e0955599e",
                     routeValues);
@@ -85,20 +89,74 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
     }
 
     /**
+     * List diagnostic logs this service.
+     * 
+     * @param {string} source
+     * @param {string} entryId
+     * @param {Date} startTime
+     * @param {Date} endTime
+     */
+    public async listLogs(
+        source: string,
+        entryId?: string,
+        startTime?: Date,
+        endTime?: Date
+        ): Promise<NotificationInterfaces.INotificationDiagnosticLog[]> {
+
+        return new Promise<NotificationInterfaces.INotificationDiagnosticLog[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                source: source,
+                entryId: entryId
+            };
+
+            let queryValues: any = {
+                startTime: startTime,
+                endTime: endTime,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "notification",
+                    "991842f3-eb16-4aea-ac81-81353ef2b75c",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<NotificationInterfaces.INotificationDiagnosticLog[]>;
+                res = await this.rest.get<NotificationInterfaces.INotificationDiagnosticLog[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              NotificationInterfaces.TypeInfo.INotificationDiagnosticLog,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
      * @param {string} subscriptionId
      */
-    public async getNotificationTracing(
+    public async getSubscriptionDiagnostics(
         subscriptionId: string
-        ): Promise<NotificationInterfaces.NotificationTracing> {
+        ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
 
-        return new Promise<NotificationInterfaces.NotificationTracing>(async (resolve, reject) => {
+        return new Promise<NotificationInterfaces.SubscriptionDiagnostics>(async (resolve, reject) => {
             let routeValues: any = {
                 subscriptionId: subscriptionId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "20f1929d-4be7-4c2e-a74e-d47640ff3418",
                     routeValues);
@@ -107,11 +165,11 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<NotificationInterfaces.NotificationTracing>;
-                res = await this.rest.get<NotificationInterfaces.NotificationTracing>(url, options);
+                let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
+                res = await this.rest.get<NotificationInterfaces.SubscriptionDiagnostics>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationTracing,
+                                              NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
                                               false);
 
                 resolve(ret);
@@ -124,22 +182,22 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
     }
 
     /**
-     * @param {NotificationInterfaces.NotificationTracingSetParameters} setParameters
+     * @param {NotificationInterfaces.UpdateSubscripitonDiagnosticsParameters} updateParameters
      * @param {string} subscriptionId
      */
-    public async updateNotificationTracing(
-        setParameters: NotificationInterfaces.NotificationTracingSetParameters,
+    public async updateSubscriptionDiagnostics(
+        updateParameters: NotificationInterfaces.UpdateSubscripitonDiagnosticsParameters,
         subscriptionId: string
-        ): Promise<NotificationInterfaces.NotificationTracing> {
+        ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
 
-        return new Promise<NotificationInterfaces.NotificationTracing>(async (resolve, reject) => {
+        return new Promise<NotificationInterfaces.SubscriptionDiagnostics>(async (resolve, reject) => {
             let routeValues: any = {
                 subscriptionId: subscriptionId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "20f1929d-4be7-4c2e-a74e-d47640ff3418",
                     routeValues);
@@ -148,11 +206,11 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<NotificationInterfaces.NotificationTracing>;
-                res = await this.rest.replace<NotificationInterfaces.NotificationTracing>(url, setParameters, options);
+                let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
+                res = await this.rest.replace<NotificationInterfaces.SubscriptionDiagnostics>(url, updateParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationTracing,
+                                              NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
                                               false);
 
                 resolve(ret);
@@ -179,7 +237,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "14c57b7a-c0e6-4555-9f51-e067188fdd8e",
                     routeValues);
@@ -190,6 +248,46 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
                 let res: restm.IRestResponse<VSSInterfaces.VssNotificationEvent>;
                 res = await this.rest.create<VSSInterfaces.VssNotificationEvent>(url, notificationEvent, options);
+
+                let ret = this.formatResponse(res.result,
+                                              VSSInterfaces.TypeInfo.VssNotificationEvent,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Tranform a notification event.
+     * 
+     * @param {NotificationInterfaces.EventTransformRequest} transformRequest - Object to be transformed.
+     */
+    public async transformEvent(
+        transformRequest: NotificationInterfaces.EventTransformRequest
+        ): Promise<NotificationInterfaces.EventTransformResult> {
+
+        return new Promise<NotificationInterfaces.EventTransformResult>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "notification",
+                    "9463a800-1b44-450e-9083-f948ea174b45",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<NotificationInterfaces.EventTransformResult>;
+                res = await this.rest.create<NotificationInterfaces.EventTransformResult>(url, transformRequest, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -220,7 +318,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "b5bbdd21-c178-4398-b6db-0166d910028a",
                     routeValues);
@@ -261,7 +359,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "cc84fb5f-6247-4c7a-aeae-e5a3c3fddb21",
                     routeValues);
@@ -305,7 +403,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "cc84fb5f-6247-4c7a-aeae-e5a3c3fddb21",
                     routeValues,
@@ -345,7 +443,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "19824fa9-1c76-40e6-9cce-cf0b9ca1cb60",
                     routeValues);
@@ -387,7 +485,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "19824fa9-1c76-40e6-9cce-cf0b9ca1cb60",
                     routeValues,
@@ -414,6 +512,80 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
     }
 
     /**
+     */
+    public async getSettings(
+        ): Promise<NotificationInterfaces.NotificationAdminSettings> {
+
+        return new Promise<NotificationInterfaces.NotificationAdminSettings>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "notification",
+                    "cbe076d8-2803-45ff-8d8d-44653686ea2a",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
+                res = await this.rest.get<NotificationInterfaces.NotificationAdminSettings>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              NotificationInterfaces.TypeInfo.NotificationAdminSettings,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {NotificationInterfaces.NotificationAdminSettingsUpdateParameters} updateParameters
+     */
+    public async updateSettings(
+        updateParameters: NotificationInterfaces.NotificationAdminSettingsUpdateParameters
+        ): Promise<NotificationInterfaces.NotificationAdminSettings> {
+
+        return new Promise<NotificationInterfaces.NotificationAdminSettings>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "notification",
+                    "cbe076d8-2803-45ff-8d8d-44653686ea2a",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
+                res = await this.rest.update<NotificationInterfaces.NotificationAdminSettings>(url, updateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                                              NotificationInterfaces.TypeInfo.NotificationAdminSettings,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
      * @param {string} subscriberId
      */
     public async getSubscriber(
@@ -427,7 +599,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "4d5caff1-25ba-430b-b808-7a1f352cc197",
                     routeValues);
@@ -468,7 +640,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "4d5caff1-25ba-430b-b808-7a1f352cc197",
                     routeValues);
@@ -508,7 +680,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "6864db85-08c0-4006-8e8e-cc1bebe31675",
                     routeValues);
@@ -548,7 +720,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "70f911d6-abac-488c-85b3-a206bf57e165",
                     routeValues);
@@ -589,7 +761,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "70f911d6-abac-488c-85b3-a206bf57e165",
                     routeValues);
@@ -636,7 +808,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "70f911d6-abac-488c-85b3-a206bf57e165",
                     routeValues,
@@ -685,7 +857,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "70f911d6-abac-488c-85b3-a206bf57e165",
                     routeValues,
@@ -729,7 +901,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "70f911d6-abac-488c-85b3-a206bf57e165",
                     routeValues);
@@ -767,7 +939,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "fa5d24ba-7484-4f3d-888d-4ec6b1974082",
                     routeValues);
@@ -813,7 +985,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "notification",
                     "ed5a3dff-aeb5-41b1-b4f7-89e66e58b62e",
                     routeValues);

--- a/api/PolicyApi.ts
+++ b/api/PolicyApi.ts
@@ -22,7 +22,7 @@ export interface IPolicyApi extends basem.ClientApiBase {
     createPolicyConfiguration(configuration: PolicyInterfaces.PolicyConfiguration, project: string, configurationId?: number): Promise<PolicyInterfaces.PolicyConfiguration>;
     deletePolicyConfiguration(project: string, configurationId: number): Promise<void>;
     getPolicyConfiguration(project: string, configurationId: number): Promise<PolicyInterfaces.PolicyConfiguration>;
-    getPolicyConfigurations(project: string, scope?: string): Promise<PolicyInterfaces.PolicyConfiguration[]>;
+    getPolicyConfigurations(project: string, scope?: string, policyType?: string): Promise<PolicyInterfaces.PolicyConfiguration[]>;
     updatePolicyConfiguration(configuration: PolicyInterfaces.PolicyConfiguration, project: string, configurationId: number): Promise<PolicyInterfaces.PolicyConfiguration>;
     getPolicyEvaluation(project: string, evaluationId: string): Promise<PolicyInterfaces.PolicyEvaluationRecord>;
     requeuePolicyEvaluation(project: string, evaluationId: string): Promise<PolicyInterfaces.PolicyEvaluationRecord>;
@@ -61,7 +61,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "dad91cbe-d183-45f8-9c6e-9c1164472121",
                     routeValues);
@@ -105,7 +105,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "dad91cbe-d183-45f8-9c6e-9c1164472121",
                     routeValues);
@@ -149,7 +149,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "dad91cbe-d183-45f8-9c6e-9c1164472121",
                     routeValues);
@@ -178,11 +178,13 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
      * Get a list of policy configurations in a project.
      * 
      * @param {string} project - Project ID or project name
-     * @param {string} scope - The scope on which a subset of policies is applied.
+     * @param {string} scope - The scope on which a subset of policies is defined.
+     * @param {string} policyType - Filter returned policies to only this type
      */
     public async getPolicyConfigurations(
         project: string,
-        scope?: string
+        scope?: string,
+        policyType?: string
         ): Promise<PolicyInterfaces.PolicyConfiguration[]> {
 
         return new Promise<PolicyInterfaces.PolicyConfiguration[]>(async (resolve, reject) => {
@@ -192,11 +194,12 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             let queryValues: any = {
                 scope: scope,
+                policyType: policyType,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "dad91cbe-d183-45f8-9c6e-9c1164472121",
                     routeValues,
@@ -243,7 +246,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "dad91cbe-d183-45f8-9c6e-9c1164472121",
                     routeValues);
@@ -287,7 +290,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "46aecb7a-5d2c-4647-897b-0209505a9fe4",
                     routeValues);
@@ -331,7 +334,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "46aecb7a-5d2c-4647-897b-0209505a9fe4",
                     routeValues);
@@ -387,7 +390,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "c23ddff5-229c-4d04-a80b-0fdce9f360c8",
                     routeValues,
@@ -435,7 +438,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "fe1e68a2-60d3-43cb-855b-85e41ae97c95",
                     routeValues);
@@ -488,7 +491,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "fe1e68a2-60d3-43cb-855b-85e41ae97c95",
                     routeValues,
@@ -533,7 +536,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "44096322-2d3d-466a-bb30-d1b7de69f61f",
                     routeValues);
@@ -574,7 +577,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "policy",
                     "44096322-2d3d-466a-bb30-d1b7de69f61f",
                     routeValues);

--- a/api/ProjectAnalysisApi.ts
+++ b/api/ProjectAnalysisApi.ts
@@ -30,6 +30,8 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
         super(baseUrl, handlers, 'node-ProjectAnalysis-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "7658fa33-b1bf-4580-990f-fac5896773d3";
+
     /**
      * @param {string} project - Project ID or project name
      */
@@ -44,7 +46,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "projectanalysis",
                     "5b02a779-1867-433f-90b7-d23ed5e33e57",
                     routeValues);
@@ -92,7 +94,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "projectanalysis",
                     "e40ae584-9ea6-4f06-a7c7-6284651b466b",
                     routeValues,
@@ -149,7 +151,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "projectanalysis",
                     "df7fbbca-630a-40e3-8aa3-7a3faf66947e",
                     routeValues,
@@ -201,7 +203,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "projectanalysis",
                     "df7fbbca-630a-40e3-8aa3-7a3faf66947e",
                     routeValues,

--- a/api/ReleaseApi.ts
+++ b/api/ReleaseApi.ts
@@ -27,7 +27,9 @@ export interface IReleaseApi extends basem.ClientApiBase {
     updateReleaseApproval(approval: ReleaseInterfaces.ReleaseApproval, project: string, approvalId: number): Promise<ReleaseInterfaces.ReleaseApproval>;
     updateReleaseApprovals(approvals: ReleaseInterfaces.ReleaseApproval[], project: string): Promise<ReleaseInterfaces.ReleaseApproval[]>;
     getTaskAttachmentContent(project: string, releaseId: number, environmentId: number, attemptId: number, timelineId: string, recordId: string, type: string, name: string): Promise<NodeJS.ReadableStream>;
+    getReleaseTaskAttachmentContent(project: string, releaseId: number, environmentId: number, attemptId: number, planId: string, timelineId: string, recordId: string, type: string, name: string): Promise<NodeJS.ReadableStream>;
     getTaskAttachments(project: string, releaseId: number, environmentId: number, attemptId: number, timelineId: string, type: string): Promise<ReleaseInterfaces.ReleaseTaskAttachment[]>;
+    getReleaseTaskAttachments(project: string, releaseId: number, environmentId: number, attemptId: number, planId: string, type: string): Promise<ReleaseInterfaces.ReleaseTaskAttachment[]>;
     getAutoTriggerIssues(artifactType: string, sourceId: string, artifactVersionId: string, project?: string): Promise<ReleaseInterfaces.AutoTriggerIssue[]>;
     getDeploymentBadge(projectId: string, releaseDefinitionId: number, environmentId: number, branchName?: string): Promise<string>;
     getReleaseChanges(project: string, releaseId: number, baseReleaseId?: number, top?: number): Promise<ReleaseInterfaces.Change[]>;
@@ -39,7 +41,7 @@ export interface IReleaseApi extends basem.ClientApiBase {
     getReleaseDefinitions(project: string, searchText?: string, expand?: ReleaseInterfaces.ReleaseDefinitionExpands, artifactType?: string, artifactSourceId?: string, top?: number, continuationToken?: string, queryOrder?: ReleaseInterfaces.ReleaseDefinitionQueryOrder, path?: string, isExactNameMatch?: boolean, tagFilter?: string[], propertyFilters?: string[], definitionIdFilter?: string[], isDeleted?: boolean): Promise<ReleaseInterfaces.ReleaseDefinition[]>;
     undeleteReleaseDefinition(releaseDefinitionUndeleteParameter: ReleaseInterfaces.ReleaseDefinitionUndeleteParameter, project: string, definitionId: number): Promise<ReleaseInterfaces.ReleaseDefinition>;
     updateReleaseDefinition(releaseDefinition: ReleaseInterfaces.ReleaseDefinition, project: string): Promise<ReleaseInterfaces.ReleaseDefinition>;
-    getDeployments(project: string, definitionId?: number, definitionEnvironmentId?: number, createdBy?: string, minModifiedTime?: Date, maxModifiedTime?: Date, deploymentStatus?: ReleaseInterfaces.DeploymentStatus, operationStatus?: ReleaseInterfaces.DeploymentOperationStatus, latestAttemptsOnly?: boolean, queryOrder?: ReleaseInterfaces.ReleaseQueryOrder, top?: number, continuationToken?: number, createdFor?: string): Promise<ReleaseInterfaces.Deployment[]>;
+    getDeployments(project: string, definitionId?: number, definitionEnvironmentId?: number, createdBy?: string, minModifiedTime?: Date, maxModifiedTime?: Date, deploymentStatus?: ReleaseInterfaces.DeploymentStatus, operationStatus?: ReleaseInterfaces.DeploymentOperationStatus, latestAttemptsOnly?: boolean, queryOrder?: ReleaseInterfaces.ReleaseQueryOrder, top?: number, continuationToken?: number, createdFor?: string, minStartedTime?: Date, maxStartedTime?: Date): Promise<ReleaseInterfaces.Deployment[]>;
     getDeploymentsForMultipleEnvironments(queryParameters: ReleaseInterfaces.DeploymentQueryParameters, project: string): Promise<ReleaseInterfaces.Deployment[]>;
     getReleaseEnvironment(project: string, releaseId: number, environmentId: number): Promise<ReleaseInterfaces.ReleaseEnvironment>;
     updateReleaseEnvironment(environmentUpdateData: ReleaseInterfaces.ReleaseEnvironmentUpdateMetadata, project: string, releaseId: number, environmentId: number): Promise<ReleaseInterfaces.ReleaseEnvironment>;
@@ -51,10 +53,12 @@ export interface IReleaseApi extends basem.ClientApiBase {
     createFavorites(favoriteItems: ReleaseInterfaces.FavoriteItem[], project: string, scope: string, identityId?: string): Promise<ReleaseInterfaces.FavoriteItem[]>;
     deleteFavorites(project: string, scope: string, identityId?: string, favoriteItemIds?: string): Promise<void>;
     getFavorites(project: string, scope: string, identityId?: string): Promise<ReleaseInterfaces.FavoriteItem[]>;
+    getFlightAssignments(flightName?: string): Promise<string[]>;
     createFolder(folder: ReleaseInterfaces.Folder, project: string, path: string): Promise<ReleaseInterfaces.Folder>;
     deleteFolder(project: string, path: string): Promise<void>;
     getFolders(project: string, path?: string, queryOrder?: ReleaseInterfaces.FolderPathQueryOrder): Promise<ReleaseInterfaces.Folder[]>;
     updateFolder(folder: ReleaseInterfaces.Folder, project: string, path: string): Promise<ReleaseInterfaces.Folder>;
+    updateGates(gateUpdateMetadata: ReleaseInterfaces.GateUpdateMetadata, project: string, gateStepId: number): Promise<ReleaseInterfaces.ReleaseGates>;
     getReleaseHistory(project: string, releaseId: number): Promise<ReleaseInterfaces.ReleaseRevision[]>;
     getInputValues(query: FormInputInterfaces.InputValuesQuery, project: string): Promise<FormInputInterfaces.InputValuesQuery>;
     getIssues(project: string, buildId: number, sourceId?: string): Promise<ReleaseInterfaces.AutoTriggerIssue[]>;
@@ -71,7 +75,7 @@ export interface IReleaseApi extends basem.ClientApiBase {
     getReleases(project?: string, definitionId?: number, definitionEnvironmentId?: number, searchText?: string, createdBy?: string, statusFilter?: ReleaseInterfaces.ReleaseStatus, environmentStatusFilter?: number, minCreatedTime?: Date, maxCreatedTime?: Date, queryOrder?: ReleaseInterfaces.ReleaseQueryOrder, top?: number, continuationToken?: number, expand?: ReleaseInterfaces.ReleaseExpands, artifactTypeId?: string, sourceId?: string, artifactVersionId?: string, sourceBranchFilter?: string, isDeleted?: boolean, tagFilter?: string[], propertyFilters?: string[], releaseIdFilter?: number[]): Promise<ReleaseInterfaces.Release[]>;
     createRelease(releaseStartMetadata: ReleaseInterfaces.ReleaseStartMetadata, project: string): Promise<ReleaseInterfaces.Release>;
     deleteRelease(project: string, releaseId: number, comment?: string): Promise<void>;
-    getRelease(project: string, releaseId: number, approvalFilters?: ReleaseInterfaces.ApprovalFilters, propertyFilters?: string[]): Promise<ReleaseInterfaces.Release>;
+    getRelease(project: string, releaseId: number, approvalFilters?: ReleaseInterfaces.ApprovalFilters, propertyFilters?: string[], expand?: ReleaseInterfaces.SingleReleaseExpands, topGateRecords?: number): Promise<ReleaseInterfaces.Release>;
     getReleaseDefinitionSummary(project: string, definitionId: number, releaseCount: number, includeArtifact?: boolean, definitionEnvironmentIdsFilter?: number[]): Promise<ReleaseInterfaces.ReleaseDefinitionSummary>;
     getReleaseRevision(project: string, releaseId: number, definitionSnapshotRevision: number): Promise<NodeJS.ReadableStream>;
     undeleteRelease(project: string, releaseId: number, comment: string): Promise<void>;
@@ -128,7 +132,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "f2571c27-bf50-4938-b396-32d109ddef26",
                     routeValues);
@@ -196,7 +200,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "b47c6458-e73b-47cb-a770-4df1e8813a91",
                     routeValues,
@@ -241,7 +245,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "250c7158-852e-4130-a00f-a0cce9b72d05",
                     routeValues);
@@ -291,7 +295,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "9328e074-59fb-465a-89d9-b09c82ee5109",
                     routeValues,
@@ -338,7 +342,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "9328e074-59fb-465a-89d9-b09c82ee5109",
                     routeValues);
@@ -379,7 +383,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "c957584a-82aa-4131-8222-6d47f78bfa7a",
                     routeValues);
@@ -439,9 +443,64 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c4071f6d-3697-46ca-858e-8b10ff09e52f",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                
+                let apiVersion: string = verData.apiVersion;
+                let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
+                resolve((await this.http.get(url, { "Accept": accept })).message);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} releaseId
+     * @param {number} environmentId
+     * @param {number} attemptId
+     * @param {string} planId
+     * @param {string} timelineId
+     * @param {string} recordId
+     * @param {string} type
+     * @param {string} name
+     */
+    public async getReleaseTaskAttachmentContent(
+        project: string,
+        releaseId: number,
+        environmentId: number,
+        attemptId: number,
+        planId: string,
+        timelineId: string,
+        recordId: string,
+        type: string,
+        name: string
+        ): Promise<NodeJS.ReadableStream> {
+
+        return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                releaseId: releaseId,
+                environmentId: environmentId,
+                attemptId: attemptId,
+                planId: planId,
+                timelineId: timelineId,
+                recordId: recordId,
+                type: type,
+                name: name
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Release",
+                    "60b86efb-7b8c-4853-8f9f-aa142b77b479",
                     routeValues);
 
                 let url: string = verData.requestUrl;
@@ -485,9 +544,63 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "214111ee-2415-4df2-8ed2-74417f7d61f9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTaskAttachment[]>;
+                res = await this.rest.get<ReleaseInterfaces.ReleaseTaskAttachment[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ReleaseInterfaces.TypeInfo.ReleaseTaskAttachment,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} releaseId
+     * @param {number} environmentId
+     * @param {number} attemptId
+     * @param {string} planId
+     * @param {string} type
+     */
+    public async getReleaseTaskAttachments(
+        project: string,
+        releaseId: number,
+        environmentId: number,
+        attemptId: number,
+        planId: string,
+        type: string
+        ): Promise<ReleaseInterfaces.ReleaseTaskAttachment[]> {
+
+        return new Promise<ReleaseInterfaces.ReleaseTaskAttachment[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                releaseId: releaseId,
+                environmentId: environmentId,
+                attemptId: attemptId,
+                planId: planId,
+                type: type
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Release",
+                    "a4d06688-0dfa-4895-82a5-f43ec9452306",
                     routeValues);
 
                 let url: string = verData.requestUrl;
@@ -536,7 +649,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c1a68497-69da-40fb-9423-cab19cfeeca9",
                     routeValues,
@@ -587,7 +700,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "1a60a35d-b8c9-45fb-bf67-da0829711147",
                     routeValues);
@@ -638,7 +751,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "8dcf9fe9-ca37-4113-8ee1-37928e98407c",
                     routeValues,
@@ -687,7 +800,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "12b5d21a-f54c-430e-a8c1-7515d196890e",
                     routeValues,
@@ -731,7 +844,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues);
@@ -784,7 +897,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues,
@@ -815,7 +928,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * 
      * @param {string} project - Project ID or project name
      * @param {number} definitionId - Id of the release definition.
-     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to retrieve.
+     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to be retrieved. If set, the returned Release Definition will contain values for the specified property Ids (if they exist). If not set, properties will not be included.
      */
     public async getReleaseDefinition(
         project: string,
@@ -835,7 +948,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues,
@@ -886,7 +999,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues,
@@ -908,7 +1021,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * Get a list of release definitions.
      * 
      * @param {string} project - Project ID or project name
-     * @param {string} searchText - Get release definitions with names starting with searchText.
+     * @param {string} searchText - Get release definitions with names containing searchText.
      * @param {ReleaseInterfaces.ReleaseDefinitionExpands} expand - The properties that should be expanded in the list of Release definitions.
      * @param {string} artifactType - Release definitions with given artifactType will be returned. Values can be Build, Jenkins, GitHub, Nuget, Team Build (external), ExternalTFSBuild, Git, TFVC, ExternalTfsXamlBuild.
      * @param {string} artifactSourceId - Release definitions with given artifactSourceId will be returned. e.g. For build it would be {projectGuid}:{BuildDefinitionId}, for Jenkins it would be {JenkinsConnectionId}:{JenkinsDefinitionId}, for TfsOnPrem it would be {TfsOnPremConnectionId}:{ProjectName}:{TfsOnPremDefinitionId}. For third-party artifacts e.g. TeamCity, BitBucket you may refer 'uniqueSourceIdentifier' inside vss-extension.json at https://github.com/Microsoft/vsts-rm-extensions/blob/master/Extensions.
@@ -918,7 +1031,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * @param {string} path - Gets the release definitions under the specified path.
      * @param {boolean} isExactNameMatch - 'true'to gets the release definitions with exact match as specified in searchText. Default is 'false'.
      * @param {string[]} tagFilter - A comma-delimited list of tags. Only release definitions with these tags will be returned.
-     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to retrieve.
+     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to be retrieved. If set, the returned Release Definitions will contain values for the specified property Ids (if they exist). If not set, properties will not be included. Note that this will not filter out any Release Definition from results irrespective of whether it has property set or not.
      * @param {string[]} definitionIdFilter - A comma-delimited list of release definitions to retrieve.
      * @param {boolean} isDeleted - 'true' to get release definitions that has been deleted. Default is 'false'
      */
@@ -962,7 +1075,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues,
@@ -1009,7 +1122,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues);
@@ -1052,7 +1165,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "d8f96f24-8ea7-4cb6-baab-2df8fc515665",
                     routeValues);
@@ -1091,6 +1204,8 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * @param {number} top
      * @param {number} continuationToken
      * @param {string} createdFor
+     * @param {Date} minStartedTime
+     * @param {Date} maxStartedTime
      */
     public async getDeployments(
         project: string,
@@ -1105,7 +1220,9 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
         queryOrder?: ReleaseInterfaces.ReleaseQueryOrder,
         top?: number,
         continuationToken?: number,
-        createdFor?: string
+        createdFor?: string,
+        minStartedTime?: Date,
+        maxStartedTime?: Date
         ): Promise<ReleaseInterfaces.Deployment[]> {
 
         return new Promise<ReleaseInterfaces.Deployment[]>(async (resolve, reject) => {
@@ -1126,11 +1243,13 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 '$top': top,
                 continuationToken: continuationToken,
                 createdFor: createdFor,
+                minStartedTime: minStartedTime,
+                maxStartedTime: maxStartedTime,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "b005ef73-cddc-448e-9ba2-5193bf36b19f",
                     routeValues,
@@ -1172,7 +1291,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "b005ef73-cddc-448e-9ba2-5193bf36b19f",
                     routeValues);
@@ -1217,7 +1336,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.5",
+                    "5.0-preview.6",
                     "Release",
                     "a7e426b1-03dc-48af-9dfe-c98bac612dcb",
                     routeValues);
@@ -1266,7 +1385,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.5",
+                    "5.0-preview.6",
                     "Release",
                     "a7e426b1-03dc-48af-9dfe-c98bac612dcb",
                     routeValues);
@@ -1309,7 +1428,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "6b03b696-824e-4479-8eb2-6644a51aba89",
                     routeValues);
@@ -1356,7 +1475,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "6b03b696-824e-4479-8eb2-6644a51aba89",
                     routeValues,
@@ -1404,7 +1523,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "6b03b696-824e-4479-8eb2-6644a51aba89",
                     routeValues,
@@ -1452,7 +1571,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "6b03b696-824e-4479-8eb2-6644a51aba89",
                     routeValues,
@@ -1500,7 +1619,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Release",
                     "6b03b696-824e-4479-8eb2-6644a51aba89",
                     routeValues,
@@ -1551,7 +1670,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "938f7222-9acb-48fe-b8a3-4eda04597171",
                     routeValues,
@@ -1603,7 +1722,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "938f7222-9acb-48fe-b8a3-4eda04597171",
                     routeValues,
@@ -1652,7 +1771,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "938f7222-9acb-48fe-b8a3-4eda04597171",
                     routeValues,
@@ -1664,6 +1783,49 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
                 let res: restm.IRestResponse<ReleaseInterfaces.FavoriteItem[]>;
                 res = await this.rest.get<ReleaseInterfaces.FavoriteItem[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} flightName
+     */
+    public async getFlightAssignments(
+        flightName?: string
+        ): Promise<string[]> {
+
+        return new Promise<string[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            let queryValues: any = {
+                flightName: flightName,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Release",
+                    "409d301f-3046-46f3-beb9-4357fbce0a8c",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string[]>;
+                res = await this.rest.get<string[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -1699,7 +1861,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "f7ddf76d-ce0c-4d68-94ff-becaec5d9dea",
                     routeValues);
@@ -1743,7 +1905,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "f7ddf76d-ce0c-4d68-94ff-becaec5d9dea",
                     routeValues);
@@ -1793,7 +1955,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "f7ddf76d-ce0c-4d68-94ff-becaec5d9dea",
                     routeValues,
@@ -1840,7 +2002,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "f7ddf76d-ce0c-4d68-94ff-becaec5d9dea",
                     routeValues);
@@ -1854,6 +2016,52 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
                 let ret = this.formatResponse(res.result,
                                               ReleaseInterfaces.TypeInfo.Folder,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates the gate for a deployment.
+     * 
+     * @param {ReleaseInterfaces.GateUpdateMetadata} gateUpdateMetadata - Metadata to patch the Release Gates.
+     * @param {string} project - Project ID or project name
+     * @param {number} gateStepId - Gate step Id.
+     */
+    public async updateGates(
+        gateUpdateMetadata: ReleaseInterfaces.GateUpdateMetadata,
+        project: string,
+        gateStepId: number
+        ): Promise<ReleaseInterfaces.ReleaseGates> {
+
+        return new Promise<ReleaseInterfaces.ReleaseGates>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                gateStepId: gateStepId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Release",
+                    "2666a539-2001-4f80-bcc7-0379956749d4",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ReleaseInterfaces.ReleaseGates>;
+                res = await this.rest.update<ReleaseInterfaces.ReleaseGates>(url, gateUpdateMetadata, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ReleaseInterfaces.TypeInfo.ReleaseGates,
                                               false);
 
                 resolve(ret);
@@ -1882,7 +2090,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "23f461c8-629a-4144-a076-3054fa5f268a",
                     routeValues);
@@ -1923,7 +2131,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "71dd499b-317d-45ea-9134-140ea1932b5e",
                     routeValues);
@@ -1971,7 +2179,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "cd42261a-f5c6-41c8-9259-f078989b9f25",
                     routeValues,
@@ -2025,7 +2233,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "dec7ca5a-7f7f-4797-8bf1-8efc0dc93b28",
                     routeValues);
@@ -2061,7 +2269,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "c37fbab5-214b-48e4-a55b-cb6b4f6e4038",
                     routeValues);
@@ -2109,7 +2317,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "e71ba1ed-c0a4-4a28-a61f-2dd5f68cf3fd",
                     routeValues,
@@ -2167,7 +2375,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "2577e6c3-6999-4400-bc69-fe1d837755fe",
                     routeValues,
@@ -2222,7 +2430,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "17c91af7-09fd-4256-bff1-c24ee4f73bc0",
                     routeValues,
@@ -2262,7 +2470,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "616c46e4-f370-4456-adaa-fbaf79c7b79e",
                     routeValues);
@@ -2306,7 +2514,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "616c46e4-f370-4456-adaa-fbaf79c7b79e",
                     routeValues);
@@ -2355,7 +2563,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "616c46e4-f370-4456-adaa-fbaf79c7b79e",
                     routeValues);
@@ -2400,7 +2608,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "cd1502bb-3c73-4e11-80a6-d11308dceae5",
                     routeValues,
@@ -2446,7 +2654,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "917ace4a-79d1-45a7-987c-7be4db4268fa",
                     routeValues,
@@ -2478,7 +2686,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * @param {string} project - Project ID or project name
      * @param {number} definitionId - Releases from this release definition Id.
      * @param {number} definitionEnvironmentId
-     * @param {string} searchText - Releases with names starting with searchText.
+     * @param {string} searchText - Releases with names containing searchText.
      * @param {string} createdBy - Releases created by this user.
      * @param {ReleaseInterfaces.ReleaseStatus} statusFilter - Releases that have this status.
      * @param {number} environmentStatusFilter
@@ -2494,7 +2702,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * @param {string} sourceBranchFilter - Releases with given sourceBranchFilter will be returned.
      * @param {boolean} isDeleted - Gets the soft deleted releases, if true.
      * @param {string[]} tagFilter - A comma-delimited list of tags. Only releases with these tags will be returned.
-     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to retrieve.
+     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to be retrieved. If set, the returned Releases will contain values for the specified property Ids (if they exist). If not set, properties will not be included. Note that this will not filter out any Release from results irrespective of whether it has property set or not.
      * @param {number[]} releaseIdFilter - A comma-delimited list of releases Ids. Only releases with these Ids will be returned.
      */
     public async getReleases(
@@ -2551,7 +2759,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2595,7 +2803,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues);
@@ -2645,7 +2853,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2677,13 +2885,17 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
      * @param {string} project - Project ID or project name
      * @param {number} releaseId - Id of the release.
      * @param {ReleaseInterfaces.ApprovalFilters} approvalFilters - A filter which would allow fetching approval steps selectively based on whether it is automated, or manual. This would also decide whether we should fetch pre and post approval snapshots. Assumes All by default
-     * @param {string[]} propertyFilters - A comma-delimited list of properties to include in the results.
+     * @param {string[]} propertyFilters - A comma-delimited list of extended properties to be retrieved. If set, the returned Release will contain values for the specified property Ids (if they exist). If not set, properties will not be included.
+     * @param {ReleaseInterfaces.SingleReleaseExpands} expand - A property that should be expanded in the release.
+     * @param {number} topGateRecords - Number of release gate records to get. Default is 5.
      */
     public async getRelease(
         project: string,
         releaseId: number,
         approvalFilters?: ReleaseInterfaces.ApprovalFilters,
-        propertyFilters?: string[]
+        propertyFilters?: string[],
+        expand?: ReleaseInterfaces.SingleReleaseExpands,
+        topGateRecords?: number
         ): Promise<ReleaseInterfaces.Release> {
 
         return new Promise<ReleaseInterfaces.Release>(async (resolve, reject) => {
@@ -2695,11 +2907,13 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             let queryValues: any = {
                 approvalFilters: approvalFilters,
                 propertyFilters: propertyFilters && propertyFilters.join(","),
+                '$expand': expand,
+                '$topGateRecords': topGateRecords,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2756,7 +2970,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2807,7 +3021,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2850,7 +3064,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues,
@@ -2897,7 +3111,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues);
@@ -2943,7 +3157,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.6",
+                    "5.0-preview.8",
                     "Release",
                     "a166fde7-27ad-408e-ba75-703c2cc9d500",
                     routeValues);
@@ -2984,7 +3198,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c63c3718-7cfd-41e0-b89b-81c1ca143437",
                     routeValues);
@@ -3027,7 +3241,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c63c3718-7cfd-41e0-b89b-81c1ca143437",
                     routeValues);
@@ -3074,7 +3288,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "258b82e0-9d41-43f3-86d6-fef14ddd44bc",
                     routeValues);
@@ -3110,7 +3324,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "258b82e0-9d41-43f3-86d6-fef14ddd44bc",
                     routeValues);
@@ -3152,7 +3366,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "224e92b2-8d13-4c14-b120-13d877c516f8",
                     routeValues);
@@ -3196,7 +3410,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "224e92b2-8d13-4c14-b120-13d877c516f8",
                     routeValues);
@@ -3238,7 +3452,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "0e5def23-78b3-461f-8198-1558f25041c8",
                     routeValues);
@@ -3285,7 +3499,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "3d21b4c8-c32e-45b2-a7cb-770a369012f4",
                     routeValues);
@@ -3331,7 +3545,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "3d21b4c8-c32e-45b2-a7cb-770a369012f4",
                     routeValues);
@@ -3378,7 +3592,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "3d21b4c8-c32e-45b2-a7cb-770a369012f4",
                     routeValues);
@@ -3422,7 +3636,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "3d21b4c8-c32e-45b2-a7cb-770a369012f4",
                     routeValues);
@@ -3469,7 +3683,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c5b602b6-d1b3-4363-8a51-94384f78068f",
                     routeValues);
@@ -3515,7 +3729,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c5b602b6-d1b3-4363-8a51-94384f78068f",
                     routeValues);
@@ -3562,7 +3776,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c5b602b6-d1b3-4363-8a51-94384f78068f",
                     routeValues);
@@ -3606,7 +3820,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "c5b602b6-d1b3-4363-8a51-94384f78068f",
                     routeValues);
@@ -3645,7 +3859,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "86cee25a-68ba-4ba3-9171-8ad6ffc6df93",
                     routeValues);
@@ -3693,7 +3907,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "4259191d-4b0a-4409-9fb3-09f22ab9bc47",
                     routeValues);
@@ -3744,7 +3958,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "4259291d-4b0a-4409-9fb3-04f22ab9bc47",
                     routeValues);
@@ -3795,7 +4009,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Release",
                     "36b276e0-3c70-4320-a63c-1a2e1466a0d1",
                     routeValues,
@@ -3835,7 +4049,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "8efc2a3c-1fc8-4f6d-9822-75e98cecb48f",
                     routeValues);
@@ -3880,7 +4094,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "30fc787e-a9e0-4a07-9fbc-3e903aa051d2",
                     routeValues,
@@ -3894,7 +4108,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 res = await this.rest.get<ReleaseInterfaces.ArtifactVersionQueryResult>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              ReleaseInterfaces.TypeInfo.ArtifactVersionQueryResult,
                                               false);
 
                 resolve(ret);
@@ -3922,7 +4136,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "30fc787e-a9e0-4a07-9fbc-3e903aa051d2",
                     routeValues);
@@ -3935,7 +4149,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 res = await this.rest.create<ReleaseInterfaces.ArtifactVersionQueryResult>(url, artifacts, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              ReleaseInterfaces.TypeInfo.ArtifactVersionQueryResult,
                                               false);
 
                 resolve(ret);
@@ -3973,7 +4187,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Release",
                     "4f165cc0-875c-4768-b148-f12f78769fab",
                     routeValues,

--- a/api/TaskAgentApiBase.ts
+++ b/api/TaskAgentApiBase.ts
@@ -2,7 +2,7 @@
  * ---------------------------------------------------------
  * Copyright(C) Microsoft Corporation. All rights reserved.
  * ---------------------------------------------------------
- * 
+ *
  * ---------------------------------------------------------
  * Generated file, DO NOT EDIT
  * ---------------------------------------------------------
@@ -17,23 +17,40 @@ import basem = require('./ClientApiBases');
 import serm = require('./Serialization');
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import TaskAgentInterfaces = require("./interfaces/TaskAgentInterfaces");
-import VSSInterfaces = require("./interfaces/common/VSSInterfaces");
 
 export interface ITaskAgentApiBase extends basem.ClientApiBase {
+    addAgentCloud(agentCloud: TaskAgentInterfaces.TaskAgentCloud): Promise<TaskAgentInterfaces.TaskAgentCloud>;
+    deleteAgentCloud(agentCloudId: number): Promise<TaskAgentInterfaces.TaskAgentCloud>;
+    getAgentCloud(agentCloudId: number): Promise<TaskAgentInterfaces.TaskAgentCloud>;
+    getAgentClouds(): Promise<TaskAgentInterfaces.TaskAgentCloud[]>;
+    getAgentCloudTypes(): Promise<TaskAgentInterfaces.TaskAgentCloudType[]>;
+    queueAgentRequest(request: TaskAgentInterfaces.TaskAgentJobRequest, queueId: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest>;
     addAgent(agent: TaskAgentInterfaces.TaskAgent, poolId: number): Promise<TaskAgentInterfaces.TaskAgent>;
     deleteAgent(poolId: number, agentId: number): Promise<void>;
     getAgent(poolId: number, agentId: number, includeCapabilities?: boolean, includeAssignedRequest?: boolean, propertyFilters?: string[]): Promise<TaskAgentInterfaces.TaskAgent>;
     getAgents(poolId: number, agentName?: string, includeCapabilities?: boolean, includeAssignedRequest?: boolean, propertyFilters?: string[], demands?: string[]): Promise<TaskAgentInterfaces.TaskAgent[]>;
     replaceAgent(agent: TaskAgentInterfaces.TaskAgent, poolId: number, agentId: number): Promise<TaskAgentInterfaces.TaskAgent>;
     updateAgent(agent: TaskAgentInterfaces.TaskAgent, poolId: number, agentId: number): Promise<TaskAgentInterfaces.TaskAgent>;
+    getAzureManagementGroups(): Promise<TaskAgentInterfaces.AzureManagementGroupQueryResult>;
     getAzureSubscriptions(): Promise<TaskAgentInterfaces.AzureSubscriptionQueryResult>;
     generateDeploymentGroupAccessToken(project: string, deploymentGroupId: number): Promise<string>;
-    addDeploymentGroup(deploymentGroup: TaskAgentInterfaces.DeploymentGroup, project: string): Promise<TaskAgentInterfaces.DeploymentGroup>;
+    addDeploymentGroup(deploymentGroup: TaskAgentInterfaces.DeploymentGroupCreateParameter, project: string): Promise<TaskAgentInterfaces.DeploymentGroup>;
     deleteDeploymentGroup(project: string, deploymentGroupId: number): Promise<void>;
     getDeploymentGroup(project: string, deploymentGroupId: number, actionFilter?: TaskAgentInterfaces.DeploymentGroupActionFilter, expand?: TaskAgentInterfaces.DeploymentGroupExpands): Promise<TaskAgentInterfaces.DeploymentGroup>;
-    getDeploymentGroups(project: string, name?: string, actionFilter?: TaskAgentInterfaces.DeploymentGroupActionFilter, expand?: TaskAgentInterfaces.DeploymentGroupExpands): Promise<TaskAgentInterfaces.DeploymentGroup[]>;
-    updateDeploymentGroup(deploymentGroup: TaskAgentInterfaces.DeploymentGroup, project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentGroup>;
+    getDeploymentGroups(project: string, name?: string, actionFilter?: TaskAgentInterfaces.DeploymentGroupActionFilter, expand?: TaskAgentInterfaces.DeploymentGroupExpands, continuationToken?: string, top?: number, ids?: number[]): Promise<TaskAgentInterfaces.DeploymentGroup[]>;
+    updateDeploymentGroup(deploymentGroup: TaskAgentInterfaces.DeploymentGroupUpdateParameter, project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentGroup>;
+    getDeploymentGroupsMetrics(project: string, deploymentGroupName?: string, continuationToken?: string, top?: number): Promise<TaskAgentInterfaces.DeploymentGroupMetrics[]>;
+    getAgentRequestsForDeploymentMachine(project: string, deploymentGroupId: number, machineId: number, completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+    getAgentRequestsForDeploymentMachines(project: string, deploymentGroupId: number, machineIds?: number[], completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+    refreshDeploymentMachines(project: string, deploymentGroupId: number): Promise<void>;
+    generateDeploymentPoolAccessToken(poolId: number): Promise<string>;
+    getDeploymentPoolsSummary(poolName?: string, expands?: TaskAgentInterfaces.DeploymentPoolSummaryExpands): Promise<TaskAgentInterfaces.DeploymentPoolSummary[]>;
+    getAgentRequestsForDeploymentTarget(project: string, deploymentGroupId: number, targetId: number, completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+    getAgentRequestsForDeploymentTargets(project: string, deploymentGroupId: number, targetIds?: number[], ownerId?: number, completedOn?: Date, completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+    refreshDeploymentTargets(project: string, deploymentGroupId: number): Promise<void>;
     queryEndpoint(endpoint: TaskAgentInterfaces.TaskDefinitionEndpoint): Promise<string[]>;
+    getServiceEndpointExecutionRecords(project: string, endpointId: string, top?: number): Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>;
+    addServiceEndpointExecutionRecords(input: TaskAgentInterfaces.ServiceEndpointExecutionRecordsInput, project: string): Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>;
     getTaskHubLicenseDetails(hubName: string, includeEnterpriseUsersCount?: boolean, includeHostedAgentMinutesCount?: boolean): Promise<TaskAgentInterfaces.TaskHubLicenseDetails>;
     updateTaskHubLicenseDetails(taskHubLicenseDetails: TaskAgentInterfaces.TaskHubLicenseDetails, hubName: string): Promise<TaskAgentInterfaces.TaskHubLicenseDetails>;
     validateInputs(inputValidationRequest: TaskAgentInterfaces.InputValidationRequest): Promise<TaskAgentInterfaces.InputValidationRequest>;
@@ -42,7 +59,7 @@ export interface ITaskAgentApiBase extends basem.ClientApiBase {
     getAgentRequestsForAgent(poolId: number, agentId: number, completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
     getAgentRequestsForAgents(poolId: number, agentIds?: number[], completedRequestCount?: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
     getAgentRequestsForPlan(poolId: number, planId: string, jobId?: string): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>;
-    queueAgentRequest(request: TaskAgentInterfaces.TaskAgentJobRequest, poolId: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest>;
+    queueAgentRequestByPool(request: TaskAgentInterfaces.TaskAgentJobRequest, poolId: number): Promise<TaskAgentInterfaces.TaskAgentJobRequest>;
     updateAgentRequest(request: TaskAgentInterfaces.TaskAgentJobRequest, poolId: number, requestId: number, lockToken: string): Promise<TaskAgentInterfaces.TaskAgentJobRequest>;
     generateDeploymentMachineGroupAccessToken(project: string, machineGroupId: number): Promise<string>;
     addDeploymentMachineGroup(machineGroup: TaskAgentInterfaces.DeploymentMachineGroup, project: string): Promise<TaskAgentInterfaces.DeploymentMachineGroup>;
@@ -52,8 +69,13 @@ export interface ITaskAgentApiBase extends basem.ClientApiBase {
     updateDeploymentMachineGroup(machineGroup: TaskAgentInterfaces.DeploymentMachineGroup, project: string, machineGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachineGroup>;
     getDeploymentMachineGroupMachines(project: string, machineGroupId: number, tagFilters?: string[]): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
     updateDeploymentMachineGroupMachines(deploymentMachines: TaskAgentInterfaces.DeploymentMachine[], project: string, machineGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
-    getDeploymentMachines(project: string, deploymentGroupId: number, tags?: string[]): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
-    updateDeploymentMachines(deploymentMachines: TaskAgentInterfaces.DeploymentMachine[], project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
+    addDeploymentMachine(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    deleteDeploymentMachine(project: string, deploymentGroupId: number, machineId: number): Promise<void>;
+    getDeploymentMachine(project: string, deploymentGroupId: number, machineId: number, expand?: TaskAgentInterfaces.DeploymentMachineExpands): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    getDeploymentMachines(project: string, deploymentGroupId: number, tags?: string[], name?: string, expand?: TaskAgentInterfaces.DeploymentMachineExpands): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
+    replaceDeploymentMachine(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number, machineId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    updateDeploymentMachine(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number, machineId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    updateDeploymentMachines(machines: TaskAgentInterfaces.DeploymentMachine[], project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
     createAgentPoolMaintenanceDefinition(definition: TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition, poolId: number): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
     deleteAgentPoolMaintenanceDefinition(poolId: number, definitionId: number): Promise<void>;
     getAgentPoolMaintenanceDefinition(poolId: number, definitionId: number): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
@@ -71,25 +93,30 @@ export interface ITaskAgentApiBase extends basem.ClientApiBase {
     refreshAgents(poolId: number): Promise<void>;
     sendMessage(message: TaskAgentInterfaces.TaskAgentMessage, poolId: number, requestId: number): Promise<void>;
     getPackage(packageType: string, platform: string, version: string): Promise<TaskAgentInterfaces.PackageMetadata>;
-    getPackages(packageType?: string, platform?: string, top?: number): Promise<TaskAgentInterfaces.PackageMetadata[]>;
-    getAgentPoolRoles(poolId?: number): Promise<VSSInterfaces.IdentityRef[]>;
+    getPackages(packageType: string, platform?: string, top?: number): Promise<TaskAgentInterfaces.PackageMetadata[]>;
+    getAgentPoolMetadata(poolId: number): Promise<NodeJS.ReadableStream>;
     addAgentPool(pool: TaskAgentInterfaces.TaskAgentPool): Promise<TaskAgentInterfaces.TaskAgentPool>;
     deleteAgentPool(poolId: number): Promise<void>;
     getAgentPool(poolId: number, properties?: string[], actionFilter?: TaskAgentInterfaces.TaskAgentPoolActionFilter): Promise<TaskAgentInterfaces.TaskAgentPool>;
     getAgentPools(poolName?: string, properties?: string[], poolType?: TaskAgentInterfaces.TaskAgentPoolType, actionFilter?: TaskAgentInterfaces.TaskAgentPoolActionFilter): Promise<TaskAgentInterfaces.TaskAgentPool[]>;
     updateAgentPool(pool: TaskAgentInterfaces.TaskAgentPool, poolId: number): Promise<TaskAgentInterfaces.TaskAgentPool>;
-    getAgentQueueRoles(queueId?: number): Promise<VSSInterfaces.IdentityRef[]>;
     addAgentQueue(queue: TaskAgentInterfaces.TaskAgentQueue, project?: string): Promise<TaskAgentInterfaces.TaskAgentQueue>;
     createTeamProject(project?: string): Promise<void>;
     deleteAgentQueue(queueId: number, project?: string): Promise<void>;
     getAgentQueue(queueId: number, project?: string, actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter): Promise<TaskAgentInterfaces.TaskAgentQueue>;
     getAgentQueues(project?: string, queueName?: string, actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter): Promise<TaskAgentInterfaces.TaskAgentQueue[]>;
+    getAgentQueuesByIds(queueIds: number[], project?: string, actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter): Promise<TaskAgentInterfaces.TaskAgentQueue[]>;
+    getAgentQueuesByNames(queueNames: string[], project?: string, actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter): Promise<TaskAgentInterfaces.TaskAgentQueue[]>;
+    getAgentCloudRequests(agentCloudId: number): Promise<TaskAgentInterfaces.TaskAgentCloudRequest[]>;
+    getResourceLimits(): Promise<TaskAgentInterfaces.ResourceLimit[]>;
+    getResourceUsage(parallelismTag?: string, poolIsHosted?: boolean, includeRunningRequests?: boolean): Promise<TaskAgentInterfaces.ResourceUsage>;
     getTaskGroupHistory(project: string, taskGroupId: string): Promise<TaskAgentInterfaces.TaskGroupRevision[]>;
     deleteSecureFile(project: string, secureFileId: string): Promise<void>;
     downloadSecureFile(project: string, secureFileId: string, ticket: string, download?: boolean): Promise<NodeJS.ReadableStream>;
-    getSecureFile(project: string, secureFileId: string, includeDownloadTicket?: boolean): Promise<TaskAgentInterfaces.SecureFile>;
+    getSecureFile(project: string, secureFileId: string, includeDownloadTicket?: boolean, actionFilter?: TaskAgentInterfaces.SecureFileActionFilter): Promise<TaskAgentInterfaces.SecureFile>;
     getSecureFiles(project: string, namePattern?: string, includeDownloadTickets?: boolean, actionFilter?: TaskAgentInterfaces.SecureFileActionFilter): Promise<TaskAgentInterfaces.SecureFile[]>;
-    getSecureFilesByIds(project: string, secureFileIds: string[], includeDownloadTickets?: boolean): Promise<TaskAgentInterfaces.SecureFile[]>;
+    getSecureFilesByIds(project: string, secureFileIds: string[], includeDownloadTickets?: boolean, actionFilter?: TaskAgentInterfaces.SecureFileActionFilter): Promise<TaskAgentInterfaces.SecureFile[]>;
+    getSecureFilesByNames(project: string, secureFileNames: string[], includeDownloadTickets?: boolean, actionFilter?: TaskAgentInterfaces.SecureFileActionFilter): Promise<TaskAgentInterfaces.SecureFile[]>;
     querySecureFilesByProperties(condition: string, project: string, namePattern?: string): Promise<TaskAgentInterfaces.SecureFile[]>;
     updateSecureFile(secureFile: TaskAgentInterfaces.SecureFile, project: string, secureFileId: string): Promise<TaskAgentInterfaces.SecureFile>;
     updateSecureFiles(secureFiles: TaskAgentInterfaces.SecureFile[], project: string): Promise<TaskAgentInterfaces.SecureFile[]>;
@@ -100,36 +127,281 @@ export interface ITaskAgentApiBase extends basem.ClientApiBase {
     deleteServiceEndpoint(project: string, endpointId: string): Promise<void>;
     getServiceEndpointDetails(project: string, endpointId: string): Promise<TaskAgentInterfaces.ServiceEndpoint>;
     getServiceEndpoints(project: string, type?: string, authSchemes?: string[], endpointIds?: string[], includeFailed?: boolean): Promise<TaskAgentInterfaces.ServiceEndpoint[]>;
-    updateServiceEndpoint(endpoint: TaskAgentInterfaces.ServiceEndpoint, project: string, endpointId: string): Promise<TaskAgentInterfaces.ServiceEndpoint>;
+    getServiceEndpointsByNames(project: string, endpointNames: string[], type?: string, authSchemes?: string[], includeFailed?: boolean): Promise<TaskAgentInterfaces.ServiceEndpoint[]>;
+    updateServiceEndpoint(endpoint: TaskAgentInterfaces.ServiceEndpoint, project: string, endpointId: string, operation?: string): Promise<TaskAgentInterfaces.ServiceEndpoint>;
     updateServiceEndpoints(endpoints: TaskAgentInterfaces.ServiceEndpoint[], project: string): Promise<TaskAgentInterfaces.ServiceEndpoint[]>;
     getServiceEndpointTypes(type?: string, scheme?: string): Promise<TaskAgentInterfaces.ServiceEndpointType[]>;
     createAgentSession(session: TaskAgentInterfaces.TaskAgentSession, poolId: number): Promise<TaskAgentInterfaces.TaskAgentSession>;
     deleteAgentSession(poolId: number, sessionId: string): Promise<void>;
-    addTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroup, project: string): Promise<TaskAgentInterfaces.TaskGroup>;
-    deleteTaskGroup(project: string, taskGroupId: string): Promise<void>;
+    addDeploymentTarget(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    deleteDeploymentTarget(project: string, deploymentGroupId: number, targetId: number): Promise<void>;
+    getDeploymentTarget(project: string, deploymentGroupId: number, targetId: number, expand?: TaskAgentInterfaces.DeploymentTargetExpands): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    getDeploymentTargets(project: string, deploymentGroupId: number, tags?: string[], name?: string, partialNameMatch?: boolean, expand?: TaskAgentInterfaces.DeploymentTargetExpands, agentStatus?: TaskAgentInterfaces.TaskAgentStatusFilter, agentJobResult?: TaskAgentInterfaces.TaskAgentJobResultFilter, continuationToken?: string, top?: number, enabled?: boolean): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
+    replaceDeploymentTarget(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number, targetId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    updateDeploymentTarget(machine: TaskAgentInterfaces.DeploymentMachine, project: string, deploymentGroupId: number, targetId: number): Promise<TaskAgentInterfaces.DeploymentMachine>;
+    updateDeploymentTargets(machines: TaskAgentInterfaces.DeploymentTargetUpdateParameter[], project: string, deploymentGroupId: number): Promise<TaskAgentInterfaces.DeploymentMachine[]>;
+    addTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroupCreateParameter, project: string): Promise<TaskAgentInterfaces.TaskGroup>;
+    deleteTaskGroup(project: string, taskGroupId: string, comment?: string): Promise<void>;
+    getTaskGroup(project: string, taskGroupId: string, versionSpec: string, expand?: TaskAgentInterfaces.TaskGroupExpands): Promise<TaskAgentInterfaces.TaskGroup>;
     getTaskGroupRevision(project: string, taskGroupId: string, revision: number): Promise<NodeJS.ReadableStream>;
-    getTaskGroups(project: string, taskGroupId?: string, expanded?: boolean): Promise<TaskAgentInterfaces.TaskGroup[]>;
-    updateTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroup, project: string): Promise<TaskAgentInterfaces.TaskGroup>;
+    getTaskGroups(project: string, taskGroupId?: string, expanded?: boolean, taskIdFilter?: string, deleted?: boolean, top?: number, continuationToken?: Date, queryOrder?: TaskAgentInterfaces.TaskGroupQueryOrder): Promise<TaskAgentInterfaces.TaskGroup[]>;
+    publishPreviewTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroup, project: string, taskGroupId: string, disablePriorVersions?: boolean): Promise<TaskAgentInterfaces.TaskGroup[]>;
+    publishTaskGroup(taskGroupMetadata: TaskAgentInterfaces.PublishTaskGroupMetadata, project: string, parentTaskGroupId: string): Promise<TaskAgentInterfaces.TaskGroup[]>;
+    undeleteTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroup, project: string): Promise<TaskAgentInterfaces.TaskGroup[]>;
+    updateTaskGroup(taskGroup: TaskAgentInterfaces.TaskGroupUpdateParameter, project: string, taskGroupId?: string): Promise<TaskAgentInterfaces.TaskGroup>;
     deleteTaskDefinition(taskId: string): Promise<void>;
     getTaskContentZip(taskId: string, versionString: string, visibility?: string[], scopeLocal?: boolean): Promise<NodeJS.ReadableStream>;
     getTaskDefinition(taskId: string, versionString: string, visibility?: string[], scopeLocal?: boolean): Promise<TaskAgentInterfaces.TaskDefinition>;
     getTaskDefinitions(taskId?: string, visibility?: string[], scopeLocal?: boolean): Promise<TaskAgentInterfaces.TaskDefinition[]>;
     updateAgentUpdateState(poolId: number, agentId: number, currentState: string): Promise<TaskAgentInterfaces.TaskAgent>;
-    updateAgentUserCapabilities(userCapabilities: { [key: string]: string; }, poolId: number, agentId: number): Promise<TaskAgentInterfaces.TaskAgent>;
-    addVariableGroup(group: TaskAgentInterfaces.VariableGroup, project: string): Promise<TaskAgentInterfaces.VariableGroup>;
+    updateAgentUserCapabilities(userCapabilities: { [key: string] : string; }, poolId: number, agentId: number): Promise<TaskAgentInterfaces.TaskAgent>;
+    addVariableGroup(group: TaskAgentInterfaces.VariableGroupParameters, project: string): Promise<TaskAgentInterfaces.VariableGroup>;
     deleteVariableGroup(project: string, groupId: number): Promise<void>;
     getVariableGroup(project: string, groupId: number): Promise<TaskAgentInterfaces.VariableGroup>;
-    getVariableGroups(project: string, groupName?: string, actionFilter?: TaskAgentInterfaces.VariableGroupActionFilter): Promise<TaskAgentInterfaces.VariableGroup[]>;
+    getVariableGroups(project: string, groupName?: string, actionFilter?: TaskAgentInterfaces.VariableGroupActionFilter, top?: number, continuationToken?: number, queryOrder?: TaskAgentInterfaces.VariableGroupQueryOrder): Promise<TaskAgentInterfaces.VariableGroup[]>;
     getVariableGroupsById(project: string, groupIds: number[]): Promise<TaskAgentInterfaces.VariableGroup[]>;
-    updateVariableGroup(group: TaskAgentInterfaces.VariableGroup, project: string, groupId: number): Promise<TaskAgentInterfaces.VariableGroup>;
+    updateVariableGroup(group: TaskAgentInterfaces.VariableGroupParameters, project: string, groupId: number): Promise<TaskAgentInterfaces.VariableGroup>;
     acquireAccessToken(authenticationRequest: TaskAgentInterfaces.AadOauthTokenRequest): Promise<TaskAgentInterfaces.AadOauthTokenResult>;
-    createAadOAuthRequest(tenantId: string, redirectUri: string, promptOption?: TaskAgentInterfaces.AadLoginPromptOption): Promise<string>;
+    createAadOAuthRequest(tenantId: string, redirectUri: string, promptOption?: TaskAgentInterfaces.AadLoginPromptOption, completeCallbackPayload?: string, completeCallbackByAuthCode?: boolean): Promise<string>;
     getVstsAadTenantId(): Promise<string>;
 }
 
 export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentApiBase {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-TaskAgent-api', options);
+    }
+
+    public static readonly RESOURCE_AREA_ID = "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd";
+
+    /**
+     * @param {TaskAgentInterfaces.TaskAgentCloud} agentCloud
+     */
+    public async addAgentCloud(
+        agentCloud: TaskAgentInterfaces.TaskAgentCloud
+        ): Promise<TaskAgentInterfaces.TaskAgentCloud> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloud>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "bfa72b3d-0fc6-43fb-932b-a7f6559f93b9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
+                res = await this.rest.create<TaskAgentInterfaces.TaskAgentCloud>(url, agentCloud, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {number} agentCloudId
+     */
+    public async deleteAgentCloud(
+        agentCloudId: number
+        ): Promise<TaskAgentInterfaces.TaskAgentCloud> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloud>(async (resolve, reject) => {
+            let routeValues: any = {
+                agentCloudId: agentCloudId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "bfa72b3d-0fc6-43fb-932b-a7f6559f93b9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
+                res = await this.rest.del<TaskAgentInterfaces.TaskAgentCloud>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {number} agentCloudId
+     */
+    public async getAgentCloud(
+        agentCloudId: number
+        ): Promise<TaskAgentInterfaces.TaskAgentCloud> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloud>(async (resolve, reject) => {
+            let routeValues: any = {
+                agentCloudId: agentCloudId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "bfa72b3d-0fc6-43fb-932b-a7f6559f93b9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloud>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     */
+    public async getAgentClouds(
+        ): Promise<TaskAgentInterfaces.TaskAgentCloud[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloud[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "bfa72b3d-0fc6-43fb-932b-a7f6559f93b9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloud[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get agent cloud types.
+     * 
+     */
+    public async getAgentCloudTypes(
+        ): Promise<TaskAgentInterfaces.TaskAgentCloudType[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloudType[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "5932e193-f376-469d-9c3e-e5588ce12cb5",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloudType[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloudType[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentCloudType,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TaskAgentInterfaces.TaskAgentJobRequest} request
+     * @param {number} queueId
+     */
+    public async queueAgentRequest(
+        request: TaskAgentInterfaces.TaskAgentJobRequest,
+        queueId: number
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentJobRequest>(async (resolve, reject) => {
+            let routeValues: any = {
+                queueId: queueId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "f5f81ffb-f396-498d-85b1-5ada145e648a",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
+                res = await this.rest.create<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
     }
 
     /**
@@ -139,7 +411,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async addAgent(
         agent: TaskAgentInterfaces.TaskAgent,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -148,24 +420,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -180,7 +452,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteAgent(
         poolId: number,
         agentId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -190,24 +462,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -228,7 +500,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         includeCapabilities?: boolean,
         includeAssignedRequest?: boolean,
         propertyFilters?: string[]
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -241,28 +513,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 includeAssignedRequest: includeAssignedRequest,
                 propertyFilters: propertyFilters && propertyFilters.join(","),
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgent>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -285,7 +557,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         includeAssignedRequest?: boolean,
         propertyFilters?: string[],
         demands?: string[]
-    ): Promise<TaskAgentInterfaces.TaskAgent[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgent[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -299,28 +571,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 propertyFilters: propertyFilters && propertyFilters.join(","),
                 demands: demands && demands.join(","),
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgent[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -337,7 +609,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         agent: TaskAgentInterfaces.TaskAgent,
         poolId: number,
         agentId: number
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -347,24 +619,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -381,7 +653,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         agent: TaskAgentInterfaces.TaskAgent,
         poolId: number,
         agentId: number
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -391,24 +663,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "e298ef32-5878-4cab-993c-043836571f42",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -417,9 +689,49 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Returns list of azure subscriptions
+     * 
+     */
+    public async getAzureManagementGroups(
+        ): Promise<TaskAgentInterfaces.AzureManagementGroupQueryResult> {
+
+        return new Promise<TaskAgentInterfaces.AzureManagementGroupQueryResult>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "39fe3bf2-7ee0-4198-a469-4a29929afa9c",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.AzureManagementGroupQueryResult>;
+                res = await this.rest.get<TaskAgentInterfaces.AzureManagementGroupQueryResult>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns list of azure subscriptions
+     * 
      */
     public async getAzureSubscriptions(
-    ): Promise<TaskAgentInterfaces.AzureSubscriptionQueryResult> {
+        ): Promise<TaskAgentInterfaces.AzureSubscriptionQueryResult> {
 
         return new Promise<TaskAgentInterfaces.AzureSubscriptionQueryResult>(async (resolve, reject) => {
             let routeValues: any = {
@@ -427,24 +739,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "bcd6189c-0303-471f-a8e1-acb22b74d700",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.AzureSubscriptionQueryResult>;
                 res = await this.rest.get<TaskAgentInterfaces.AzureSubscriptionQueryResult>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -453,13 +765,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * GET a PAT token for managing (configuring, removing, tagging) deployment targets in a deployment group.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} deploymentGroupId
+     * @param {number} deploymentGroupId - ID of the deployment group in which deployment targets are managed.
      */
     public async generateDeploymentGroupAccessToken(
         project: string,
         deploymentGroupId: number
-    ): Promise<string> {
+        ): Promise<string> {
 
         return new Promise<string>(async (resolve, reject) => {
             let routeValues: any = {
@@ -469,24 +783,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "3d197ba2-c3e9-4253-882f-0ee2440f8174",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -495,13 +809,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.DeploymentGroup} deploymentGroup
+     * Create a deployment group.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentGroupCreateParameter} deploymentGroup - Deployment group to create.
      * @param {string} project - Project ID or project name
      */
     public async addDeploymentGroup(
-        deploymentGroup: TaskAgentInterfaces.DeploymentGroup,
+        deploymentGroup: TaskAgentInterfaces.DeploymentGroupCreateParameter,
         project: string
-    ): Promise<TaskAgentInterfaces.DeploymentGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -510,24 +826,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "083c4d89-ab35-45af-aa11-7cf66895c53e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentGroup>(url, deploymentGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -536,13 +852,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Delete a deployment group.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} deploymentGroupId
+     * @param {number} deploymentGroupId - ID of the deployment group to be deleted.
      */
     public async deleteDeploymentGroup(
         project: string,
         deploymentGroupId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -552,24 +870,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "083c4d89-ab35-45af-aa11-7cf66895c53e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -578,17 +896,19 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Get a deployment group by its ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} deploymentGroupId
-     * @param {TaskAgentInterfaces.DeploymentGroupActionFilter} actionFilter
-     * @param {TaskAgentInterfaces.DeploymentGroupExpands} expand
+     * @param {number} deploymentGroupId - ID of the deployment group.
+     * @param {TaskAgentInterfaces.DeploymentGroupActionFilter} actionFilter - Get the deployment group only if this action can be performed on it.
+     * @param {TaskAgentInterfaces.DeploymentGroupExpands} expand - Include these additional details in the returned object.
      */
     public async getDeploymentGroup(
         project: string,
         deploymentGroupId: number,
         actionFilter?: TaskAgentInterfaces.DeploymentGroupActionFilter,
         expand?: TaskAgentInterfaces.DeploymentGroupExpands
-    ): Promise<TaskAgentInterfaces.DeploymentGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -600,28 +920,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 actionFilter: actionFilter,
                 '$expand': expand,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "083c4d89-ab35-45af-aa11-7cf66895c53e",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentGroup>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -630,17 +950,25 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Get a list of deployment groups by name or IDs.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} name
-     * @param {TaskAgentInterfaces.DeploymentGroupActionFilter} actionFilter
-     * @param {TaskAgentInterfaces.DeploymentGroupExpands} expand
+     * @param {string} name - Name of the deployment group.
+     * @param {TaskAgentInterfaces.DeploymentGroupActionFilter} actionFilter - Get only deployment groups on which this action can be performed.
+     * @param {TaskAgentInterfaces.DeploymentGroupExpands} expand - Include these additional details in the returned objects.
+     * @param {string} continuationToken - Get deployment groups with names greater than this continuationToken lexicographically.
+     * @param {number} top - Maximum number of deployment groups to return. Default is **1000**.
+     * @param {number[]} ids - Comma separated list of IDs of the deployment groups.
      */
     public async getDeploymentGroups(
         project: string,
         name?: string,
         actionFilter?: TaskAgentInterfaces.DeploymentGroupActionFilter,
-        expand?: TaskAgentInterfaces.DeploymentGroupExpands
-    ): Promise<TaskAgentInterfaces.DeploymentGroup[]> {
+        expand?: TaskAgentInterfaces.DeploymentGroupExpands,
+        continuationToken?: string,
+        top?: number,
+        ids?: number[]
+        ): Promise<TaskAgentInterfaces.DeploymentGroup[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -651,29 +979,32 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 name: name,
                 actionFilter: actionFilter,
                 '$expand': expand,
+                continuationToken: continuationToken,
+                '$top': top,
+                ids: ids && ids.join(","),
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "083c4d89-ab35-45af-aa11-7cf66895c53e",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentGroup,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -682,15 +1013,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.DeploymentGroup} deploymentGroup
+     * Update a deployment group.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentGroupUpdateParameter} deploymentGroup - Deployment group to update.
      * @param {string} project - Project ID or project name
-     * @param {number} deploymentGroupId
+     * @param {number} deploymentGroupId - ID of the deployment group.
      */
     public async updateDeploymentGroup(
-        deploymentGroup: TaskAgentInterfaces.DeploymentGroup,
+        deploymentGroup: TaskAgentInterfaces.DeploymentGroupUpdateParameter,
         project: string,
         deploymentGroupId: number
-    ): Promise<TaskAgentInterfaces.DeploymentGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -700,24 +1033,471 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "083c4d89-ab35-45af-aa11-7cf66895c53e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentGroup>(url, deploymentGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentGroup,
+                                              false);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * Get a list of deployment group metrics.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} deploymentGroupName - Name of the deployment group.
+     * @param {string} continuationToken - Get metrics for deployment groups with names greater than this continuationToken lexicographically.
+     * @param {number} top - Maximum number of deployment group metrics to return. Default is **50**.
+     */
+    public async getDeploymentGroupsMetrics(
+        project: string,
+        deploymentGroupName?: string,
+        continuationToken?: string,
+        top?: number
+        ): Promise<TaskAgentInterfaces.DeploymentGroupMetrics[]> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentGroupMetrics[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                deploymentGroupName: deploymentGroupName,
+                continuationToken: continuationToken,
+                '$top': top,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "281c6308-427a-49e1-b83a-dac0f4862189",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroupMetrics[]>;
+                res = await this.rest.get<TaskAgentInterfaces.DeploymentGroupMetrics[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentGroupMetrics,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number} machineId
+     * @param {number} completedRequestCount
+     */
+    public async getAgentRequestsForDeploymentMachine(
+        project: string,
+        deploymentGroupId: number,
+        machineId: number,
+        completedRequestCount?: number
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            let queryValues: any = {
+                machineId: machineId,
+                completedRequestCount: completedRequestCount,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "a3540e5b-f0dc-4668-963b-b752459be545",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number[]} machineIds
+     * @param {number} completedRequestCount
+     */
+    public async getAgentRequestsForDeploymentMachines(
+        project: string,
+        deploymentGroupId: number,
+        machineIds?: number[],
+        completedRequestCount?: number
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            let queryValues: any = {
+                machineIds: machineIds && machineIds.join(","),
+                completedRequestCount: completedRequestCount,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "a3540e5b-f0dc-4668-963b-b752459be545",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     */
+    public async refreshDeploymentMachines(
+        project: string,
+        deploymentGroupId: number
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "91006ac4-0f68-4d82-a2bc-540676bd73ce",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.create<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * GET a PAT token for managing (configuring, removing, tagging) deployment agents in a deployment pool.
+     * 
+     * @param {number} poolId - ID of the deployment pool in which deployment agents are managed.
+     */
+    public async generateDeploymentPoolAccessToken(
+        poolId: number
+        ): Promise<string> {
+
+        return new Promise<string>(async (resolve, reject) => {
+            let routeValues: any = {
+                poolId: poolId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "e077ee4a-399b-420b-841f-c43fbc058e0b",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string>;
+                res = await this.rest.create<string>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of deployment pool summaries.
+     * 
+     * @param {string} poolName - Name of the deployment pool.
+     * @param {TaskAgentInterfaces.DeploymentPoolSummaryExpands} expands - Include these additional details in the returned objects.
+     */
+    public async getDeploymentPoolsSummary(
+        poolName?: string,
+        expands?: TaskAgentInterfaces.DeploymentPoolSummaryExpands
+        ): Promise<TaskAgentInterfaces.DeploymentPoolSummary[]> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentPoolSummary[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            let queryValues: any = {
+                poolName: poolName,
+                expands: expands,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6525d6c6-258f-40e0-a1a9-8a24a3957625",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentPoolSummary[]>;
+                res = await this.rest.get<TaskAgentInterfaces.DeploymentPoolSummary[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentPoolSummary,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get agent requests for a deployment target.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group to which the target belongs.
+     * @param {number} targetId - ID of the deployment target.
+     * @param {number} completedRequestCount - Maximum number of completed requests to return. Default is **50**
+     */
+    public async getAgentRequestsForDeploymentTarget(
+        project: string,
+        deploymentGroupId: number,
+        targetId: number,
+        completedRequestCount?: number
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            let queryValues: any = {
+                targetId: targetId,
+                completedRequestCount: completedRequestCount,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2fac0be3-8c8f-4473-ab93-c1389b08a2c9",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get agent requests for a list deployment targets.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group to which the targets belong.
+     * @param {number[]} targetIds - Comma separated list of IDs of the deployment targets.
+     * @param {number} ownerId - Id of owner of agent job request.
+     * @param {Date} completedOn - Datetime to return request after this time.
+     * @param {number} completedRequestCount - Maximum number of completed requests to return for each target. Default is **50**
+     */
+    public async getAgentRequestsForDeploymentTargets(
+        project: string,
+        deploymentGroupId: number,
+        targetIds?: number[],
+        ownerId?: number,
+        completedOn?: Date,
+        completedRequestCount?: number
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            let queryValues: any = {
+                targetIds: targetIds && targetIds.join(","),
+                ownerId: ownerId,
+                completedOn: completedOn,
+                completedRequestCount: completedRequestCount,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2fac0be3-8c8f-4473-ab93-c1389b08a2c9",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Upgrade the deployment targets in a deployment group.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group.
+     */
+    public async refreshDeploymentTargets(
+        project: string,
+        deploymentGroupId: number
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "1c1a817f-f23d-41c6-bf8d-14b638f64152",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.create<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -732,7 +1512,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async queryEndpoint(
         endpoint: TaskAgentInterfaces.TaskDefinitionEndpoint
-    ): Promise<string[]> {
+        ): Promise<string[]> {
 
         return new Promise<string[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -740,24 +1520,114 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f223b809-8c33-4b7d-b53f-07232569b5d6",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, endpoint, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {string} endpointId
+     * @param {number} top
+     */
+    public async getServiceEndpointExecutionRecords(
+        project: string,
+        endpointId: string,
+        top?: number
+        ): Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]> {
+
+        return new Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                endpointId: endpointId
+            };
+
+            let queryValues: any = {
+                top: top,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "3ad71e20-7586-45f9-a6c8-0342e00835ac",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>;
+                res = await this.rest.get<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.ServiceEndpointExecutionRecord,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TaskAgentInterfaces.ServiceEndpointExecutionRecordsInput} input
+     * @param {string} project - Project ID or project name
+     */
+    public async addServiceEndpointExecutionRecords(
+        input: TaskAgentInterfaces.ServiceEndpointExecutionRecordsInput,
+        project: string
+        ): Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]> {
+
+        return new Promise<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "11a45c69-2cce-4ade-a361-c9f5a37239ee",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>;
+                res = await this.rest.create<TaskAgentInterfaces.ServiceEndpointExecutionRecord[]>(url, input, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.ServiceEndpointExecutionRecord,
+                                              true);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -774,7 +1644,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         hubName: string,
         includeEnterpriseUsersCount?: boolean,
         includeHostedAgentMinutesCount?: boolean
-    ): Promise<TaskAgentInterfaces.TaskHubLicenseDetails> {
+        ): Promise<TaskAgentInterfaces.TaskHubLicenseDetails> {
 
         return new Promise<TaskAgentInterfaces.TaskHubLicenseDetails>(async (resolve, reject) => {
             let routeValues: any = {
@@ -785,28 +1655,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 includeEnterpriseUsersCount: includeEnterpriseUsersCount,
                 includeHostedAgentMinutesCount: includeHostedAgentMinutesCount,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.3",
                     "distributedtask",
                     "f9f0f436-b8a1-4475-9041-1ccdbf8f0128",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskHubLicenseDetails>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskHubLicenseDetails>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -821,7 +1691,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async updateTaskHubLicenseDetails(
         taskHubLicenseDetails: TaskAgentInterfaces.TaskHubLicenseDetails,
         hubName: string
-    ): Promise<TaskAgentInterfaces.TaskHubLicenseDetails> {
+        ): Promise<TaskAgentInterfaces.TaskHubLicenseDetails> {
 
         return new Promise<TaskAgentInterfaces.TaskHubLicenseDetails>(async (resolve, reject) => {
             let routeValues: any = {
@@ -830,24 +1700,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.3",
                     "distributedtask",
                     "f9f0f436-b8a1-4475-9041-1ccdbf8f0128",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskHubLicenseDetails>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskHubLicenseDetails>(url, taskHubLicenseDetails, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -860,7 +1730,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async validateInputs(
         inputValidationRequest: TaskAgentInterfaces.InputValidationRequest
-    ): Promise<TaskAgentInterfaces.InputValidationRequest> {
+        ): Promise<TaskAgentInterfaces.InputValidationRequest> {
 
         return new Promise<TaskAgentInterfaces.InputValidationRequest>(async (resolve, reject) => {
             let routeValues: any = {
@@ -868,24 +1738,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "58475b1e-adaf-4155-9bc1-e04bf1fff4c2",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.InputValidationRequest>;
                 res = await this.rest.create<TaskAgentInterfaces.InputValidationRequest>(url, inputValidationRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -904,7 +1774,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         requestId: number,
         lockToken: string,
         result?: TaskAgentInterfaces.TaskResult
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -916,28 +1786,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 lockToken: lockToken,
                 result: result,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -952,7 +1822,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getAgentRequest(
         poolId: number,
         requestId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest>(async (resolve, reject) => {
             let routeValues: any = {
@@ -962,24 +1832,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -996,7 +1866,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         agentId: number,
         completedRequestCount?: number
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1007,28 +1877,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 agentId: agentId,
                 completedRequestCount: completedRequestCount,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1045,7 +1915,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         agentIds?: number[],
         completedRequestCount?: number
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1056,28 +1926,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 agentIds: agentIds && agentIds.join(","),
                 completedRequestCount: completedRequestCount,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1094,7 +1964,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         planId: string,
         jobId?: string
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1105,28 +1975,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 planId: planId,
                 jobId: jobId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1138,10 +2008,10 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {TaskAgentInterfaces.TaskAgentJobRequest} request
      * @param {number} poolId
      */
-    public async queueAgentRequest(
+    public async queueAgentRequestByPool(
         request: TaskAgentInterfaces.TaskAgentJobRequest,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1150,24 +2020,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1186,7 +2056,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         requestId: number,
         lockToken: string
-    ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
+        ): Promise<TaskAgentInterfaces.TaskAgentJobRequest> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJobRequest>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1197,28 +2067,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 lockToken: lockToken,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "fc825784-c92a-4299-9221-998a02d1b54f",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1233,7 +2103,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async generateDeploymentMachineGroupAccessToken(
         project: string,
         machineGroupId: number
-    ): Promise<string> {
+        ): Promise<string> {
 
         return new Promise<string>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1243,24 +2113,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f8c7c0de-ac0d-469b-9cb1-c21f72d67693",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1275,7 +2145,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async addDeploymentMachineGroup(
         machineGroup: TaskAgentInterfaces.DeploymentMachineGroup,
         project: string
-    ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachineGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1284,24 +2154,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "d4adf50f-80c6-4ac8-9ca1-6e4e544286e9",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentMachineGroup>(url, machineGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1316,7 +2186,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteDeploymentMachineGroup(
         project: string,
         machineGroupId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1326,24 +2196,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "d4adf50f-80c6-4ac8-9ca1-6e4e544286e9",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1360,7 +2230,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         project: string,
         machineGroupId: number,
         actionFilter?: TaskAgentInterfaces.MachineGroupActionFilter
-    ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachineGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1371,28 +2241,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "d4adf50f-80c6-4ac8-9ca1-6e4e544286e9",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachineGroup>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1409,7 +2279,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         project: string,
         machineGroupName?: string,
         actionFilter?: TaskAgentInterfaces.MachineGroupActionFilter
-    ): Promise<TaskAgentInterfaces.DeploymentMachineGroup[]> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachineGroup[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachineGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1420,28 +2290,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 machineGroupName: machineGroupName,
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "d4adf50f-80c6-4ac8-9ca1-6e4e544286e9",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachineGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1458,7 +2328,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         machineGroup: TaskAgentInterfaces.DeploymentMachineGroup,
         project: string,
         machineGroupId: number
-    ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachineGroup> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachineGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1468,24 +2338,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "d4adf50f-80c6-4ac8-9ca1-6e4e544286e9",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachineGroup>(url, machineGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1502,7 +2372,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         project: string,
         machineGroupId: number,
         tagFilters?: string[]
-    ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1513,28 +2383,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 tagFilters: tagFilters && tagFilters.join(","),
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "966c3874-c347-4b18-a90c-d509116717fd",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachine,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1551,7 +2421,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         deploymentMachines: TaskAgentInterfaces.DeploymentMachine[],
         project: string,
         machineGroupId: number
-    ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1561,24 +2431,165 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "966c3874-c347-4b18-a90c-d509116717fd",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, deploymentMachines, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachine,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     */
+    public async addDeploymentMachine(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6f6d406f-cfe6-409c-9327-7009928077e7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.create<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number} machineId
+     */
+    public async deleteDeploymentMachine(
+        project: string,
+        deploymentGroupId: number,
+        machineId: number
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                machineId: machineId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6f6d406f-cfe6-409c-9327-7009928077e7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number} machineId
+     * @param {TaskAgentInterfaces.DeploymentMachineExpands} expand
+     */
+    public async getDeploymentMachine(
+        project: string,
+        deploymentGroupId: number,
+        machineId: number,
+        expand?: TaskAgentInterfaces.DeploymentMachineExpands
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                machineId: machineId
+            };
+
+            let queryValues: any = {
+                '$expand': expand,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6f6d406f-cfe6-409c-9327-7009928077e7",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -1590,12 +2601,16 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {string} project - Project ID or project name
      * @param {number} deploymentGroupId
      * @param {string[]} tags
+     * @param {string} name
+     * @param {TaskAgentInterfaces.DeploymentMachineExpands} expand
      */
     public async getDeploymentMachines(
         project: string,
         deploymentGroupId: number,
-        tags?: string[]
-    ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+        tags?: string[],
+        name?: string,
+        expand?: TaskAgentInterfaces.DeploymentMachineExpands
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1605,29 +2620,31 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             let queryValues: any = {
                 tags: tags && tags.join(","),
+                name: name,
+                '$expand': expand,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6f6d406f-cfe6-409c-9327-7009928077e7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachine,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1636,15 +2653,109 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.DeploymentMachine[]} deploymentMachines
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number} machineId
+     */
+    public async replaceDeploymentMachine(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number,
+        machineId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                machineId: machineId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6f6d406f-cfe6-409c-9327-7009928077e7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.replace<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId
+     * @param {number} machineId
+     */
+    public async updateDeploymentMachine(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number,
+        machineId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                machineId: machineId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6f6d406f-cfe6-409c-9327-7009928077e7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TaskAgentInterfaces.DeploymentMachine[]} machines
      * @param {string} project - Project ID or project name
      * @param {number} deploymentGroupId
      */
     public async updateDeploymentMachines(
-        deploymentMachines: TaskAgentInterfaces.DeploymentMachine[],
+        machines: TaskAgentInterfaces.DeploymentMachine[],
         project: string,
         deploymentGroupId: number
-    ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
 
         return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1654,24 +2765,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6f6d406f-cfe6-409c-9327-7009928077e7",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
-                res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, deploymentMachines, options);
+                res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, machines, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.DeploymentMachine,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1686,7 +2797,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async createAgentPoolMaintenanceDefinition(
         definition: TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1695,24 +2806,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "80572e16-58f0-4419-ac07-d19fde32195c",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, definition, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1727,7 +2838,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteAgentPoolMaintenanceDefinition(
         poolId: number,
         definitionId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1737,24 +2848,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "80572e16-58f0-4419-ac07-d19fde32195c",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1769,7 +2880,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getAgentPoolMaintenanceDefinition(
         poolId: number,
         definitionId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1779,24 +2890,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "80572e16-58f0-4419-ac07-d19fde32195c",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1809,7 +2920,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async getAgentPoolMaintenanceDefinitions(
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1818,24 +2929,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "80572e16-58f0-4419-ac07-d19fde32195c",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1852,7 +2963,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         definition: TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition,
         poolId: number,
         definitionId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1862,24 +2973,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "80572e16-58f0-4419-ac07-d19fde32195c",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, definition, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1894,7 +3005,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteAgentPoolMaintenanceJob(
         poolId: number,
         jobId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1904,24 +3015,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1936,7 +3047,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getAgentPoolMaintenanceJob(
         poolId: number,
         jobId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1946,24 +3057,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -1978,7 +3089,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getAgentPoolMaintenanceJobLogs(
         poolId: number,
         jobId: number
-    ): Promise<NodeJS.ReadableStream> {
+        ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1988,13 +3099,13 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let apiVersion: string = verData.apiVersion;
                 let accept: string = this.createAcceptHeader("application/zip", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -2012,7 +3123,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getAgentPoolMaintenanceJobs(
         poolId: number,
         definitionId?: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2022,28 +3133,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 definitionId: definitionId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2058,7 +3169,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async queueAgentPoolMaintenanceJob(
         job: TaskAgentInterfaces.TaskAgentPoolMaintenanceJob,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2067,24 +3178,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, job, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2101,7 +3212,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         job: TaskAgentInterfaces.TaskAgentPoolMaintenanceJob,
         poolId: number,
         jobId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2111,24 +3222,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "15e7ab6e-abce-4601-a6d8-e111fe148f46",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, job, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2145,7 +3256,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         messageId: number,
         sessionId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2156,28 +3267,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 sessionId: sessionId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "c3a054f6-7a8a-49c0-944e-3a8e5d7adfd7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2194,7 +3305,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         sessionId: string,
         lastMessageId?: number
-    ): Promise<TaskAgentInterfaces.TaskAgentMessage> {
+        ): Promise<TaskAgentInterfaces.TaskAgentMessage> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentMessage>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2205,28 +3316,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 sessionId: sessionId,
                 lastMessageId: lastMessageId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "c3a054f6-7a8a-49c0-944e-3a8e5d7adfd7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentMessage>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentMessage>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2241,7 +3352,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async refreshAgent(
         poolId: number,
         agentId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2251,28 +3362,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 agentId: agentId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "c3a054f6-7a8a-49c0-944e-3a8e5d7adfd7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2285,7 +3396,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async refreshAgents(
         poolId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2294,24 +3405,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "c3a054f6-7a8a-49c0-944e-3a8e5d7adfd7",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2328,7 +3439,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         message: TaskAgentInterfaces.TaskAgentMessage,
         poolId: number,
         requestId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2338,28 +3449,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 requestId: requestId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "c3a054f6-7a8a-49c0-944e-3a8e5d7adfd7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, message, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2376,7 +3487,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         packageType: string,
         platform: string,
         version: string
-    ): Promise<TaskAgentInterfaces.PackageMetadata> {
+        ): Promise<TaskAgentInterfaces.PackageMetadata> {
 
         return new Promise<TaskAgentInterfaces.PackageMetadata>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2387,24 +3498,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "8ffcd551-079c-493a-9c02-54346299d144",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.PackageMetadata>;
                 res = await this.rest.get<TaskAgentInterfaces.PackageMetadata>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.PackageMetadata,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.PackageMetadata,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2418,10 +3529,10 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {number} top
      */
     public async getPackages(
-        packageType?: string,
+        packageType: string,
         platform?: string,
         top?: number
-    ): Promise<TaskAgentInterfaces.PackageMetadata[]> {
+        ): Promise<TaskAgentInterfaces.PackageMetadata[]> {
 
         return new Promise<TaskAgentInterfaces.PackageMetadata[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2432,28 +3543,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 '$top': top,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "8ffcd551-079c-493a-9c02-54346299d144",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.PackageMetadata[]>;
                 res = await this.rest.get<TaskAgentInterfaces.PackageMetadata[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.PackageMetadata,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.PackageMetadata,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2464,35 +3575,27 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     /**
      * @param {number} poolId
      */
-    public async getAgentPoolRoles(
-        poolId?: number
-    ): Promise<VSSInterfaces.IdentityRef[]> {
+    public async getAgentPoolMetadata(
+        poolId: number
+        ): Promise<NodeJS.ReadableStream> {
 
-        return new Promise<VSSInterfaces.IdentityRef[]>(async (resolve, reject) => {
+        return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
                 poolId: poolId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
-                    "381dd2bb-35cf-4103-ae8c-3c815b25763c",
+                    "0d62f887-9f53-48b9-9161-4c35d5735b0f",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
-
-                let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
-                res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
-
-                let ret = this.formatResponse(res.result,
-                    null,
-                    true);
-
-                resolve(ret);
-
+                
+                let apiVersion: string = verData.apiVersion;
+                let accept: string = this.createAcceptHeader("text/plain", apiVersion);
+                resolve((await this.http.get(url, { "Accept": accept })).message);
             }
             catch (err) {
                 reject(err);
@@ -2505,7 +3608,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async addAgentPool(
         pool: TaskAgentInterfaces.TaskAgentPool
-    ): Promise<TaskAgentInterfaces.TaskAgentPool> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPool> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPool>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2513,24 +3616,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "a8c47e17-4d56-4a56-92bb-de7ea7dc65be",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPool>(url, pool, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPool,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPool,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2543,7 +3646,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async deleteAgentPool(
         poolId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2552,24 +3655,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "a8c47e17-4d56-4a56-92bb-de7ea7dc65be",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2586,7 +3689,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         properties?: string[],
         actionFilter?: TaskAgentInterfaces.TaskAgentPoolActionFilter
-    ): Promise<TaskAgentInterfaces.TaskAgentPool> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPool> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPool>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2597,28 +3700,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 properties: properties && properties.join(","),
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "a8c47e17-4d56-4a56-92bb-de7ea7dc65be",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPool>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPool,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPool,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2637,7 +3740,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         properties?: string[],
         poolType?: TaskAgentInterfaces.TaskAgentPoolType,
         actionFilter?: TaskAgentInterfaces.TaskAgentPoolActionFilter
-    ): Promise<TaskAgentInterfaces.TaskAgentPool[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPool[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPool[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2649,28 +3752,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 poolType: poolType,
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "a8c47e17-4d56-4a56-92bb-de7ea7dc65be",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPool[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPool,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPool,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2685,7 +3788,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async updateAgentPool(
         pool: TaskAgentInterfaces.TaskAgentPool,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentPool> {
+        ): Promise<TaskAgentInterfaces.TaskAgentPool> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentPool>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2694,63 +3797,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "a8c47e17-4d56-4a56-92bb-de7ea7dc65be",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentPool>(url, pool, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentPool,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentPool,
+                                              false);
 
                 resolve(ret);
-
-            }
-            catch (err) {
-                reject(err);
-            }
-        });
-    }
-
-    /**
-     * @param {number} queueId
-     */
-    public async getAgentQueueRoles(
-        queueId?: number
-    ): Promise<VSSInterfaces.IdentityRef[]> {
-
-        return new Promise<VSSInterfaces.IdentityRef[]>(async (resolve, reject) => {
-            let routeValues: any = {
-                queueId: queueId
-            };
-
-            try {
-                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
-                    "distributedtask",
-                    "b0c6d64d-c9fa-4946-b8de-77de623ee585",
-                    routeValues);
-
-                let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
-
-                let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
-                res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
-
-                let ret = this.formatResponse(res.result,
-                    null,
-                    true);
-
-                resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2765,7 +3829,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async addAgentQueue(
         queue: TaskAgentInterfaces.TaskAgentQueue,
         project?: string
-    ): Promise<TaskAgentInterfaces.TaskAgentQueue> {
+        ): Promise<TaskAgentInterfaces.TaskAgentQueue> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentQueue>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2774,24 +3838,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "900fa995-c559-4923-aae7-f8424fe4fbea",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentQueue>(url, queue, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2804,7 +3868,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async createTeamProject(
         project?: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2813,24 +3877,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "900fa995-c559-4923-aae7-f8424fe4fbea",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2845,7 +3909,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteAgentQueue(
         queueId: number,
         project?: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2855,24 +3919,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "900fa995-c559-4923-aae7-f8424fe4fbea",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2889,7 +3953,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         queueId: number,
         project?: string,
         actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter
-    ): Promise<TaskAgentInterfaces.TaskAgentQueue> {
+        ): Promise<TaskAgentInterfaces.TaskAgentQueue> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentQueue>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2900,28 +3964,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "900fa995-c559-4923-aae7-f8424fe4fbea",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -2938,7 +4002,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         project?: string,
         queueName?: string,
         actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter
-    ): Promise<TaskAgentInterfaces.TaskAgentQueue[]> {
+        ): Promise<TaskAgentInterfaces.TaskAgentQueue[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentQueue[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2949,28 +4013,250 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 queueName: queueName,
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "900fa995-c559-4923-aae7-f8424fe4fbea",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {number[]} queueIds
+     * @param {string} project - Project ID or project name
+     * @param {TaskAgentInterfaces.TaskAgentQueueActionFilter} actionFilter
+     */
+    public async getAgentQueuesByIds(
+        queueIds: number[],
+        project?: string,
+        actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter
+        ): Promise<TaskAgentInterfaces.TaskAgentQueue[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentQueue[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                queueIds: queueIds && queueIds.join(","),
+                actionFilter: actionFilter,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "900fa995-c559-4923-aae7-f8424fe4fbea",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string[]} queueNames
+     * @param {string} project - Project ID or project name
+     * @param {TaskAgentInterfaces.TaskAgentQueueActionFilter} actionFilter
+     */
+    public async getAgentQueuesByNames(
+        queueNames: string[],
+        project?: string,
+        actionFilter?: TaskAgentInterfaces.TaskAgentQueueActionFilter
+        ): Promise<TaskAgentInterfaces.TaskAgentQueue[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentQueue[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                queueNames: queueNames && queueNames.join(","),
+                actionFilter: actionFilter,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "900fa995-c559-4923-aae7-f8424fe4fbea",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {number} agentCloudId
+     */
+    public async getAgentCloudRequests(
+        agentCloudId: number
+        ): Promise<TaskAgentInterfaces.TaskAgentCloudRequest[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskAgentCloudRequest[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                agentCloudId: agentCloudId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "20189bd7-5134-49c2-b8e9-f9e856eea2b2",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloudRequest[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloudRequest[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentCloudRequest,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     */
+    public async getResourceLimits(
+        ): Promise<TaskAgentInterfaces.ResourceLimit[]> {
+
+        return new Promise<TaskAgentInterfaces.ResourceLimit[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "1f1f0557-c445-42a6-b4a0-0df605a3a0f8",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.ResourceLimit[]>;
+                res = await this.rest.get<TaskAgentInterfaces.ResourceLimit[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} parallelismTag
+     * @param {boolean} poolIsHosted
+     * @param {boolean} includeRunningRequests
+     */
+    public async getResourceUsage(
+        parallelismTag?: string,
+        poolIsHosted?: boolean,
+        includeRunningRequests?: boolean
+        ): Promise<TaskAgentInterfaces.ResourceUsage> {
+
+        return new Promise<TaskAgentInterfaces.ResourceUsage>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            let queryValues: any = {
+                parallelismTag: parallelismTag,
+                poolIsHosted: poolIsHosted,
+                includeRunningRequests: includeRunningRequests,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "distributedtask",
+                    "eae1d376-a8b1-4475-9041-1dfdbe8f0143",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.ResourceUsage>;
+                res = await this.rest.get<TaskAgentInterfaces.ResourceUsage>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.ResourceUsage,
+                                              false);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -2985,7 +4271,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getTaskGroupHistory(
         project: string,
         taskGroupId: string
-    ): Promise<TaskAgentInterfaces.TaskGroupRevision[]> {
+        ): Promise<TaskAgentInterfaces.TaskGroupRevision[]> {
 
         return new Promise<TaskAgentInterfaces.TaskGroupRevision[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -2995,24 +4281,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "100cc92a-b255-47fa-9ab3-e44a2985a3ac",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroupRevision[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskGroupRevision[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskGroupRevision,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskGroupRevision,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3029,7 +4315,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteSecureFile(
         project: string,
         secureFileId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3039,24 +4325,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3077,7 +4363,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         secureFileId: string,
         ticket: string,
         download?: boolean
-    ): Promise<NodeJS.ReadableStream> {
+        ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3089,17 +4375,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 ticket: ticket,
                 download: download,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let apiVersion: string = verData.apiVersion;
                 let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -3116,12 +4402,14 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {string} project - Project ID or project name
      * @param {string} secureFileId - The unique secure file Id
      * @param {boolean} includeDownloadTicket - If includeDownloadTicket is true and the caller has permissions, a download ticket is included in the response.
+     * @param {TaskAgentInterfaces.SecureFileActionFilter} actionFilter
      */
     public async getSecureFile(
         project: string,
         secureFileId: string,
-        includeDownloadTicket?: boolean
-    ): Promise<TaskAgentInterfaces.SecureFile> {
+        includeDownloadTicket?: boolean,
+        actionFilter?: TaskAgentInterfaces.SecureFileActionFilter
+        ): Promise<TaskAgentInterfaces.SecureFile> {
 
         return new Promise<TaskAgentInterfaces.SecureFile>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3131,29 +4419,30 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             let queryValues: any = {
                 includeDownloadTicket: includeDownloadTicket,
+                actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3174,7 +4463,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         namePattern?: string,
         includeDownloadTickets?: boolean,
         actionFilter?: TaskAgentInterfaces.SecureFileActionFilter
-    ): Promise<TaskAgentInterfaces.SecureFile[]> {
+        ): Promise<TaskAgentInterfaces.SecureFile[]> {
 
         return new Promise<TaskAgentInterfaces.SecureFile[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3186,28 +4475,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 includeDownloadTickets: includeDownloadTickets,
                 actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3221,12 +4510,14 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {string} project - Project ID or project name
      * @param {string[]} secureFileIds - A list of secure file Ids
      * @param {boolean} includeDownloadTickets - If includeDownloadTickets is true and the caller has permissions, a download ticket for each secure file is included in the response.
+     * @param {TaskAgentInterfaces.SecureFileActionFilter} actionFilter
      */
     public async getSecureFilesByIds(
         project: string,
         secureFileIds: string[],
-        includeDownloadTickets?: boolean
-    ): Promise<TaskAgentInterfaces.SecureFile[]> {
+        includeDownloadTickets?: boolean,
+        actionFilter?: TaskAgentInterfaces.SecureFileActionFilter
+        ): Promise<TaskAgentInterfaces.SecureFile[]> {
 
         return new Promise<TaskAgentInterfaces.SecureFile[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3236,29 +4527,84 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 secureFileIds: secureFileIds && secureFileIds.join(","),
                 includeDownloadTickets: includeDownloadTickets,
+                actionFilter: actionFilter,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * Get secure files
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string[]} secureFileNames - A list of secure file Ids
+     * @param {boolean} includeDownloadTickets - If includeDownloadTickets is true and the caller has permissions, a download ticket for each secure file is included in the response.
+     * @param {TaskAgentInterfaces.SecureFileActionFilter} actionFilter
+     */
+    public async getSecureFilesByNames(
+        project: string,
+        secureFileNames: string[],
+        includeDownloadTickets?: boolean,
+        actionFilter?: TaskAgentInterfaces.SecureFileActionFilter
+        ): Promise<TaskAgentInterfaces.SecureFile[]> {
+
+        return new Promise<TaskAgentInterfaces.SecureFile[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                secureFileNames: secureFileNames && secureFileNames.join(","),
+                includeDownloadTickets: includeDownloadTickets,
+                actionFilter: actionFilter,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
+                res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              true);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -3277,7 +4623,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         condition: string,
         project: string,
         namePattern?: string
-    ): Promise<TaskAgentInterfaces.SecureFile[]> {
+        ): Promise<TaskAgentInterfaces.SecureFile[]> {
 
         return new Promise<TaskAgentInterfaces.SecureFile[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3287,28 +4633,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 namePattern: namePattern,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.create<TaskAgentInterfaces.SecureFile[]>(url, condition, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3327,7 +4673,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         secureFile: TaskAgentInterfaces.SecureFile,
         project: string,
         secureFileId: string
-    ): Promise<TaskAgentInterfaces.SecureFile> {
+        ): Promise<TaskAgentInterfaces.SecureFile> {
 
         return new Promise<TaskAgentInterfaces.SecureFile>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3337,24 +4683,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.update<TaskAgentInterfaces.SecureFile>(url, secureFile, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3371,7 +4717,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async updateSecureFiles(
         secureFiles: TaskAgentInterfaces.SecureFile[],
         project: string
-    ): Promise<TaskAgentInterfaces.SecureFile[]> {
+        ): Promise<TaskAgentInterfaces.SecureFile[]> {
 
         return new Promise<TaskAgentInterfaces.SecureFile[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3380,24 +4726,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.update<TaskAgentInterfaces.SecureFile[]>(url, secureFiles, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3417,7 +4763,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         contentStream: NodeJS.ReadableStream,
         project: string,
         name: string
-    ): Promise<TaskAgentInterfaces.SecureFile> {
+        ): Promise<TaskAgentInterfaces.SecureFile> {
 
         return new Promise<TaskAgentInterfaces.SecureFile>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3427,30 +4773,30 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 name: name,
             };
-
+            
             customHeaders = customHeaders || {};
             customHeaders["Content-Type"] = "application/octet-stream";
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "adcfd8bc-b184-43ba-bd84-7c8c6a2ff421",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                                                                                verData.apiVersion);
                 options.additionalHeaders = customHeaders;
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.SecureFile>("POST", url, contentStream, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.SecureFile,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.SecureFile,
+                                              false);
 
                 resolve(ret);
             }
@@ -3469,7 +4815,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         serviceEndpointRequest: TaskAgentInterfaces.ServiceEndpointRequest,
         project: string,
         endpointId: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpointRequestResult> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpointRequestResult> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpointRequestResult>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3479,28 +4825,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 endpointId: endpointId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "f956a7de-d766-43af-81b1-e9e349245634",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpointRequestResult>;
                 res = await this.rest.create<TaskAgentInterfaces.ServiceEndpointRequestResult>(url, serviceEndpointRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.ServiceEndpointRequestResult,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.ServiceEndpointRequestResult,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3517,7 +4863,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async queryServiceEndpoint(
         binding: TaskAgentInterfaces.DataSourceBinding,
         project: string
-    ): Promise<string[]> {
+        ): Promise<string[]> {
 
         return new Promise<string[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3526,24 +4872,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "f956a7de-d766-43af-81b1-e9e349245634",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, binding, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3558,7 +4904,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async createServiceEndpoint(
         endpoint: TaskAgentInterfaces.ServiceEndpoint,
         project: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpoint>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3567,24 +4913,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint>;
                 res = await this.rest.create<TaskAgentInterfaces.ServiceEndpoint>(url, endpoint, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3599,7 +4945,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteServiceEndpoint(
         project: string,
         endpointId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3609,24 +4955,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3641,7 +4987,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getServiceEndpointDetails(
         project: string,
         endpointId: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpoint>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3651,24 +4997,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint>;
                 res = await this.rest.get<TaskAgentInterfaces.ServiceEndpoint>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3689,7 +5035,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         authSchemes?: string[],
         endpointIds?: string[],
         includeFailed?: boolean
-    ): Promise<TaskAgentInterfaces.ServiceEndpoint[]> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint[]> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpoint[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3702,28 +5048,83 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 endpointIds: endpointIds && endpointIds.join(","),
                 includeFailed: includeFailed,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint[]>;
                 res = await this.rest.get<TaskAgentInterfaces.ServiceEndpoint[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {string[]} endpointNames
+     * @param {string} type
+     * @param {string[]} authSchemes
+     * @param {boolean} includeFailed
+     */
+    public async getServiceEndpointsByNames(
+        project: string,
+        endpointNames: string[],
+        type?: string,
+        authSchemes?: string[],
+        includeFailed?: boolean
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint[]> {
+
+        return new Promise<TaskAgentInterfaces.ServiceEndpoint[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                endpointNames: endpointNames && endpointNames.join(","),
+                type: type,
+                authSchemes: authSchemes && authSchemes.join(","),
+                includeFailed: includeFailed,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "distributedtask",
+                    "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint[]>;
+                res = await this.rest.get<TaskAgentInterfaces.ServiceEndpoint[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -3735,12 +5136,14 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {TaskAgentInterfaces.ServiceEndpoint} endpoint
      * @param {string} project - Project ID or project name
      * @param {string} endpointId
+     * @param {string} operation
      */
     public async updateServiceEndpoint(
         endpoint: TaskAgentInterfaces.ServiceEndpoint,
         project: string,
-        endpointId: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
+        endpointId: string,
+        operation?: string
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpoint>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3748,26 +5151,31 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 endpointId: endpointId
             };
 
+            let queryValues: any = {
+                operation: operation,
+            };
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
-                    routeValues);
+                    routeValues,
+                    queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint>;
                 res = await this.rest.replace<TaskAgentInterfaces.ServiceEndpoint>(url, endpoint, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3782,7 +5190,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async updateServiceEndpoints(
         endpoints: TaskAgentInterfaces.ServiceEndpoint[],
         project: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpoint[]> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpoint[]> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpoint[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3791,24 +5199,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.2",
+                    "5.0-preview.2",
                     "distributedtask",
                     "dca61d2f-3444-410a-b5ec-db2fc4efb4c5",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpoint[]>;
                 res = await this.rest.replace<TaskAgentInterfaces.ServiceEndpoint[]>(url, endpoints, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3823,7 +5231,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async getServiceEndpointTypes(
         type?: string,
         scheme?: string
-    ): Promise<TaskAgentInterfaces.ServiceEndpointType[]> {
+        ): Promise<TaskAgentInterfaces.ServiceEndpointType[]> {
 
         return new Promise<TaskAgentInterfaces.ServiceEndpointType[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3833,28 +5241,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 type: type,
                 scheme: scheme,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "7c74af83-8605-45c1-a30b-7a05d5d7f8c1",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.ServiceEndpointType[]>;
                 res = await this.rest.get<TaskAgentInterfaces.ServiceEndpointType[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.ServiceEndpointType,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.ServiceEndpointType,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3869,7 +5277,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async createAgentSession(
         session: TaskAgentInterfaces.TaskAgentSession,
         poolId: number
-    ): Promise<TaskAgentInterfaces.TaskAgentSession> {
+        ): Promise<TaskAgentInterfaces.TaskAgentSession> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentSession>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3878,24 +5286,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "134e239e-2df3-4794-a6f6-24f1f19ec8dc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentSession>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentSession>(url, session, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgentSession,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgentSession,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3910,7 +5318,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     public async deleteAgentSession(
         poolId: number,
         sessionId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3920,24 +5328,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "134e239e-2df3-4794-a6f6-24f1f19ec8dc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3946,13 +5354,381 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.TaskGroup} taskGroup
+     * Register a deployment target to a deployment group. Generally this is called by agent configuration tool.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine - Deployment target to register.
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group to which the deployment target is registered.
+     */
+    public async addDeploymentTarget(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.create<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete a deployment target in a deployment group. This deletes the agent from associated deployment pool too.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group in which deployment target is deleted.
+     * @param {number} targetId - ID of the deployment target to delete.
+     */
+    public async deleteDeploymentTarget(
+        project: string,
+        deploymentGroupId: number,
+        targetId: number
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                targetId: targetId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a deployment target by its ID in a deployment group
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group to which deployment target belongs.
+     * @param {number} targetId - ID of the deployment target to return.
+     * @param {TaskAgentInterfaces.DeploymentTargetExpands} expand - Include these additional details in the returned objects.
+     */
+    public async getDeploymentTarget(
+        project: string,
+        deploymentGroupId: number,
+        targetId: number,
+        expand?: TaskAgentInterfaces.DeploymentTargetExpands
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                targetId: targetId
+            };
+
+            let queryValues: any = {
+                '$expand': expand,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of deployment targets in a deployment group.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group.
+     * @param {string[]} tags - Get only the deployment targets that contain all these comma separted list of tags.
+     * @param {string} name - Name pattern of the deployment targets to return.
+     * @param {boolean} partialNameMatch - When set to true, treats **name** as pattern. Else treats it as absolute match. Default is **false**.
+     * @param {TaskAgentInterfaces.DeploymentTargetExpands} expand - Include these additional details in the returned objects.
+     * @param {TaskAgentInterfaces.TaskAgentStatusFilter} agentStatus - Get only deployment targets that have this status.
+     * @param {TaskAgentInterfaces.TaskAgentJobResultFilter} agentJobResult - Get only deployment targets that have this last job result.
+     * @param {string} continuationToken - Get deployment targets with names greater than this continuationToken lexicographically.
+     * @param {number} top - Maximum number of deployment targets to return. Default is **1000**.
+     * @param {boolean} enabled - Get only deployment targets that are enabled or disabled. Default is 'null' which returns all the targets.
+     */
+    public async getDeploymentTargets(
+        project: string,
+        deploymentGroupId: number,
+        tags?: string[],
+        name?: string,
+        partialNameMatch?: boolean,
+        expand?: TaskAgentInterfaces.DeploymentTargetExpands,
+        agentStatus?: TaskAgentInterfaces.TaskAgentStatusFilter,
+        agentJobResult?: TaskAgentInterfaces.TaskAgentJobResultFilter,
+        continuationToken?: string,
+        top?: number,
+        enabled?: boolean
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            let queryValues: any = {
+                tags: tags && tags.join(","),
+                name: name,
+                partialNameMatch: partialNameMatch,
+                '$expand': expand,
+                agentStatus: agentStatus,
+                agentJobResult: agentJobResult,
+                continuationToken: continuationToken,
+                '$top': top,
+                enabled: enabled,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
+                res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Replace a deployment target in a deployment group. Generally this is called by agent configuration tool.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine - New deployment target.
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group in which deployment target is replaced.
+     * @param {number} targetId - ID of the deployment target to replace.
+     */
+    public async replaceDeploymentTarget(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number,
+        targetId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                targetId: targetId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.replace<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update a deployment target and its agent properties in a deployment group. Generally this is called by agent configuration tool.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentMachine} machine - Deployment target to update.
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group in which deployment target is updated.
+     * @param {number} targetId - ID of the deployment target to update.
+     */
+    public async updateDeploymentTarget(
+        machine: TaskAgentInterfaces.DeploymentMachine,
+        project: string,
+        deploymentGroupId: number,
+        targetId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId,
+                targetId: targetId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
+                res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update tags of a list of deployment targets in a deployment group.
+     * 
+     * @param {TaskAgentInterfaces.DeploymentTargetUpdateParameter[]} machines - Deployment targets with tags to udpdate.
+     * @param {string} project - Project ID or project name
+     * @param {number} deploymentGroupId - ID of the deployment group in which deployment targets are updated.
+     */
+    public async updateDeploymentTargets(
+        machines: TaskAgentInterfaces.DeploymentTargetUpdateParameter[],
+        project: string,
+        deploymentGroupId: number
+        ): Promise<TaskAgentInterfaces.DeploymentMachine[]> {
+
+        return new Promise<TaskAgentInterfaces.DeploymentMachine[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                deploymentGroupId: deploymentGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "2f0aa599-c121-4256-a5fd-ba370e0ae7b6",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
+                res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, machines, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.DeploymentMachine,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create a task group.
+     * 
+     * @param {TaskAgentInterfaces.TaskGroupCreateParameter} taskGroup - Task group object to create.
      * @param {string} project - Project ID or project name
      */
     public async addTaskGroup(
-        taskGroup: TaskAgentInterfaces.TaskGroup,
+        taskGroup: TaskAgentInterfaces.TaskGroupCreateParameter,
         project: string
-    ): Promise<TaskAgentInterfaces.TaskGroup> {
+        ): Promise<TaskAgentInterfaces.TaskGroup> {
 
         return new Promise<TaskAgentInterfaces.TaskGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -3961,24 +5737,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskGroup>(url, taskGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -3987,13 +5763,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Delete a task group.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} taskGroupId
+     * @param {string} taskGroupId - Id of the task group to be deleted.
+     * @param {string} comment - Comments to delete.
      */
     public async deleteTaskGroup(
         project: string,
-        taskGroupId: string
-    ): Promise<void> {
+        taskGroupId: string,
+        comment?: string
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4001,26 +5781,85 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 taskGroupId: taskGroupId
             };
 
+            let queryValues: any = {
+                comment: comment,
+            };
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
-                    routeValues);
+                    routeValues,
+                    queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * Get task group.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} taskGroupId - Id of the task group.
+     * @param {string} versionSpec - version specification of the task group. examples: 1, 1.0.
+     * @param {TaskAgentInterfaces.TaskGroupExpands} expand - The properties that should be expanded. example $expand=Tasks will expand nested task groups.
+     */
+    public async getTaskGroup(
+        project: string,
+        taskGroupId: string,
+        versionSpec: string,
+        expand?: TaskAgentInterfaces.TaskGroupExpands
+        ): Promise<TaskAgentInterfaces.TaskGroup> {
+
+        return new Promise<TaskAgentInterfaces.TaskGroup>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                taskGroupId: taskGroupId
+            };
+
+            let queryValues: any = {
+                versionSpec: versionSpec,
+                '$expand': expand,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskGroup>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              false);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -4037,7 +5876,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         project: string,
         taskGroupId: string,
         revision: number
-    ): Promise<NodeJS.ReadableStream> {
+        ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4048,17 +5887,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 revision: revision,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let apiVersion: string = verData.apiVersion;
                 let accept: string = this.createAcceptHeader("text/plain", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -4070,15 +5909,27 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * List task groups.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} taskGroupId
-     * @param {boolean} expanded
+     * @param {string} taskGroupId - Id of the task group.
+     * @param {boolean} expanded - 'true' to recursively expand task groups. Default is 'false'.
+     * @param {string} taskIdFilter - Guid of the taskId to filter.
+     * @param {boolean} deleted - 'true'to include deleted task groups. Default is 'false'.
+     * @param {number} top - Number of task groups to get.
+     * @param {Date} continuationToken - Gets the task groups after the continuation token provided.
+     * @param {TaskAgentInterfaces.TaskGroupQueryOrder} queryOrder - Gets the results in the defined order. Default is 'CreatedOnDescending'.
      */
     public async getTaskGroups(
         project: string,
         taskGroupId?: string,
-        expanded?: boolean
-    ): Promise<TaskAgentInterfaces.TaskGroup[]> {
+        expanded?: boolean,
+        taskIdFilter?: string,
+        deleted?: boolean,
+        top?: number,
+        continuationToken?: Date,
+        queryOrder?: TaskAgentInterfaces.TaskGroupQueryOrder
+        ): Promise<TaskAgentInterfaces.TaskGroup[]> {
 
         return new Promise<TaskAgentInterfaces.TaskGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4088,29 +5939,133 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             let queryValues: any = {
                 expanded: expanded,
+                taskIdFilter: taskIdFilter,
+                deleted: deleted,
+                '$top': top,
+                continuationToken: continuationToken,
+                queryOrder: queryOrder,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {TaskAgentInterfaces.TaskGroup} taskGroup
+     * @param {string} project - Project ID or project name
+     * @param {string} taskGroupId
+     * @param {boolean} disablePriorVersions
+     */
+    public async publishPreviewTaskGroup(
+        taskGroup: TaskAgentInterfaces.TaskGroup,
+        project: string,
+        taskGroupId: string,
+        disablePriorVersions?: boolean
+        ): Promise<TaskAgentInterfaces.TaskGroup[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskGroup[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                taskGroupId: taskGroupId
+            };
+
+            let queryValues: any = {
+                disablePriorVersions: disablePriorVersions,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
+                res = await this.rest.update<TaskAgentInterfaces.TaskGroup[]>(url, taskGroup, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TaskAgentInterfaces.PublishTaskGroupMetadata} taskGroupMetadata
+     * @param {string} project - Project ID or project name
+     * @param {string} parentTaskGroupId
+     */
+    public async publishTaskGroup(
+        taskGroupMetadata: TaskAgentInterfaces.PublishTaskGroupMetadata,
+        project: string,
+        parentTaskGroupId: string
+        ): Promise<TaskAgentInterfaces.TaskGroup[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskGroup[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                parentTaskGroupId: parentTaskGroupId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
+                res = await this.rest.replace<TaskAgentInterfaces.TaskGroup[]>(url, taskGroupMetadata, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              true);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -4122,36 +6077,82 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {TaskAgentInterfaces.TaskGroup} taskGroup
      * @param {string} project - Project ID or project name
      */
-    public async updateTaskGroup(
+    public async undeleteTaskGroup(
         taskGroup: TaskAgentInterfaces.TaskGroup,
         project: string
-    ): Promise<TaskAgentInterfaces.TaskGroup> {
+        ): Promise<TaskAgentInterfaces.TaskGroup[]> {
 
-        return new Promise<TaskAgentInterfaces.TaskGroup>(async (resolve, reject) => {
+        return new Promise<TaskAgentInterfaces.TaskGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
                 project: project
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
+                res = await this.rest.update<TaskAgentInterfaces.TaskGroup[]>(url, taskGroup, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update a task group.
+     * 
+     * @param {TaskAgentInterfaces.TaskGroupUpdateParameter} taskGroup - Task group to update.
+     * @param {string} project - Project ID or project name
+     * @param {string} taskGroupId - Id of the task group to update.
+     */
+    public async updateTaskGroup(
+        taskGroup: TaskAgentInterfaces.TaskGroupUpdateParameter,
+        project: string,
+        taskGroupId?: string
+        ): Promise<TaskAgentInterfaces.TaskGroup> {
+
+        return new Promise<TaskAgentInterfaces.TaskGroup>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                taskGroupId: taskGroupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "6c08ffbf-dbf1-4f9a-94e5-a1cbd47005e7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskGroup>(url, taskGroup, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4164,7 +6165,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async deleteTaskDefinition(
         taskId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4173,24 +6174,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "60aac929-f0cd-4bc8-9ce4-6b30e8f1b1bd",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4209,7 +6210,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         versionString: string,
         visibility?: string[],
         scopeLocal?: boolean
-    ): Promise<NodeJS.ReadableStream> {
+        ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4221,17 +6222,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 visibility: visibility,
                 scopeLocal: scopeLocal,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "60aac929-f0cd-4bc8-9ce4-6b30e8f1b1bd",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let apiVersion: string = verData.apiVersion;
                 let accept: string = this.createAcceptHeader("application/zip", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -4253,7 +6254,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         versionString: string,
         visibility?: string[],
         scopeLocal?: boolean
-    ): Promise<TaskAgentInterfaces.TaskDefinition> {
+        ): Promise<TaskAgentInterfaces.TaskDefinition> {
 
         return new Promise<TaskAgentInterfaces.TaskDefinition>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4265,28 +6266,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 visibility: visibility,
                 scopeLocal: scopeLocal,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "60aac929-f0cd-4bc8-9ce4-6b30e8f1b1bd",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskDefinition>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskDefinition>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4303,7 +6304,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         taskId?: string,
         visibility?: string[],
         scopeLocal?: boolean
-    ): Promise<TaskAgentInterfaces.TaskDefinition[]> {
+        ): Promise<TaskAgentInterfaces.TaskDefinition[]> {
 
         return new Promise<TaskAgentInterfaces.TaskDefinition[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4314,28 +6315,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 visibility: visibility,
                 scopeLocal: scopeLocal,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "60aac929-f0cd-4bc8-9ce4-6b30e8f1b1bd",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskDefinition[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskDefinition[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4352,7 +6353,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
         poolId: number,
         agentId: number,
         currentState: string
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4363,28 +6364,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 currentState: currentState,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "8cc1b02b-ae49-4516-b5ad-4f9b29967c30",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4398,10 +6399,10 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {number} agentId
      */
     public async updateAgentUserCapabilities(
-        userCapabilities: { [key: string]: string; },
+        userCapabilities: { [key: string] : string; },
         poolId: number,
         agentId: number
-    ): Promise<TaskAgentInterfaces.TaskAgent> {
+        ): Promise<TaskAgentInterfaces.TaskAgent> {
 
         return new Promise<TaskAgentInterfaces.TaskAgent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4411,24 +6412,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "30ba3ada-fedf-4da8-bbb5-dacf2f82e176",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, userCapabilities, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAgent,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAgent,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4437,13 +6438,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.VariableGroup} group
+     * Add a variable group.
+     * 
+     * @param {TaskAgentInterfaces.VariableGroupParameters} group - Variable group to add.
      * @param {string} project - Project ID or project name
      */
     public async addVariableGroup(
-        group: TaskAgentInterfaces.VariableGroup,
+        group: TaskAgentInterfaces.VariableGroupParameters,
         project: string
-    ): Promise<TaskAgentInterfaces.VariableGroup> {
+        ): Promise<TaskAgentInterfaces.VariableGroup> {
 
         return new Promise<TaskAgentInterfaces.VariableGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4452,24 +6455,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.VariableGroup>(url, group, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.VariableGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.VariableGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4478,13 +6481,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Delete a variable group
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} groupId
+     * @param {number} groupId - Id of the variable group.
      */
     public async deleteVariableGroup(
         project: string,
         groupId: number
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4494,24 +6499,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4520,13 +6525,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Get a variable group.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} groupId
+     * @param {number} groupId - Id of the variable group.
      */
     public async getVariableGroup(
         project: string,
         groupId: number
-    ): Promise<TaskAgentInterfaces.VariableGroup> {
+        ): Promise<TaskAgentInterfaces.VariableGroup> {
 
         return new Promise<TaskAgentInterfaces.VariableGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4536,24 +6543,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.VariableGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.VariableGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4562,15 +6569,23 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Get variable groups.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} groupName
-     * @param {TaskAgentInterfaces.VariableGroupActionFilter} actionFilter
+     * @param {string} groupName - Name of variable group.
+     * @param {TaskAgentInterfaces.VariableGroupActionFilter} actionFilter - Action filter for the variable group. It specifies the action which can be performed on the variable groups.
+     * @param {number} top - Number of variable groups to get.
+     * @param {number} continuationToken - Gets the variable groups after the continuation token provided.
+     * @param {TaskAgentInterfaces.VariableGroupQueryOrder} queryOrder - Gets the results in the defined order. Default is 'IdDescending'.
      */
     public async getVariableGroups(
         project: string,
         groupName?: string,
-        actionFilter?: TaskAgentInterfaces.VariableGroupActionFilter
-    ): Promise<TaskAgentInterfaces.VariableGroup[]> {
+        actionFilter?: TaskAgentInterfaces.VariableGroupActionFilter,
+        top?: number,
+        continuationToken?: number,
+        queryOrder?: TaskAgentInterfaces.VariableGroupQueryOrder
+        ): Promise<TaskAgentInterfaces.VariableGroup[]> {
 
         return new Promise<TaskAgentInterfaces.VariableGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4580,29 +6595,32 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 groupName: groupName,
                 actionFilter: actionFilter,
+                '$top': top,
+                continuationToken: continuationToken,
+                queryOrder: queryOrder,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.VariableGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.VariableGroup,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4611,13 +6629,15 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
+     * Get variable groups by ids.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number[]} groupIds
+     * @param {number[]} groupIds - Comma separated list of Ids of variable groups.
      */
     public async getVariableGroupsById(
         project: string,
         groupIds: number[]
-    ): Promise<TaskAgentInterfaces.VariableGroup[]> {
+        ): Promise<TaskAgentInterfaces.VariableGroup[]> {
 
         return new Promise<TaskAgentInterfaces.VariableGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4627,28 +6647,28 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
             let queryValues: any = {
                 groupIds: groupIds && groupIds.join(","),
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.VariableGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.VariableGroup,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4657,15 +6677,17 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     }
 
     /**
-     * @param {TaskAgentInterfaces.VariableGroup} group
+     * Update a variable group.
+     * 
+     * @param {TaskAgentInterfaces.VariableGroupParameters} group - Variable group to update.
      * @param {string} project - Project ID or project name
-     * @param {number} groupId
+     * @param {number} groupId - Id of the variable group to update.
      */
     public async updateVariableGroup(
-        group: TaskAgentInterfaces.VariableGroup,
+        group: TaskAgentInterfaces.VariableGroupParameters,
         project: string,
         groupId: number
-    ): Promise<TaskAgentInterfaces.VariableGroup> {
+        ): Promise<TaskAgentInterfaces.VariableGroup> {
 
         return new Promise<TaskAgentInterfaces.VariableGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4675,24 +6697,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "f5b09dd5-9d54-45a1-8b5a-1c8287d634cc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.replace<TaskAgentInterfaces.VariableGroup>(url, group, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.VariableGroup,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.VariableGroup,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4705,7 +6727,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      */
     public async acquireAccessToken(
         authenticationRequest: TaskAgentInterfaces.AadOauthTokenRequest
-    ): Promise<TaskAgentInterfaces.AadOauthTokenResult> {
+        ): Promise<TaskAgentInterfaces.AadOauthTokenResult> {
 
         return new Promise<TaskAgentInterfaces.AadOauthTokenResult>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4713,24 +6735,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "9c63205e-3a0f-42a0-ad88-095200f13607",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.AadOauthTokenResult>;
                 res = await this.rest.create<TaskAgentInterfaces.AadOauthTokenResult>(url, authenticationRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4742,12 +6764,16 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
      * @param {string} tenantId
      * @param {string} redirectUri
      * @param {TaskAgentInterfaces.AadLoginPromptOption} promptOption
+     * @param {string} completeCallbackPayload
+     * @param {boolean} completeCallbackByAuthCode
      */
     public async createAadOAuthRequest(
         tenantId: string,
         redirectUri: string,
-        promptOption?: TaskAgentInterfaces.AadLoginPromptOption
-    ): Promise<string> {
+        promptOption?: TaskAgentInterfaces.AadLoginPromptOption,
+        completeCallbackPayload?: string,
+        completeCallbackByAuthCode?: boolean
+        ): Promise<string> {
 
         return new Promise<string>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4757,29 +6783,31 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 tenantId: tenantId,
                 redirectUri: redirectUri,
                 promptOption: promptOption,
+                completeCallbackPayload: completeCallbackPayload,
+                completeCallbackByAuthCode: completeCallbackByAuthCode,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "9c63205e-3a0f-42a0-ad88-095200f13607",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -4790,7 +6818,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
     /**
      */
     public async getVstsAadTenantId(
-    ): Promise<string> {
+        ): Promise<string> {
 
         return new Promise<string>(async (resolve, reject) => {
             let routeValues: any = {
@@ -4798,24 +6826,24 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "9c63205e-3a0f-42a0-ad88-095200f13607",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);

--- a/api/TaskApi.ts
+++ b/api/TaskApi.ts
@@ -2,7 +2,7 @@
  * ---------------------------------------------------------
  * Copyright(C) Microsoft Corporation. All rights reserved.
  * ---------------------------------------------------------
- * 
+ *
  * ---------------------------------------------------------
  * Generated file, DO NOT EDIT
  * ---------------------------------------------------------
@@ -25,12 +25,14 @@ export interface ITaskApi extends basem.ClientApiBase {
     getAttachment(scopeIdentifier: string, hubName: string, planId: string, timelineId: string, recordId: string, type: string, name: string): Promise<TaskAgentInterfaces.TaskAttachment>;
     getAttachmentContent(scopeIdentifier: string, hubName: string, planId: string, timelineId: string, recordId: string, type: string, name: string): Promise<NodeJS.ReadableStream>;
     getAttachments(scopeIdentifier: string, hubName: string, planId: string, timelineId: string, recordId: string, type: string): Promise<TaskAgentInterfaces.TaskAttachment[]>;
-    appendTimelineRecordFeed(lines: VSSInterfaces.VssJsonCollectionWrapperV<string[]>, scopeIdentifier: string, hubName: string, planId: string, timelineId: string, recordId: string): Promise<void>;
+    appendTimelineRecordFeed(lines: TaskAgentInterfaces.TimelineRecordFeedLinesWrapper, scopeIdentifier: string, hubName: string, planId: string, timelineId: string, recordId: string): Promise<void>;
     appendLogContent(customHeaders: any, contentStream: NodeJS.ReadableStream, scopeIdentifier: string, hubName: string, planId: string, logId: number): Promise<TaskAgentInterfaces.TaskLog>;
     createLog(log: TaskAgentInterfaces.TaskLog, scopeIdentifier: string, hubName: string, planId: string): Promise<TaskAgentInterfaces.TaskLog>;
     getLog(scopeIdentifier: string, hubName: string, planId: string, logId: number, startLine?: number, endLine?: number): Promise<string[]>;
     getLogs(scopeIdentifier: string, hubName: string, planId: string): Promise<TaskAgentInterfaces.TaskLog[]>;
-    getQueuedPlanGroups(scopeIdentifier: string, hubName: string, statusFilter?: TaskAgentInterfaces.PlanGroupStatusFilter, count?: number): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>;
+    getPlanGroupsQueueMetrics(scopeIdentifier: string, hubName: string): Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>;
+    getQueuedPlanGroups(scopeIdentifier: string, hubName: string, statusFilter?: TaskAgentInterfaces.PlanGroupStatus, count?: number): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>;
+    getQueuedPlanGroup(scopeIdentifier: string, hubName: string, planGroup: string): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>;
     getPlan(scopeIdentifier: string, hubName: string, planId: string): Promise<TaskAgentInterfaces.TaskOrchestrationPlan>;
     getRecords(scopeIdentifier: string, hubName: string, planId: string, timelineId: string, changeId?: number): Promise<TaskAgentInterfaces.TimelineRecord[]>;
     updateRecords(records: VSSInterfaces.VssJsonCollectionWrapperV<TaskAgentInterfaces.TimelineRecord[]>, scopeIdentifier: string, hubName: string, planId: string, timelineId: string): Promise<TaskAgentInterfaces.TimelineRecord[]>;
@@ -56,7 +58,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         type: string
-    ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
+        ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -68,24 +70,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "eb55e5d6-2f30-4295-b5ed-38da50b1fc52",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -113,7 +115,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-    ): Promise<TaskAgentInterfaces.TaskAttachment> {
+        ): Promise<TaskAgentInterfaces.TaskAttachment> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment>(async (resolve, reject) => {
             let routeValues: any = {
@@ -131,23 +133,23 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "7898f959-9cdf-4096-b29e-7f293031629e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                                                                                verData.apiVersion);
                 options.additionalHeaders = customHeaders;
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskAttachment>("PUT", url, contentStream, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                                              false);
 
                 resolve(ret);
             }
@@ -174,7 +176,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-    ): Promise<TaskAgentInterfaces.TaskAttachment> {
+        ): Promise<TaskAgentInterfaces.TaskAttachment> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment>(async (resolve, reject) => {
             let routeValues: any = {
@@ -189,24 +191,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "7898f959-9cdf-4096-b29e-7f293031629e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -231,7 +233,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-    ): Promise<NodeJS.ReadableStream> {
+        ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -246,13 +248,13 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "7898f959-9cdf-4096-b29e-7f293031629e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let apiVersion: string = verData.apiVersion;
                 let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -278,7 +280,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         timelineId: string,
         recordId: string,
         type: string
-    ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
+        ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -292,24 +294,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "7898f959-9cdf-4096-b29e-7f293031629e",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -318,7 +320,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
     }
 
     /**
-     * @param {VSSInterfaces.VssJsonCollectionWrapperV<string[]>} lines
+     * @param {TaskAgentInterfaces.TimelineRecordFeedLinesWrapper} lines
      * @param {string} scopeIdentifier - The project GUID to scope the request
      * @param {string} hubName - The name of the server hub: "build" for the Build server or "rm" for the Release Management server
      * @param {string} planId
@@ -326,13 +328,13 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
      * @param {string} recordId
      */
     public async appendTimelineRecordFeed(
-        lines: VSSInterfaces.VssJsonCollectionWrapperV<string[]>,
+        lines: TaskAgentInterfaces.TimelineRecordFeedLinesWrapper,
         scopeIdentifier: string,
         hubName: string,
         planId: string,
         timelineId: string,
         recordId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -345,24 +347,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "858983e4-19bd-4c5e-864c-507b59b58b12",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, lines, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -384,7 +386,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         logId: number
-    ): Promise<TaskAgentInterfaces.TaskLog> {
+        ): Promise<TaskAgentInterfaces.TaskLog> {
 
         return new Promise<TaskAgentInterfaces.TaskLog>(async (resolve, reject) => {
             let routeValues: any = {
@@ -399,23 +401,23 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "46f5667d-263a-4684-91b1-dff7fdcf64e2",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-
+                
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                                                                                verData.apiVersion);
                 options.additionalHeaders = customHeaders;
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskLog>("POST", url, contentStream, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskLog,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskLog,
+                                              false);
 
                 resolve(ret);
             }
@@ -436,7 +438,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-    ): Promise<TaskAgentInterfaces.TaskLog> {
+        ): Promise<TaskAgentInterfaces.TaskLog> {
 
         return new Promise<TaskAgentInterfaces.TaskLog>(async (resolve, reject) => {
             let routeValues: any = {
@@ -447,24 +449,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "46f5667d-263a-4684-91b1-dff7fdcf64e2",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskLog>(url, log, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskLog,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskLog,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -487,7 +489,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         logId: number,
         startLine?: number,
         endLine?: number
-    ): Promise<string[]> {
+        ): Promise<string[]> {
 
         return new Promise<string[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -501,28 +503,28 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 startLine: startLine,
                 endLine: endLine,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "46f5667d-263a-4684-91b1-dff7fdcf64e2",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    true);
+                                              null,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -539,7 +541,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-    ): Promise<TaskAgentInterfaces.TaskLog[]> {
+        ): Promise<TaskAgentInterfaces.TaskLog[]> {
 
         return new Promise<TaskAgentInterfaces.TaskLog[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -550,24 +552,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "46f5667d-263a-4684-91b1-dff7fdcf64e2",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskLog[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskLog,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskLog,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -578,15 +580,57 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
     /**
      * @param {string} scopeIdentifier - The project GUID to scope the request
      * @param {string} hubName - The name of the server hub: "build" for the Build server or "rm" for the Release Management server
-     * @param {TaskAgentInterfaces.PlanGroupStatusFilter} statusFilter
+     */
+    public async getPlanGroupsQueueMetrics(
+        scopeIdentifier: string,
+        hubName: string
+        ): Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]> {
+
+        return new Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                scopeIdentifier: scopeIdentifier,
+                hubName: hubName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "038fd4d5-cda7-44ca-92c0-935843fee1a7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlanGroupsQueueMetrics,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} scopeIdentifier - The project GUID to scope the request
+     * @param {string} hubName - The name of the server hub: "build" for the Build server or "rm" for the Release Management server
+     * @param {TaskAgentInterfaces.PlanGroupStatus} statusFilter
      * @param {number} count
      */
     public async getQueuedPlanGroups(
         scopeIdentifier: string,
         hubName: string,
-        statusFilter?: TaskAgentInterfaces.PlanGroupStatusFilter,
+        statusFilter?: TaskAgentInterfaces.PlanGroupStatus,
         count?: number
-    ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]> {
+        ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -598,28 +642,73 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 statusFilter: statusFilter,
                 count: count,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "0dd73091-3e36-4f43-b443-1b76dd426d84",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
+                                              true);
 
                 resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
 
+    /**
+     * @param {string} scopeIdentifier - The project GUID to scope the request
+     * @param {string} hubName - The name of the server hub: "build" for the Build server or "rm" for the Release Management server
+     * @param {string} planGroup
+     */
+    public async getQueuedPlanGroup(
+        scopeIdentifier: string,
+        hubName: string,
+        planGroup: string
+        ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup> {
+
+        return new Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>(async (resolve, reject) => {
+            let routeValues: any = {
+                scopeIdentifier: scopeIdentifier,
+                hubName: hubName,
+                planGroup: planGroup
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "distributedtask",
+                    "65fd0708-bc1e-447b-a731-0587c5464e5b",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>;
+                res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
+                                              false);
+
+                resolve(ret);
+                
             }
             catch (err) {
                 reject(err);
@@ -636,7 +725,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-    ): Promise<TaskAgentInterfaces.TaskOrchestrationPlan> {
+        ): Promise<TaskAgentInterfaces.TaskOrchestrationPlan> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationPlan>(async (resolve, reject) => {
             let routeValues: any = {
@@ -647,24 +736,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "5cecd946-d704-471e-a45f-3b4064fcfaba",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlan>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlan>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlan,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlan,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -685,7 +774,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         planId: string,
         timelineId: string,
         changeId?: number
-    ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
+        ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
 
         return new Promise<TaskAgentInterfaces.TimelineRecord[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -698,28 +787,28 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             let queryValues: any = {
                 changeId: changeId,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "8893bc5b-35b2-4be7-83cb-99e683551db4",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TimelineRecord[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TimelineRecord,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TimelineRecord,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -740,7 +829,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         timelineId: string
-    ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
+        ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
 
         return new Promise<TaskAgentInterfaces.TimelineRecord[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -752,24 +841,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "8893bc5b-35b2-4be7-83cb-99e683551db4",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.update<TaskAgentInterfaces.TimelineRecord[]>(url, records, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.TimelineRecord,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.TimelineRecord,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -788,7 +877,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-    ): Promise<TaskAgentInterfaces.Timeline> {
+        ): Promise<TaskAgentInterfaces.Timeline> {
 
         return new Promise<TaskAgentInterfaces.Timeline>(async (resolve, reject) => {
             let routeValues: any = {
@@ -799,24 +888,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "83597576-cc2c-453c-bea6-2882ae6a1653",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.create<TaskAgentInterfaces.Timeline>(url, timeline, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.Timeline,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.Timeline,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -835,7 +924,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         timelineId: string
-    ): Promise<void> {
+        ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -847,24 +936,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "83597576-cc2c-453c-bea6-2882ae6a1653",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    null,
-                    false);
+                                              null,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -887,7 +976,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         timelineId: string,
         changeId?: number,
         includeRecords?: boolean
-    ): Promise<TaskAgentInterfaces.Timeline> {
+        ): Promise<TaskAgentInterfaces.Timeline> {
 
         return new Promise<TaskAgentInterfaces.Timeline>(async (resolve, reject) => {
             let routeValues: any = {
@@ -901,28 +990,28 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 changeId: changeId,
                 includeRecords: includeRecords,
             };
-
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "83597576-cc2c-453c-bea6-2882ae6a1653",
                     routeValues,
                     queryValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.Timeline,
-                    false);
+                                              TaskAgentInterfaces.TypeInfo.Timeline,
+                                              false);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);
@@ -939,7 +1028,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-    ): Promise<TaskAgentInterfaces.Timeline[]> {
+        ): Promise<TaskAgentInterfaces.Timeline[]> {
 
         return new Promise<TaskAgentInterfaces.Timeline[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -950,24 +1039,24 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "3.2-preview.1",
+                    "5.0-preview.1",
                     "distributedtask",
                     "83597576-cc2c-453c-bea6-2882ae6a1653",
                     routeValues);
 
                 let url: string = verData.requestUrl;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                    verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline[]>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                    TaskAgentInterfaces.TypeInfo.Timeline,
-                    true);
+                                              TaskAgentInterfaces.TypeInfo.Timeline,
+                                              true);
 
                 resolve(ret);
-
+                
             }
             catch (err) {
                 reject(err);

--- a/api/TestApi.ts
+++ b/api/TestApi.ts
@@ -21,11 +21,17 @@ import TfsCoreInterfaces = require("./interfaces/CoreInterfaces");
 
 export interface ITestApi extends basem.ClientApiBase {
     getActionResults(project: string, runId: number, testCaseResultId: number, iterationId: number, actionPath?: string): Promise<TestInterfaces.TestActionResultModel[]>;
+    createAfnStrip(afnStrip: TestInterfaces.AfnStrip, project: string): Promise<TestInterfaces.AfnStrip>;
+    getAfnStrips(project: string, testCaseIds?: number[]): Promise<TestInterfaces.AfnStrip[]>;
     createTestIterationResultAttachment(attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel, project: string, runId: number, testCaseResultId: number, iterationId: number, actionPath?: string): Promise<TestInterfaces.TestAttachmentReference>;
     createTestResultAttachment(attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel, project: string, runId: number, testCaseResultId: number): Promise<TestInterfaces.TestAttachmentReference>;
+    createTestSubResultAttachment(attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel, project: string, runId: number, testCaseResultId: number, testSubResultId: number): Promise<TestInterfaces.TestAttachmentReference>;
     getTestResultAttachmentContent(project: string, runId: number, testCaseResultId: number, attachmentId: number): Promise<NodeJS.ReadableStream>;
     getTestResultAttachments(project: string, runId: number, testCaseResultId: number): Promise<TestInterfaces.TestAttachment[]>;
     getTestResultAttachmentZip(project: string, runId: number, testCaseResultId: number, attachmentId: number): Promise<NodeJS.ReadableStream>;
+    getTestSubResultAttachmentContent(project: string, runId: number, testCaseResultId: number, attachmentId: number, testSubResultId: number): Promise<NodeJS.ReadableStream>;
+    getTestSubResultAttachments(project: string, runId: number, testCaseResultId: number, testSubResultId: number): Promise<TestInterfaces.TestAttachment[]>;
+    getTestSubResultAttachmentZip(project: string, runId: number, testCaseResultId: number, attachmentId: number, testSubResultId: number): Promise<NodeJS.ReadableStream>;
     createTestRunAttachment(attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel, project: string, runId: number): Promise<TestInterfaces.TestAttachmentReference>;
     getTestRunAttachmentContent(project: string, runId: number, attachmentId: number): Promise<NodeJS.ReadableStream>;
     getTestRunAttachments(project: string, runId: number): Promise<TestInterfaces.TestAttachment[]>;
@@ -60,11 +66,11 @@ export interface ITestApi extends basem.ClientApiBase {
     getPoints(project: string, planId: number, suiteId: number, witFields?: string, configurationId?: string, testCaseId?: string, testPointIds?: string, includePointDetails?: boolean, skip?: number, top?: number): Promise<TestInterfaces.TestPoint[]>;
     updateTestPoints(pointUpdateModel: TestInterfaces.PointUpdateModel, project: string, planId: number, suiteId: number, pointIds: string): Promise<TestInterfaces.TestPoint[]>;
     getPointsByQuery(query: TestInterfaces.TestPointsQuery, project: string, skip?: number, top?: number): Promise<TestInterfaces.TestPointsQuery>;
-    getTestResultDetailsForBuild(project: string, buildId: number, publishContext?: string, groupBy?: string, filter?: string, orderby?: string): Promise<TestInterfaces.TestResultsDetails>;
-    getTestResultDetailsForRelease(project: string, releaseId: number, releaseEnvId: number, publishContext?: string, groupBy?: string, filter?: string, orderby?: string): Promise<TestInterfaces.TestResultsDetails>;
+    getTestResultDetailsForBuild(project: string, buildId: number, publishContext?: string, groupBy?: string, filter?: string, orderby?: string, shouldIncludeResults?: boolean, queryRunSummaryForInProgress?: boolean): Promise<TestInterfaces.TestResultsDetails>;
+    getTestResultDetailsForRelease(project: string, releaseId: number, releaseEnvId: number, publishContext?: string, groupBy?: string, filter?: string, orderby?: string, shouldIncludeResults?: boolean, queryRunSummaryForInProgress?: boolean): Promise<TestInterfaces.TestResultsDetails>;
     publishTestResultDocument(document: TestInterfaces.TestResultDocument, project: string, runId: number): Promise<TestInterfaces.TestResultDocument>;
-    getResultGroupsByBuild(project: string, buildId: number, publishContext: string, fields?: string[]): Promise<TestInterfaces.TestResultsGroupsForBuild>;
-    getResultGroupsByRelease(project: string, releaseId: number, publishContext: string, releaseEnvId?: number, fields?: string[]): Promise<TestInterfaces.TestResultsGroupsForRelease>;
+    getResultGroupsByBuild(project: string, buildId: number, publishContext: string, fields?: string[], continuationToken?: string): Promise<TestInterfaces.FieldDetailsForTestResults[]>;
+    getResultGroupsByRelease(project: string, releaseId: number, publishContext: string, releaseEnvId?: number, fields?: string[], continuationToken?: string): Promise<TestInterfaces.FieldDetailsForTestResults[]>;
     getResultRetentionSettings(project: string): Promise<TestInterfaces.ResultRetentionSettings>;
     updateResultRetentionSettings(retentionSettings: TestInterfaces.ResultRetentionSettings, project: string): Promise<TestInterfaces.ResultRetentionSettings>;
     addTestResultsToTestRun(results: TestInterfaces.TestCaseResult[], project: string, runId: number): Promise<TestInterfaces.TestCaseResult[]>;
@@ -72,6 +78,8 @@ export interface ITestApi extends basem.ClientApiBase {
     getTestResults(project: string, runId: number, detailsToInclude?: TestInterfaces.ResultDetails, skip?: number, top?: number, outcomes?: TestInterfaces.TestOutcome[]): Promise<TestInterfaces.TestCaseResult[]>;
     updateTestResults(results: TestInterfaces.TestCaseResult[], project: string, runId: number): Promise<TestInterfaces.TestCaseResult[]>;
     getTestResultsByQuery(query: TestInterfaces.TestResultsQuery, project: string): Promise<TestInterfaces.TestResultsQuery>;
+    getTestResultsByBuild(project: string, buildId: number, publishContext?: string, outcomes?: TestInterfaces.TestOutcome[], top?: number, continuationToken?: string): Promise<TestInterfaces.ShallowTestCaseResult[]>;
+    getTestResultsByRelease(project: string, releaseId: number, releaseEnvid?: number, publishContext?: string, outcomes?: TestInterfaces.TestOutcome[], top?: number, continuationToken?: string): Promise<TestInterfaces.ShallowTestCaseResult[]>;
     queryTestResultsReportForBuild(project: string, buildId: number, publishContext?: string, includeFailureDetails?: boolean, buildToCompare?: TestInterfaces.BuildReference): Promise<TestInterfaces.TestResultSummary>;
     queryTestResultsReportForRelease(project: string, releaseId: number, releaseEnvId: number, publishContext?: string, includeFailureDetails?: boolean, releaseToCompare?: TestInterfaces.ReleaseReference): Promise<TestInterfaces.TestResultSummary>;
     queryTestResultsSummaryForReleases(releases: TestInterfaces.ReleaseReference[], project: string): Promise<TestInterfaces.TestResultSummary[]>;
@@ -81,7 +89,7 @@ export interface ITestApi extends basem.ClientApiBase {
     getTestRunStatistics(project: string, runId: number): Promise<TestInterfaces.TestRunStatistic>;
     createTestRun(testRun: TestInterfaces.RunCreateModel, project: string): Promise<TestInterfaces.TestRun>;
     deleteTestRun(project: string, runId: number): Promise<void>;
-    getTestRunById(project: string, runId: number): Promise<TestInterfaces.TestRun>;
+    getTestRunById(project: string, runId: number, includeDetails?: boolean): Promise<TestInterfaces.TestRun>;
     getTestRuns(project: string, buildUri?: string, owner?: string, tmiRunId?: string, planId?: number, includeRunDetails?: boolean, automated?: boolean, skip?: number, top?: number): Promise<TestInterfaces.TestRun[]>;
     queryTestRuns(project: string, minLastUpdatedDate: Date, maxLastUpdatedDate: Date, state?: TestInterfaces.TestRunState, planIds?: number[], isAutomated?: boolean, publishContext?: TestInterfaces.TestRunPublishContext, buildIds?: number[], buildDefIds?: number[], branchName?: string, releaseIds?: number[], releaseDefIds?: number[], releaseEnvIds?: number[], releaseEnvDefIds?: number[], runTitle?: string, top?: number, continuationToken?: string): Promise<TestInterfaces.TestRun[]>;
     updateTestRun(runUpdateModel: TestInterfaces.RunUpdateModel, project: string, runId: number): Promise<TestInterfaces.TestRun>;
@@ -96,13 +104,15 @@ export interface ITestApi extends basem.ClientApiBase {
     getTestCaseById(project: string, planId: number, suiteId: number, testCaseIds: number): Promise<TestInterfaces.SuiteTestCase>;
     getTestCases(project: string, planId: number, suiteId: number): Promise<TestInterfaces.SuiteTestCase[]>;
     removeTestCasesFromSuiteUrl(project: string, planId: number, suiteId: number, testCaseIds: string): Promise<void>;
+    updateSuiteTestCases(suiteTestCaseUpdateModel: TestInterfaces.SuiteTestCaseUpdateModel, project: string, planId: number, suiteId: number, testCaseIds: string): Promise<TestInterfaces.SuiteTestCase[]>;
     createTestSuite(testSuite: TestInterfaces.SuiteCreateModel, project: string, planId: number, suiteId: number): Promise<TestInterfaces.TestSuite[]>;
     deleteTestSuite(project: string, planId: number, suiteId: number): Promise<void>;
-    getTestSuiteById(project: string, planId: number, suiteId: number, includeChildSuites?: boolean): Promise<TestInterfaces.TestSuite>;
-    getTestSuitesForPlan(project: string, planId: number, includeSuites?: boolean, skip?: number, top?: number, asTreeView?: boolean): Promise<TestInterfaces.TestSuite[]>;
+    getTestSuiteById(project: string, planId: number, suiteId: number, expand?: number): Promise<TestInterfaces.TestSuite>;
+    getTestSuitesForPlan(project: string, planId: number, expand?: number, skip?: number, top?: number, asTreeView?: boolean): Promise<TestInterfaces.TestSuite[]>;
     updateTestSuite(suiteUpdateModel: TestInterfaces.SuiteUpdateModel, project: string, planId: number, suiteId: number): Promise<TestInterfaces.TestSuite>;
     getSuitesByTestCaseId(testCaseId: number): Promise<TestInterfaces.TestSuite[]>;
     deleteTestCase(project: string, testCaseId: number): Promise<void>;
+    queryTestHistory(filter: TestInterfaces.TestHistoryQuery, project: string): Promise<TestInterfaces.TestHistoryQuery>;
     createTestSettings(testSettings: TestInterfaces.TestSettings, project: string): Promise<number>;
     deleteTestSettings(project: string, testSettingsId: number): Promise<void>;
     getTestSettingsById(project: string, testSettingsId: number): Promise<TestInterfaces.TestSettings>;
@@ -122,12 +132,16 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
         super(baseUrl, handlers, 'node-Test-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e";
+
     /**
+     * Gets the action results for an iteration in a test result.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} iterationId
-     * @param {string} actionPath
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result that contains the iterations.
+     * @param {number} iterationId - ID of the iteration that contains the actions.
+     * @param {string} actionPath - Path of a specific action, used to get just that action.
      */
     public async getActionResults(
         project: string,
@@ -148,7 +162,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Test",
                     "eaf40c31-ff84-4062-aafd-d5664be11a37",
                     routeValues);
@@ -174,12 +188,105 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel
+     * Create AfnStrip
+     * 
+     * @param {TestInterfaces.AfnStrip} afnStrip - AfnStrip request payload
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} iterationId
-     * @param {string} actionPath
+     */
+    public async createAfnStrip(
+        afnStrip: TestInterfaces.AfnStrip,
+        project: string
+        ): Promise<TestInterfaces.AfnStrip> {
+
+        return new Promise<TestInterfaces.AfnStrip>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "708cd155-cd42-48c1-8679-decc9929c3ad",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.AfnStrip>;
+                res = await this.rest.create<TestInterfaces.AfnStrip>(url, afnStrip, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TestInterfaces.TypeInfo.AfnStrip,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get list of afnStrips by testcaseid
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number[]} testCaseIds - Ids of testcases
+     */
+    public async getAfnStrips(
+        project: string,
+        testCaseIds?: number[]
+        ): Promise<TestInterfaces.AfnStrip[]> {
+
+        return new Promise<TestInterfaces.AfnStrip[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                testCaseIds: testCaseIds && testCaseIds.join(","),
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "708cd155-cd42-48c1-8679-decc9929c3ad",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.AfnStrip[]>;
+                res = await this.rest.get<TestInterfaces.AfnStrip[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TestInterfaces.TypeInfo.AfnStrip,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Attach a file to test step result
+     * 
+     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel - Attachment details TestAttachmentRequestModel
+     * @param {string} project - Project ID or project name
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result that contains the iteration
+     * @param {number} iterationId - ID of the test result iteration.
+     * @param {string} actionPath - Hex value of test result action path.
      */
     public async createTestIterationResultAttachment(
         attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel,
@@ -204,7 +311,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
                     routeValues,
@@ -231,10 +338,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel
+     * Attach a file to a test result.
+     * 
+     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel - Attachment details TestAttachmentRequestModel
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result against which attachment has to be uploaded.
      */
     public async createTestResultAttachment(
         attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel,
@@ -252,7 +361,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
                     routeValues);
@@ -278,12 +387,68 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns a test result attachment
+     * Attach a file to a test result
+     * 
+     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel - Attachment Request Model.
+     * @param {string} project - Project ID or project name
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test results that contains sub result.
+     * @param {number} testSubResultId - ID of the test sub results against which attachment has to be uploaded.
+     */
+    public async createTestSubResultAttachment(
+        attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel,
+        project: string,
+        runId: number,
+        testCaseResultId: number,
+        testSubResultId: number
+        ): Promise<TestInterfaces.TestAttachmentReference> {
+
+        return new Promise<TestInterfaces.TestAttachmentReference>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                runId: runId,
+                testCaseResultId: testCaseResultId
+            };
+
+            let queryValues: any = {
+                testSubResultId: testSubResultId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.TestAttachmentReference>;
+                res = await this.rest.create<TestInterfaces.TestAttachmentReference>(url, attachmentRequestModel, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Download a test result attachment by its ID.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} attachmentId
+     * @param {number} runId - ID of the test run that contains the testCaseResultId.
+     * @param {number} testCaseResultId - ID of the test result whose attachment has to be downloaded.
+     * @param {number} attachmentId - ID of the test result attachment to be downloaded.
      */
     public async getTestResultAttachmentContent(
         project: string,
@@ -302,7 +467,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
                     routeValues);
@@ -320,11 +485,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns attachment references for test result.
+     * Get list of test result attachments reference.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result.
      */
     public async getTestResultAttachments(
         project: string,
@@ -341,7 +506,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
                     routeValues);
@@ -367,12 +532,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns a test result attachment
+     * Download a test result attachment by its ID.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} attachmentId
+     * @param {number} runId - ID of the test run that contains the testCaseResultId.
+     * @param {number} testCaseResultId - ID of the test result whose attachment has to be downloaded.
+     * @param {number} attachmentId - ID of the test result attachment to be downloaded.
      */
     public async getTestResultAttachmentZip(
         project: string,
@@ -391,7 +556,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
                     routeValues);
@@ -409,9 +574,163 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel
+     * Download a test sub result attachment
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test results that contains sub result.
+     * @param {number} attachmentId - ID of the test result attachment to be downloaded
+     * @param {number} testSubResultId - ID of the test sub result whose attachment has to be downloaded
+     */
+    public async getTestSubResultAttachmentContent(
+        project: string,
+        runId: number,
+        testCaseResultId: number,
+        attachmentId: number,
+        testSubResultId: number
+        ): Promise<NodeJS.ReadableStream> {
+
+        return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                runId: runId,
+                testCaseResultId: testCaseResultId,
+                attachmentId: attachmentId
+            };
+
+            let queryValues: any = {
+                testSubResultId: testSubResultId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                
+                let apiVersion: string = verData.apiVersion;
+                let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
+                resolve((await this.http.get(url, { "Accept": accept })).message);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get list of test sub result attachments
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test results that contains sub result.
+     * @param {number} testSubResultId - ID of the test sub result whose attachment has to be downloaded
+     */
+    public async getTestSubResultAttachments(
+        project: string,
+        runId: number,
+        testCaseResultId: number,
+        testSubResultId: number
+        ): Promise<TestInterfaces.TestAttachment[]> {
+
+        return new Promise<TestInterfaces.TestAttachment[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                runId: runId,
+                testCaseResultId: testCaseResultId
+            };
+
+            let queryValues: any = {
+                testSubResultId: testSubResultId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.TestAttachment[]>;
+                res = await this.rest.get<TestInterfaces.TestAttachment[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TestInterfaces.TypeInfo.TestAttachment,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Download a test sub result attachment
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test results that contains sub result.
+     * @param {number} attachmentId - ID of the test result attachment to be downloaded
+     * @param {number} testSubResultId - ID of the test sub result whose attachment has to be downloaded
+     */
+    public async getTestSubResultAttachmentZip(
+        project: string,
+        runId: number,
+        testCaseResultId: number,
+        attachmentId: number,
+        testSubResultId: number
+        ): Promise<NodeJS.ReadableStream> {
+
+        return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                runId: runId,
+                testCaseResultId: testCaseResultId,
+                attachmentId: attachmentId
+            };
+
+            let queryValues: any = {
+                testSubResultId: testSubResultId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "2bffebe9-2f0f-4639-9af8-56129e9fed2d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                
+                let apiVersion: string = verData.apiVersion;
+                let accept: string = this.createAcceptHeader("application/zip", apiVersion);
+                resolve((await this.http.get(url, { "Accept": accept })).message);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Attach a file to a test run.
+     * 
+     * @param {TestInterfaces.TestAttachmentRequestModel} attachmentRequestModel - Attachment details TestAttachmentRequestModel
+     * @param {string} project - Project ID or project name
+     * @param {number} runId - ID of the test run against which attachment has to be uploaded.
      */
     public async createTestRunAttachment(
         attachmentRequestModel: TestInterfaces.TestAttachmentRequestModel,
@@ -427,7 +746,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "4f004af4-a507-489c-9b13-cb62060beb11",
                     routeValues);
@@ -453,11 +772,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns a test run attachment
+     * Download a test run attachment by its ID.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} attachmentId
+     * @param {number} runId - ID of the test run whose attachment has to be downloaded.
+     * @param {number} attachmentId - ID of the test run attachment to be downloaded.
      */
     public async getTestRunAttachmentContent(
         project: string,
@@ -474,7 +793,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "4f004af4-a507-489c-9b13-cb62060beb11",
                     routeValues);
@@ -492,10 +811,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns attachment references for test run.
+     * Get list of test run attachments reference.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the test run.
      */
     public async getTestRunAttachments(
         project: string,
@@ -510,7 +829,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "4f004af4-a507-489c-9b13-cb62060beb11",
                     routeValues);
@@ -536,11 +855,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Returns a test run attachment
+     * Download a test run attachment by its ID.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} attachmentId
+     * @param {number} runId - ID of the test run whose attachment has to be downloaded.
+     * @param {number} attachmentId - ID of the test run attachment to be downloaded.
      */
     public async getTestRunAttachmentZip(
         project: string,
@@ -557,7 +876,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "4f004af4-a507-489c-9b13-cb62060beb11",
                     routeValues);
@@ -594,7 +913,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "6de20ca2-67de-4faf-97fa-38c5d585eb00",
                     routeValues);
@@ -620,9 +939,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get clone information.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} cloneOperationId
-     * @param {boolean} includeDetails
+     * @param {number} cloneOperationId - Operation ID returned when we queue a clone operation
+     * @param {boolean} includeDetails - If false returns only status of the clone operation information, if true returns complete clone information
      */
     public async getCloneInformation(
         project: string,
@@ -642,7 +963,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "5b9d6320-abed-47a5-a151-cd6dc3798be6",
                     routeValues,
@@ -669,9 +990,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestPlanCloneRequest} cloneRequestBody
+     * Clone test plan
+     * 
+     * @param {TestInterfaces.TestPlanCloneRequest} cloneRequestBody - Plan Clone Request Body detail TestPlanCloneRequest
      * @param {string} project - Project ID or project name
-     * @param {number} planId
+     * @param {number} planId - ID of the test plan to be cloned.
      */
     public async cloneTestPlan(
         cloneRequestBody: TestInterfaces.TestPlanCloneRequest,
@@ -687,7 +1010,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "edc3ef4b-8460-4e86-86fa-8e4f5e9be831",
                     routeValues);
@@ -713,10 +1036,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestSuiteCloneRequest} cloneRequestBody
+     * Clone test suite
+     * 
+     * @param {TestInterfaces.TestSuiteCloneRequest} cloneRequestBody - Suite Clone Request Body detail TestSuiteCloneRequest
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} sourceSuiteId
+     * @param {number} planId - ID of the test plan in which suite to be cloned is present
+     * @param {number} sourceSuiteId - ID of the test suite to be cloned
      */
     public async cloneTestSuite(
         cloneRequestBody: TestInterfaces.TestSuiteCloneRequest,
@@ -734,7 +1059,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "751e4ab5-5bf6-4fb5-9d5d-19ef347662dd",
                     routeValues);
@@ -760,9 +1085,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get code coverage data for a build.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} buildId
-     * @param {number} flags
+     * @param {number} buildId - ID of the build for which code coverage data needs to be fetched.
+     * @param {number} flags - Value of flags determine the level of code coverage details to be fetched. Flags are additive. Expected Values are 1 for Modules, 2 for Functions, 4 for BlockData.
      */
     public async getBuildCodeCoverage(
         project: string,
@@ -782,7 +1109,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "77560e8a-4e8c-4d59-894e-a5f264c24444",
                     routeValues,
@@ -796,7 +1123,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 res = await this.rest.get<TestInterfaces.BuildCoverage[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              TestInterfaces.TypeInfo.BuildCoverage,
                                               true);
 
                 resolve(ret);
@@ -809,9 +1136,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get Code Coverage Summary for Build.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} buildId
-     * @param {number} deltaBuildId
+     * @param {number} buildId - ID of the build for which code coverage data needs to be fetched.
+     * @param {number} deltaBuildId - Delta Build id (optional)
      */
     public async getCodeCoverageSummary(
         project: string,
@@ -831,7 +1160,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "77560e8a-4e8c-4d59-894e-a5f264c24444",
                     routeValues,
@@ -881,7 +1210,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "77560e8a-4e8c-4d59-894e-a5f264c24444",
                     routeValues,
@@ -908,9 +1237,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get code coverage data for a test run
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} flags
+     * @param {number} runId - ID of the test run for which code coverage data needs to be fetched.
+     * @param {number} flags - Value of flags determine the level of code coverage details to be fetched. Flags are additive. Expected Values are 1 for Modules, 2 for Functions, 4 for BlockData.
      */
     public async getTestRunCodeCoverage(
         project: string,
@@ -930,7 +1261,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "9629116f-3b89-4ed8-b358-d4694efda160",
                     routeValues,
@@ -957,7 +1288,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestConfiguration} testConfiguration
+     * Create a test configuration
+     * 
+     * @param {TestInterfaces.TestConfiguration} testConfiguration - Test configuration
      * @param {string} project - Project ID or project name
      */
     public async createTestConfiguration(
@@ -972,7 +1305,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "d667591b-b9fd-4263-997a-9a084cca848f",
                     routeValues);
@@ -998,8 +1331,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete a test configuration
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} testConfigurationId
+     * @param {number} testConfigurationId - ID of the test configuration to get.
      */
     public async deleteTestConfiguration(
         project: string,
@@ -1014,7 +1349,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "d667591b-b9fd-4263-997a-9a084cca848f",
                     routeValues);
@@ -1040,8 +1375,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a test configuration
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} testConfigurationId
+     * @param {number} testConfigurationId - ID of the test configuration to get.
      */
     public async getTestConfigurationById(
         project: string,
@@ -1056,7 +1393,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "d667591b-b9fd-4263-997a-9a084cca848f",
                     routeValues);
@@ -1082,11 +1419,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test configurations
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} skip
-     * @param {number} top
-     * @param {string} continuationToken
-     * @param {boolean} includeAllProperties
+     * @param {number} skip - Number of test configurations to skip.
+     * @param {number} top - Number of test configurations to return.
+     * @param {string} continuationToken - If the list of configurations returned is not complete, a continuation token to query next batch of configurations is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test configurations.
+     * @param {boolean} includeAllProperties - If true, it returns all properties of the test configurations. Otherwise, it returns the skinny version.
      */
     public async getTestConfigurations(
         project: string,
@@ -1110,7 +1449,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "d667591b-b9fd-4263-997a-9a084cca848f",
                     routeValues,
@@ -1137,9 +1476,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestConfiguration} testConfiguration
+     * Update a test configuration
+     * 
+     * @param {TestInterfaces.TestConfiguration} testConfiguration - Test configuration
      * @param {string} project - Project ID or project name
-     * @param {number} testConfigurationId
+     * @param {number} testConfigurationId - ID of the test configuration to update.
      */
     public async updateTestConfiguration(
         testConfiguration: TestInterfaces.TestConfiguration,
@@ -1155,7 +1496,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "d667591b-b9fd-4263-997a-9a084cca848f",
                     routeValues);
@@ -1196,7 +1537,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8ce1923b-f4c7-4e22-b93b-f6284e525ec2",
                     routeValues);
@@ -1241,7 +1582,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8ce1923b-f4c7-4e22-b93b-f6284e525ec2",
                     routeValues,
@@ -1283,7 +1624,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "234616f5-429c-4e7b-9192-affd76731dfd",
                     routeValues);
@@ -1309,11 +1650,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get iteration for a result
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} iterationId
-     * @param {boolean} includeActionResults
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result that contains the iterations.
+     * @param {number} iterationId - Id of the test results Iteration.
+     * @param {boolean} includeActionResults - Include result details for each action performed in the test iteration. ActionResults refer to outcome (pass/fail) of test steps that are executed as part of a running a manual test. Including the ActionResults flag gets the outcome of test steps in the actionResults section and test parameters in the parameters section for each test iteration.
      */
     public async getTestIteration(
         project: string,
@@ -1337,7 +1680,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Test",
                     "73eb9074-3446-4c44-8296-2f811950ff8d",
                     routeValues,
@@ -1364,10 +1707,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get iterations for a result
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {boolean} includeActionResults
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result that contains the iterations.
+     * @param {boolean} includeActionResults - Include result details for each action performed in the test iteration. ActionResults refer to outcome (pass/fail) of test steps that are executed as part of a running a manual test. Including the ActionResults flag gets the outcome of test steps in the actionResults section and test parameters in the parameters section for each test iteration.
      */
     public async getTestIterations(
         project: string,
@@ -1389,7 +1734,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Test",
                     "73eb9074-3446-4c44-8296-2f811950ff8d",
                     routeValues,
@@ -1431,7 +1776,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "a4dcb25b-9878-49ea-abfd-e440bd9b1dcd",
                     routeValues);
@@ -1457,8 +1802,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test run message logs
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the run to get.
      */
     public async getTestRunLogs(
         project: string,
@@ -1473,7 +1820,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "a1e55200-637e-42e9-a7c0-7e5bfdedb1b3",
                     routeValues);
@@ -1499,11 +1846,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of parameterized results
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {number} iterationId
-     * @param {string} paramName
+     * @param {number} runId - ID of the test run that contains the result.
+     * @param {number} testCaseResultId - ID of the test result that contains the iterations.
+     * @param {number} iterationId - ID of the iteration that contains the parameterized results.
+     * @param {string} paramName - Name of the parameter.
      */
     public async getResultParameters(
         project: string,
@@ -1527,7 +1876,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "Test",
                     "7c69810d-3354-4af3-844a-180bd25db08a",
                     routeValues,
@@ -1554,7 +1903,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.PlanUpdateModel} testPlan
+     * Create a test plan.
+     * 
+     * @param {TestInterfaces.PlanUpdateModel} testPlan - A test plan object.
      * @param {string} project - Project ID or project name
      */
     public async createTestPlan(
@@ -1569,7 +1920,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "51712106-7278-4208-8563-1c96f40cf5e4",
                     routeValues);
@@ -1595,8 +1946,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete a test plan.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
+     * @param {number} planId - ID of the test plan to be deleted.
      */
     public async deleteTestPlan(
         project: string,
@@ -1611,7 +1964,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "51712106-7278-4208-8563-1c96f40cf5e4",
                     routeValues);
@@ -1637,8 +1990,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test plan by ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
+     * @param {number} planId - ID of the test plan to return.
      */
     public async getPlanById(
         project: string,
@@ -1653,7 +2008,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "51712106-7278-4208-8563-1c96f40cf5e4",
                     routeValues);
@@ -1679,12 +2034,14 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test plans.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} owner
-     * @param {number} skip
-     * @param {number} top
-     * @param {boolean} includePlanDetails
-     * @param {boolean} filterActivePlans
+     * @param {string} owner - Filter for test plan by owner ID or name.
+     * @param {number} skip - Number of test plans to skip.
+     * @param {number} top - Number of test plans to return.
+     * @param {boolean} includePlanDetails - Get all properties of the test plan.
+     * @param {boolean} filterActivePlans - Get just the active plans.
      */
     public async getPlans(
         project: string,
@@ -1710,7 +2067,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "51712106-7278-4208-8563-1c96f40cf5e4",
                     routeValues,
@@ -1737,9 +2094,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Update a test plan.
+     * 
      * @param {TestInterfaces.PlanUpdateModel} planUpdateModel
      * @param {string} project - Project ID or project name
-     * @param {number} planId
+     * @param {number} planId - ID of the test plan to be updated.
      */
     public async updateTestPlan(
         planUpdateModel: TestInterfaces.PlanUpdateModel,
@@ -1755,7 +2114,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "51712106-7278-4208-8563-1c96f40cf5e4",
                     routeValues);
@@ -1781,11 +2140,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a test point.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {number} pointIds
-     * @param {string} witFields
+     * @param {number} planId - ID of the test plan.
+     * @param {number} suiteId - ID of the suite that contains the point.
+     * @param {number} pointIds - ID of the test point to get.
+     * @param {string} witFields - Comma-separated list of work item field names.
      */
     public async getPoint(
         project: string,
@@ -1809,7 +2170,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "3bcfd5c8-be62-488e-b1da-b8289ce9299c",
                     routeValues,
@@ -1836,16 +2197,18 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test points.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {string} witFields
-     * @param {string} configurationId
-     * @param {string} testCaseId
-     * @param {string} testPointIds
-     * @param {boolean} includePointDetails
-     * @param {number} skip
-     * @param {number} top
+     * @param {number} planId - ID of the test plan.
+     * @param {number} suiteId - ID of the suite that contains the points.
+     * @param {string} witFields - Comma-separated list of work item field names.
+     * @param {string} configurationId - Get test points for specific configuration.
+     * @param {string} testCaseId - Get test points for a specific test case, valid when configurationId is not set.
+     * @param {string} testPointIds - Get test points for comma-separated list of test point IDs, valid only when configurationId and testCaseId are not set.
+     * @param {boolean} includePointDetails - Include all properties for the test point.
+     * @param {number} skip - Number of test points to skip..
+     * @param {number} top - Number of test points to return.
      */
     public async getPoints(
         project: string,
@@ -1879,7 +2242,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "3bcfd5c8-be62-488e-b1da-b8289ce9299c",
                     routeValues,
@@ -1906,11 +2269,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.PointUpdateModel} pointUpdateModel
+     * Update test points.
+     * 
+     * @param {TestInterfaces.PointUpdateModel} pointUpdateModel - Data to update.
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {string} pointIds
+     * @param {number} planId - ID of the test plan.
+     * @param {number} suiteId - ID of the suite that contains the points.
+     * @param {string} pointIds - ID of the test point to get. Use a comma-separated list of IDs to update multiple test points.
      */
     public async updateTestPoints(
         pointUpdateModel: TestInterfaces.PointUpdateModel,
@@ -1930,7 +2295,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "3bcfd5c8-be62-488e-b1da-b8289ce9299c",
                     routeValues);
@@ -1956,10 +2321,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestPointsQuery} query
+     * Get test points using query.
+     * 
+     * @param {TestInterfaces.TestPointsQuery} query - TestPointsQuery to get test points.
      * @param {string} project - Project ID or project name
-     * @param {number} skip
-     * @param {number} top
+     * @param {number} skip - Number of test points to skip..
+     * @param {number} top - Number of test points to return.
      */
     public async getPointsByQuery(
         query: TestInterfaces.TestPointsQuery,
@@ -1980,7 +2347,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "b4264fd0-a5d1-43e2-82a5-b9c46b7da9ce",
                     routeValues,
@@ -2013,6 +2380,8 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
      * @param {string} groupBy
      * @param {string} filter
      * @param {string} orderby
+     * @param {boolean} shouldIncludeResults
+     * @param {boolean} queryRunSummaryForInProgress
      */
     public async getTestResultDetailsForBuild(
         project: string,
@@ -2020,7 +2389,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
         publishContext?: string,
         groupBy?: string,
         filter?: string,
-        orderby?: string
+        orderby?: string,
+        shouldIncludeResults?: boolean,
+        queryRunSummaryForInProgress?: boolean
         ): Promise<TestInterfaces.TestResultsDetails> {
 
         return new Promise<TestInterfaces.TestResultsDetails>(async (resolve, reject) => {
@@ -2034,11 +2405,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 groupBy: groupBy,
                 '$filter': filter,
                 '$orderby': orderby,
+                shouldIncludeResults: shouldIncludeResults,
+                queryRunSummaryForInProgress: queryRunSummaryForInProgress,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "efb387b0-10d5-42e7-be40-95e06ee9430f",
                     routeValues,
@@ -2072,6 +2445,8 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
      * @param {string} groupBy
      * @param {string} filter
      * @param {string} orderby
+     * @param {boolean} shouldIncludeResults
+     * @param {boolean} queryRunSummaryForInProgress
      */
     public async getTestResultDetailsForRelease(
         project: string,
@@ -2080,7 +2455,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
         publishContext?: string,
         groupBy?: string,
         filter?: string,
-        orderby?: string
+        orderby?: string,
+        shouldIncludeResults?: boolean,
+        queryRunSummaryForInProgress?: boolean
         ): Promise<TestInterfaces.TestResultsDetails> {
 
         return new Promise<TestInterfaces.TestResultsDetails>(async (resolve, reject) => {
@@ -2095,11 +2472,13 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 groupBy: groupBy,
                 '$filter': filter,
                 '$orderby': orderby,
+                shouldIncludeResults: shouldIncludeResults,
+                queryRunSummaryForInProgress: queryRunSummaryForInProgress,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "b834ec7e-35bb-450f-a3c8-802e70ca40dd",
                     routeValues,
@@ -2144,7 +2523,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "370ca04b-8eec-4ca8-8ba3-d24dca228791",
                     routeValues);
@@ -2174,15 +2553,17 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
      * @param {number} buildId
      * @param {string} publishContext
      * @param {string[]} fields
+     * @param {string} continuationToken
      */
     public async getResultGroupsByBuild(
         project: string,
         buildId: number,
         publishContext: string,
-        fields?: string[]
-        ): Promise<TestInterfaces.TestResultsGroupsForBuild> {
+        fields?: string[],
+        continuationToken?: string
+        ): Promise<TestInterfaces.FieldDetailsForTestResults[]> {
 
-        return new Promise<TestInterfaces.TestResultsGroupsForBuild>(async (resolve, reject) => {
+        return new Promise<TestInterfaces.FieldDetailsForTestResults[]>(async (resolve, reject) => {
             let routeValues: any = {
                 project: project
             };
@@ -2191,11 +2572,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 buildId: buildId,
                 publishContext: publishContext,
                 fields: fields && fields.join(","),
+                continuationToken: continuationToken,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "Test",
                     "d279d052-c55a-4204-b913-42f733b52958",
                     routeValues,
@@ -2205,12 +2587,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<TestInterfaces.TestResultsGroupsForBuild>;
-                res = await this.rest.get<TestInterfaces.TestResultsGroupsForBuild>(url, options);
+                let res: restm.IRestResponse<TestInterfaces.FieldDetailsForTestResults[]>;
+                res = await this.rest.get<TestInterfaces.FieldDetailsForTestResults[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
-                                              false);
+                                              true);
 
                 resolve(ret);
                 
@@ -2227,16 +2609,18 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
      * @param {string} publishContext
      * @param {number} releaseEnvId
      * @param {string[]} fields
+     * @param {string} continuationToken
      */
     public async getResultGroupsByRelease(
         project: string,
         releaseId: number,
         publishContext: string,
         releaseEnvId?: number,
-        fields?: string[]
-        ): Promise<TestInterfaces.TestResultsGroupsForRelease> {
+        fields?: string[],
+        continuationToken?: string
+        ): Promise<TestInterfaces.FieldDetailsForTestResults[]> {
 
-        return new Promise<TestInterfaces.TestResultsGroupsForRelease>(async (resolve, reject) => {
+        return new Promise<TestInterfaces.FieldDetailsForTestResults[]>(async (resolve, reject) => {
             let routeValues: any = {
                 project: project
             };
@@ -2246,11 +2630,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 publishContext: publishContext,
                 releaseEnvId: releaseEnvId,
                 fields: fields && fields.join(","),
+                continuationToken: continuationToken,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "Test",
                     "ef5ce5d4-a4e5-47ee-804c-354518f8d03f",
                     routeValues,
@@ -2260,12 +2645,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<TestInterfaces.TestResultsGroupsForRelease>;
-                res = await this.rest.get<TestInterfaces.TestResultsGroupsForRelease>(url, options);
+                let res: restm.IRestResponse<TestInterfaces.FieldDetailsForTestResults[]>;
+                res = await this.rest.get<TestInterfaces.FieldDetailsForTestResults[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
-                                              false);
+                                              true);
 
                 resolve(ret);
                 
@@ -2277,6 +2662,8 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test result retention settings
+     * 
      * @param {string} project - Project ID or project name
      */
     public async getResultRetentionSettings(
@@ -2290,7 +2677,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "a3206d9e-fa8d-42d3-88cb-f75c51e69cde",
                     routeValues);
@@ -2316,7 +2703,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.ResultRetentionSettings} retentionSettings
+     * Update test result retention settings
+     * 
+     * @param {TestInterfaces.ResultRetentionSettings} retentionSettings - Test result retention settings details to be updated
      * @param {string} project - Project ID or project name
      */
     public async updateResultRetentionSettings(
@@ -2331,7 +2720,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "a3206d9e-fa8d-42d3-88cb-f75c51e69cde",
                     routeValues);
@@ -2357,9 +2746,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestCaseResult[]} results
+     * Add test results to a test run.
+     * 
+     * @param {TestInterfaces.TestCaseResult[]} results - List of test results to add.
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - Test run ID into which test results to add.
      */
     public async addTestResultsToTestRun(
         results: TestInterfaces.TestCaseResult[],
@@ -2375,7 +2766,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.4",
+                    "5.0-preview.5",
                     "Test",
                     "4637d869-3a76-4468-8057-0bb02aa385cf",
                     routeValues);
@@ -2401,10 +2792,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a test result for a test run.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
-     * @param {number} testCaseResultId
-     * @param {TestInterfaces.ResultDetails} detailsToInclude
+     * @param {number} runId - Test run ID of a test result to fetch.
+     * @param {number} testCaseResultId - Test result ID.
+     * @param {TestInterfaces.ResultDetails} detailsToInclude - Details to include with test results. Default is None. Other values are Iterations, WorkItems and SubResults.
      */
     public async getTestResultById(
         project: string,
@@ -2426,7 +2819,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.4",
+                    "5.0-preview.5",
                     "Test",
                     "4637d869-3a76-4468-8057-0bb02aa385cf",
                     routeValues,
@@ -2453,14 +2846,14 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * Get Test Results for a run based on filters.
+     * Get test results for a test run.
      * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId - Test Run Id for which results need to be fetched.
-     * @param {TestInterfaces.ResultDetails} detailsToInclude - enum indicates details need to be fetched.
-     * @param {number} skip - Number of results to skip from beginning.
-     * @param {number} top - Number of results to return. Max is 1000 when detailsToInclude is None and 100 otherwise.
-     * @param {TestInterfaces.TestOutcome[]} outcomes - List of Testoutcome to filter results, comma seperated list of Testoutcome.
+     * @param {number} runId - Test run ID of test results to fetch.
+     * @param {TestInterfaces.ResultDetails} detailsToInclude - Details to include with test results. Default is None. Other values are Iterations and WorkItems.
+     * @param {number} skip - Number of test results to skip from beginning.
+     * @param {number} top - Number of test results to return. Maximum is 1000 when detailsToInclude is None and 200 otherwise.
+     * @param {TestInterfaces.TestOutcome[]} outcomes - Comma separated list of test outcomes to filter test results.
      */
     public async getTestResults(
         project: string,
@@ -2486,7 +2879,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.4",
+                    "5.0-preview.5",
                     "Test",
                     "4637d869-3a76-4468-8057-0bb02aa385cf",
                     routeValues,
@@ -2513,9 +2906,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestCaseResult[]} results
+     * Update test results in a test run.
+     * 
+     * @param {TestInterfaces.TestCaseResult[]} results - List of test results to update.
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - Test run ID whose test results to update.
      */
     public async updateTestResults(
         results: TestInterfaces.TestCaseResult[],
@@ -2531,7 +2926,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.4",
+                    "5.0-preview.5",
                     "Test",
                     "4637d869-3a76-4468-8057-0bb02aa385cf",
                     routeValues);
@@ -2572,7 +2967,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.4",
+                    "5.0-preview.5",
                     "Test",
                     "6711da49-8e6f-4d35-9f73-cef7a3c81a5b",
                     routeValues);
@@ -2587,6 +2982,125 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let ret = this.formatResponse(res.result,
                                               TestInterfaces.TypeInfo.TestResultsQuery,
                                               false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} buildId
+     * @param {string} publishContext
+     * @param {TestInterfaces.TestOutcome[]} outcomes
+     * @param {number} top
+     * @param {string} continuationToken
+     */
+    public async getTestResultsByBuild(
+        project: string,
+        buildId: number,
+        publishContext?: string,
+        outcomes?: TestInterfaces.TestOutcome[],
+        top?: number,
+        continuationToken?: string
+        ): Promise<TestInterfaces.ShallowTestCaseResult[]> {
+
+        return new Promise<TestInterfaces.ShallowTestCaseResult[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                buildId: buildId,
+                publishContext: publishContext,
+                outcomes: outcomes && outcomes.join(","),
+                '$top': top,
+                continuationToken: continuationToken,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "3c191b88-615b-4be2-b7d9-5ff9141e91d4",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.ShallowTestCaseResult[]>;
+                res = await this.rest.get<TestInterfaces.ShallowTestCaseResult[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} releaseId
+     * @param {number} releaseEnvid
+     * @param {string} publishContext
+     * @param {TestInterfaces.TestOutcome[]} outcomes
+     * @param {number} top
+     * @param {string} continuationToken
+     */
+    public async getTestResultsByRelease(
+        project: string,
+        releaseId: number,
+        releaseEnvid?: number,
+        publishContext?: string,
+        outcomes?: TestInterfaces.TestOutcome[],
+        top?: number,
+        continuationToken?: string
+        ): Promise<TestInterfaces.ShallowTestCaseResult[]> {
+
+        return new Promise<TestInterfaces.ShallowTestCaseResult[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                releaseId: releaseId,
+                releaseEnvid: releaseEnvid,
+                publishContext: publishContext,
+                outcomes: outcomes && outcomes.join(","),
+                '$top': top,
+                continuationToken: continuationToken,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "ce01820b-83f3-4c15-a583-697a43292c4e",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.ShallowTestCaseResult[]>;
+                res = await this.rest.get<TestInterfaces.ShallowTestCaseResult[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
 
                 resolve(ret);
                 
@@ -2626,7 +3140,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "Test",
                     "000ef77b-fea2-498d-a10d-ad1a037f559f",
                     routeValues,
@@ -2684,7 +3198,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "Test",
                     "85765790-ac68-494e-b268-af36c3929744",
                     routeValues,
@@ -2726,7 +3240,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "Test",
                     "85765790-ac68-494e-b268-af36c3929744",
                     routeValues);
@@ -2773,7 +3287,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "cd08294e-308d-4460-a46e-4cfdefba0b4b",
                     routeValues,
@@ -2815,7 +3329,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "fbc82a85-0786-4442-88bb-eb0fda6b01b0",
                     routeValues);
@@ -2856,7 +3370,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "dd178e93-d8dd-4887-9635-d6b9560b7b6e",
                     routeValues);
@@ -2882,8 +3396,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test run statistics
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the run to get.
      */
     public async getTestRunStatistics(
         project: string,
@@ -2898,7 +3414,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "0a42c424-d764-4a16-a2d5-5c85f87d0ae8",
                     routeValues);
@@ -2924,7 +3440,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.RunCreateModel} testRun
+     * Create new test run.
+     * 
+     * @param {TestInterfaces.RunCreateModel} testRun - Run details RunCreateModel
      * @param {string} project - Project ID or project name
      */
     public async createTestRun(
@@ -2939,7 +3457,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
                     routeValues);
@@ -2965,8 +3483,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete a test run by its ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the run to delete.
      */
     public async deleteTestRun(
         project: string,
@@ -2981,7 +3501,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
                     routeValues);
@@ -3007,12 +3527,16 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a test run by its ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the run to get.
+     * @param {boolean} includeDetails - Defualt value is true. It includes details like run statistics,release,build,Test enviornment,Post process state and more
      */
     public async getTestRunById(
         project: string,
-        runId: number
+        runId: number,
+        includeDetails?: boolean
         ): Promise<TestInterfaces.TestRun> {
 
         return new Promise<TestInterfaces.TestRun>(async (resolve, reject) => {
@@ -3021,12 +3545,17 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 runId: runId
             };
 
+            let queryValues: any = {
+                includeDetails: includeDetails,
+            };
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
-                    routeValues);
+                    routeValues,
+                    queryValues);
 
                 let url: string = verData.requestUrl;
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
@@ -3049,15 +3578,17 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test runs.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {string} buildUri
-     * @param {string} owner
+     * @param {string} buildUri - URI of the build that the runs used.
+     * @param {string} owner - Team foundation ID of the owner of the runs.
      * @param {string} tmiRunId
-     * @param {number} planId
-     * @param {boolean} includeRunDetails
-     * @param {boolean} automated
-     * @param {number} skip
-     * @param {number} top
+     * @param {number} planId - ID of the test plan that the runs are a part of.
+     * @param {boolean} includeRunDetails - If true, include all the properties of the runs.
+     * @param {boolean} automated - If true, only returns automated runs.
+     * @param {number} skip - Number of test runs to skip.
+     * @param {number} top - Number of test runs to return.
      */
     public async getTestRuns(
         project: string,
@@ -3089,7 +3620,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
                     routeValues,
@@ -3122,16 +3653,16 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
      * @param {Date} minLastUpdatedDate - Minimum Last Modified Date of run to be queried (Mandatory).
      * @param {Date} maxLastUpdatedDate - Maximum Last Modified Date of run to be queried (Mandatory, difference between min and max date can be atmost 7 days).
      * @param {TestInterfaces.TestRunState} state - Current state of the Runs to be queried.
-     * @param {number[]} planIds - Plan Ids of the Runs to be queried, comma seperated list of valid ids.
+     * @param {number[]} planIds - Plan Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
      * @param {boolean} isAutomated - Automation type of the Runs to be queried.
      * @param {TestInterfaces.TestRunPublishContext} publishContext - PublishContext of the Runs to be queried.
-     * @param {number[]} buildIds - Build Ids of the Runs to be queried, comma seperated list of valid ids.
-     * @param {number[]} buildDefIds - Build Definition Ids of the Runs to be queried, comma seperated list of valid ids.
+     * @param {number[]} buildIds - Build Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
+     * @param {number[]} buildDefIds - Build Definition Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
      * @param {string} branchName - Source Branch name of the Runs to be queried.
-     * @param {number[]} releaseIds - Release Ids of the Runs to be queried, comma seperated list of valid ids.
-     * @param {number[]} releaseDefIds - Release Definition Ids of the Runs to be queried, comma seperated list of valid ids.
-     * @param {number[]} releaseEnvIds - Release Environment Ids of the Runs to be queried, comma seperated list of valid ids.
-     * @param {number[]} releaseEnvDefIds - Release Environment Definition Ids of the Runs to be queried, comma seperated list of valid ids.
+     * @param {number[]} releaseIds - Release Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
+     * @param {number[]} releaseDefIds - Release Definition Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
+     * @param {number[]} releaseEnvIds - Release Environment Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
+     * @param {number[]} releaseEnvDefIds - Release Environment Definition Ids of the Runs to be queried, comma seperated list of valid ids (limit no. of ids 10).
      * @param {string} runTitle - Run Title of the Runs to be queried.
      * @param {number} top - Number of runs to be queried. Limit is 100
      * @param {string} continuationToken - continuationToken received from previous batch or null for first batch.
@@ -3182,7 +3713,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
                     routeValues,
@@ -3209,9 +3740,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.RunUpdateModel} runUpdateModel
+     * Update test run by its ID.
+     * 
+     * @param {TestInterfaces.RunUpdateModel} runUpdateModel - Run details RunUpdateModel
      * @param {string} project - Project ID or project name
-     * @param {number} runId
+     * @param {number} runId - ID of the run to update.
      */
     public async updateTestRun(
         runUpdateModel: TestInterfaces.RunUpdateModel,
@@ -3227,7 +3760,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.2",
                     "Test",
                     "cadb3810-d47d-4a3c-a234-fe5f3be50138",
                     routeValues);
@@ -3253,7 +3786,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestSession} testSession
+     * Create a test session
+     * 
+     * @param {TestInterfaces.TestSession} testSession - Test session details for creation
      * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
      */
     public async createTestSession(
@@ -3272,7 +3807,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac",
                     routeValues);
@@ -3298,12 +3833,14 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test sessions
+     * 
      * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
-     * @param {number} period
-     * @param {boolean} allSessions
-     * @param {boolean} includeAllProperties
-     * @param {TestInterfaces.TestSessionSource} source
-     * @param {boolean} includeOnlyCompletedSessions
+     * @param {number} period - Period in days from now, for which test sessions are fetched.
+     * @param {boolean} allSessions - If false, returns test sessions for current user. Otherwise, it returns test sessions for all users
+     * @param {boolean} includeAllProperties - If true, it returns all properties of the test sessions. Otherwise, it returns the skinny version.
+     * @param {TestInterfaces.TestSessionSource} source - Source of the test session.
+     * @param {boolean} includeOnlyCompletedSessions - If true, it returns test sessions in completed state. Otherwise, it returns test sessions for all states
      */
     public async getTestSessions(
         teamContext: TfsCoreInterfaces.TeamContext,
@@ -3333,7 +3870,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac",
                     routeValues,
@@ -3360,7 +3897,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestSession} testSession
+     * Update a test session
+     * 
+     * @param {TestInterfaces.TestSession} testSession - Test session details for update
      * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
      */
     public async updateTestSession(
@@ -3379,7 +3918,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "1500b4b4-6c69-4ca6-9b18-35e9e97fe2ac",
                     routeValues);
@@ -3421,7 +3960,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8300eeca-0f8c-4eff-a089-d2dda409c41f",
                     routeValues);
@@ -3463,7 +4002,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "fabb3cc9-e3f8-40b7-8b62-24cc4b73fccf",
                     routeValues);
@@ -3489,8 +4028,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test suite entries in the test suite.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} suiteId
+     * @param {number} suiteId - Id of the parent suite.
      */
     public async getSuiteEntries(
         project: string,
@@ -3505,7 +4046,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "bf8b7f78-0c1f-49cb-89e9-d1a17bcaaad3",
                     routeValues);
@@ -3531,9 +4072,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.SuiteEntryUpdateModel[]} suiteEntries
+     * Reorder test suite entries in the test suite.
+     * 
+     * @param {TestInterfaces.SuiteEntryUpdateModel[]} suiteEntries - List of SuiteEntryUpdateModel to reorder.
      * @param {string} project - Project ID or project name
-     * @param {number} suiteId
+     * @param {number} suiteId - Id of the parent test suite.
      */
     public async reorderSuiteEntries(
         suiteEntries: TestInterfaces.SuiteEntryUpdateModel[],
@@ -3549,7 +4092,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "bf8b7f78-0c1f-49cb-89e9-d1a17bcaaad3",
                     routeValues);
@@ -3575,10 +4118,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Add test cases to suite.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {string} testCaseIds
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the test suite to which the test cases must be added.
+     * @param {string} testCaseIds - IDs of the test cases to add to the suite. Ids are specified in comma separated format.
      */
     public async addTestCasesToSuite(
         project: string,
@@ -3597,7 +4142,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "a4a1ec1c-b03f-41ca-8857-704594ecf58e",
                     routeValues);
@@ -3623,10 +4168,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a specific test case in a test suite with test case id.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {number} testCaseIds
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the suite that contains the test case.
+     * @param {number} testCaseIds - ID of the test case to get.
      */
     public async getTestCaseById(
         project: string,
@@ -3645,7 +4192,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "a4a1ec1c-b03f-41ca-8857-704594ecf58e",
                     routeValues);
@@ -3671,9 +4218,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get all test cases in a suite.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the suite to get.
      */
     public async getTestCases(
         project: string,
@@ -3690,7 +4239,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "a4a1ec1c-b03f-41ca-8857-704594ecf58e",
                     routeValues);
@@ -3716,10 +4265,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * The test points associated with the test cases are removed from the test suite. The test case work item is not deleted from the system. See test cases resource to delete a test case permanently.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {string} testCaseIds
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the suite to get.
+     * @param {string} testCaseIds - IDs of the test cases to remove from the suite.
      */
     public async removeTestCasesFromSuiteUrl(
         project: string,
@@ -3738,7 +4289,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "a4a1ec1c-b03f-41ca-8857-704594ecf58e",
                     routeValues);
@@ -3764,10 +4315,64 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.SuiteCreateModel} testSuite
+     * Updates the properties of the test case association in a suite.
+     * 
+     * @param {TestInterfaces.SuiteTestCaseUpdateModel} suiteTestCaseUpdateModel - Model for updation of the properties of test case suite association.
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the test suite to which the test cases must be added.
+     * @param {string} testCaseIds - IDs of the test cases to add to the suite. Ids are specified in comma separated format.
+     */
+    public async updateSuiteTestCases(
+        suiteTestCaseUpdateModel: TestInterfaces.SuiteTestCaseUpdateModel,
+        project: string,
+        planId: number,
+        suiteId: number,
+        testCaseIds: string
+        ): Promise<TestInterfaces.SuiteTestCase[]> {
+
+        return new Promise<TestInterfaces.SuiteTestCase[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId,
+                testCaseIds: testCaseIds
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.3",
+                    "Test",
+                    "a4a1ec1c-b03f-41ca-8857-704594ecf58e",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.SuiteTestCase[]>;
+                res = await this.rest.update<TestInterfaces.SuiteTestCase[]>(url, suiteTestCaseUpdateModel, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create a test suite.
+     * 
+     * @param {TestInterfaces.SuiteCreateModel} testSuite - Test suite data.
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the parent suite.
      */
     public async createTestSuite(
         testSuite: TestInterfaces.SuiteCreateModel,
@@ -3785,7 +4390,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "7b7619a0-cb54-4ab3-bf22-194056f45dd1",
                     routeValues);
@@ -3811,9 +4416,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete test suite.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the test suite to delete.
      */
     public async deleteTestSuite(
         project: string,
@@ -3830,7 +4437,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "7b7619a0-cb54-4ab3-bf22-194056f45dd1",
                     routeValues);
@@ -3856,16 +4463,18 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test suite by suite id.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
-     * @param {boolean} includeChildSuites
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the suite to get.
+     * @param {number} expand - Include the children suites and testers details
      */
     public async getTestSuiteById(
         project: string,
         planId: number,
         suiteId: number,
-        includeChildSuites?: boolean
+        expand?: number
         ): Promise<TestInterfaces.TestSuite> {
 
         return new Promise<TestInterfaces.TestSuite>(async (resolve, reject) => {
@@ -3876,12 +4485,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             };
 
             let queryValues: any = {
-                includeChildSuites: includeChildSuites,
+                '$expand': expand,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "7b7619a0-cb54-4ab3-bf22-194056f45dd1",
                     routeValues,
@@ -3908,17 +4517,19 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get test suites for plan.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {boolean} includeSuites
-     * @param {number} skip
-     * @param {number} top
-     * @param {boolean} asTreeView
+     * @param {number} planId - ID of the test plan for which suites are requested.
+     * @param {number} expand - Include the children suites and testers details.
+     * @param {number} skip - Number of suites to skip from the result.
+     * @param {number} top - Number of Suites to be return after skipping the suites from the result.
+     * @param {boolean} asTreeView - If the suites returned should be in a tree structure.
      */
     public async getTestSuitesForPlan(
         project: string,
         planId: number,
-        includeSuites?: boolean,
+        expand?: number,
         skip?: number,
         top?: number,
         asTreeView?: boolean
@@ -3931,7 +4542,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             };
 
             let queryValues: any = {
-                includeSuites: includeSuites,
+                '$expand': expand,
                 '$skip': skip,
                 '$top': top,
                 '$asTreeView': asTreeView,
@@ -3939,7 +4550,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "7b7619a0-cb54-4ab3-bf22-194056f45dd1",
                     routeValues,
@@ -3966,10 +4577,12 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.SuiteUpdateModel} suiteUpdateModel
+     * Update a test suite.
+     * 
+     * @param {TestInterfaces.SuiteUpdateModel} suiteUpdateModel - Suite Model to update
      * @param {string} project - Project ID or project name
-     * @param {number} planId
-     * @param {number} suiteId
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the suite to update.
      */
     public async updateTestSuite(
         suiteUpdateModel: TestInterfaces.SuiteUpdateModel,
@@ -3987,7 +4600,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "7b7619a0-cb54-4ab3-bf22-194056f45dd1",
                     routeValues);
@@ -4013,7 +4626,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {number} testCaseId
+     * Find the list of all test suites in which a given test case is present. This is helpful if you need to find out which test suites are using a test case, when you need to make changes to a test case.
+     * 
+     * @param {number} testCaseId - ID of the test case for which suites need to be fetched.
      */
     public async getSuitesByTestCaseId(
         testCaseId: number
@@ -4029,7 +4644,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.2",
+                    "5.0-preview.3",
                     "Test",
                     "09a6167b-e969-4775-9247-b94cf3819caf",
                     routeValues,
@@ -4056,8 +4671,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete a test case.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} testCaseId
+     * @param {number} testCaseId - Id of test case to delete.
      */
     public async deleteTestCase(
         project: string,
@@ -4072,7 +4689,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "4d472e0f-e32c-4ef8-adf4-a4078772889c",
                     routeValues);
@@ -4086,6 +4703,49 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
                 let ret = this.formatResponse(res.result,
                                               null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get history of a test method using TestHistoryQuery
+     * 
+     * @param {TestInterfaces.TestHistoryQuery} filter - TestHistoryQuery to get history
+     * @param {string} project - Project ID or project name
+     */
+    public async queryTestHistory(
+        filter: TestInterfaces.TestHistoryQuery,
+        project: string
+        ): Promise<TestInterfaces.TestHistoryQuery> {
+
+        return new Promise<TestInterfaces.TestHistoryQuery>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "Test",
+                    "929fd86c-3e38-4d8c-b4b6-90df256e5971",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TestInterfaces.TestHistoryQuery>;
+                res = await this.rest.create<TestInterfaces.TestHistoryQuery>(url, filter, options);
+
+                let ret = this.formatResponse(res.result,
+                                              TestInterfaces.TypeInfo.TestHistoryQuery,
                                               false);
 
                 resolve(ret);
@@ -4113,7 +4773,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8133ce14-962f-42af-a5f9-6aa9defcb9c8",
                     routeValues);
@@ -4155,7 +4815,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8133ce14-962f-42af-a5f9-6aa9defcb9c8",
                     routeValues);
@@ -4197,7 +4857,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "8133ce14-962f-42af-a5f9-6aa9defcb9c8",
                     routeValues);
@@ -4223,7 +4883,9 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestVariable} testVariable
+     * Create a test variable.
+     * 
+     * @param {TestInterfaces.TestVariable} testVariable - TestVariable
      * @param {string} project - Project ID or project name
      */
     public async createTestVariable(
@@ -4238,7 +4900,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "be3fcb2b-995b-47bf-90e5-ca3cf9980912",
                     routeValues);
@@ -4264,8 +4926,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Delete a test variable by its ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} testVariableId
+     * @param {number} testVariableId - ID of the test variable to delete.
      */
     public async deleteTestVariable(
         project: string,
@@ -4280,7 +4944,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "be3fcb2b-995b-47bf-90e5-ca3cf9980912",
                     routeValues);
@@ -4306,8 +4970,10 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a test variable by its ID.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} testVariableId
+     * @param {number} testVariableId - ID of the test variable to get.
      */
     public async getTestVariableById(
         project: string,
@@ -4322,7 +4988,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "be3fcb2b-995b-47bf-90e5-ca3cf9980912",
                     routeValues);
@@ -4348,9 +5014,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
+     * Get a list of test variables.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} skip
-     * @param {number} top
+     * @param {number} skip - Number of test variables to skip.
+     * @param {number} top - Number of test variables to return.
      */
     public async getTestVariables(
         project: string,
@@ -4370,7 +5038,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "be3fcb2b-995b-47bf-90e5-ca3cf9980912",
                     routeValues,
@@ -4397,9 +5065,11 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
     }
 
     /**
-     * @param {TestInterfaces.TestVariable} testVariable
+     * Update a test variable by its ID.
+     * 
+     * @param {TestInterfaces.TestVariable} testVariable - TestVariable
      * @param {string} project - Project ID or project name
-     * @param {number} testVariableId
+     * @param {number} testVariableId - ID of the test variable to update.
      */
     public async updateTestVariable(
         testVariable: TestInterfaces.TestVariable,
@@ -4415,7 +5085,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "be3fcb2b-995b-47bf-90e5-ca3cf9980912",
                     routeValues);
@@ -4456,7 +5126,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "371b1655-ce05-412e-a113-64cc77bb78d2",
                     routeValues);
@@ -4469,7 +5139,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 res = await this.rest.create<TestInterfaces.WorkItemToTestLinks>(url, workItemToTestLinks, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              TestInterfaces.TypeInfo.WorkItemToTestLinks,
                                               false);
 
                 resolve(ret);
@@ -4504,7 +5174,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "7b0bdee3-a354-47f9-a42c-89018d7808d5",
                     routeValues,
@@ -4550,7 +5220,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "7b0bdee3-a354-47f9-a42c-89018d7808d5",
                     routeValues,
@@ -4611,7 +5281,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "Test",
                     "926ff5dc-137f-45f0-bd51-9412fa9810ce",
                     routeValues,

--- a/api/TfvcApi.ts
+++ b/api/TfvcApi.ts
@@ -30,11 +30,11 @@ export interface ITfvcApi extends basem.ClientApiBase {
     getChangesetWorkItems(id?: number): Promise<TfvcInterfaces.AssociatedWorkItem[]>;
     getItemsBatch(itemRequestData: TfvcInterfaces.TfvcItemRequestData, project?: string): Promise<TfvcInterfaces.TfvcItem[][]>;
     getItemsBatchZip(itemRequestData: TfvcInterfaces.TfvcItemRequestData, project?: string): Promise<NodeJS.ReadableStream>;
-    getItem(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor): Promise<TfvcInterfaces.TfvcItem>;
-    getItemContent(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor): Promise<NodeJS.ReadableStream>;
+    getItem(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor, includeContent?: boolean): Promise<TfvcInterfaces.TfvcItem>;
+    getItemContent(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor, includeContent?: boolean): Promise<NodeJS.ReadableStream>;
     getItems(project?: string, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, includeLinks?: boolean, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor): Promise<TfvcInterfaces.TfvcItem[]>;
-    getItemText(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor): Promise<NodeJS.ReadableStream>;
-    getItemZip(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor): Promise<NodeJS.ReadableStream>;
+    getItemText(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor, includeContent?: boolean): Promise<NodeJS.ReadableStream>;
+    getItemZip(path: string, project?: string, fileName?: string, download?: boolean, scopePath?: string, recursionLevel?: TfvcInterfaces.VersionControlRecursionType, versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor, includeContent?: boolean): Promise<NodeJS.ReadableStream>;
     getLabelItems(labelId: string, top?: number, skip?: number): Promise<TfvcInterfaces.TfvcItem[]>;
     getLabel(labelId: string, requestData: TfvcInterfaces.TfvcLabelRequestData, project?: string): Promise<TfvcInterfaces.TfvcLabel>;
     getLabels(requestData: TfvcInterfaces.TfvcLabelRequestData, project?: string, top?: number, skip?: number): Promise<TfvcInterfaces.TfvcLabelRef[]>;
@@ -42,12 +42,15 @@ export interface ITfvcApi extends basem.ClientApiBase {
     getShelveset(shelvesetId: string, requestData?: TfvcInterfaces.TfvcShelvesetRequestData): Promise<TfvcInterfaces.TfvcShelveset>;
     getShelvesets(requestData?: TfvcInterfaces.TfvcShelvesetRequestData, top?: number, skip?: number): Promise<TfvcInterfaces.TfvcShelvesetRef[]>;
     getShelvesetWorkItems(shelvesetId: string): Promise<TfvcInterfaces.AssociatedWorkItem[]>;
+    getTfvcStatistics(project?: string, scopePath?: string): Promise<TfvcInterfaces.TfvcStatistics>;
 }
 
 export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-Tfvc-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "8aa40520-446d-40e6-89f6-9c9f9ce44c48";
 
     /**
      * Get a single branch hierarchy at the given path with parents or children as specified.
@@ -77,7 +80,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "bc1f417e-239d-42e7-85e1-76e80cb2d6eb",
                     routeValues,
@@ -134,7 +137,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "bc1f417e-239d-42e7-85e1-76e80cb2d6eb",
                     routeValues,
@@ -188,7 +191,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "bc1f417e-239d-42e7-85e1-76e80cb2d6eb",
                     routeValues,
@@ -239,7 +242,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "f32b86f2-15b9-4fe6-81b1-6f8938617ee5",
                     routeValues,
@@ -283,7 +286,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "tfvc",
                     "0bc8f0a4-6bfb-42a9-ba84-139da7b99c49",
                     routeValues);
@@ -357,7 +360,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "tfvc",
                     "0bc8f0a4-6bfb-42a9-ba84-139da7b99c49",
                     routeValues,
@@ -417,7 +420,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.3",
+                    "5.0-preview.3",
                     "tfvc",
                     "0bc8f0a4-6bfb-42a9-ba84-139da7b99c49",
                     routeValues,
@@ -458,7 +461,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "b7e7c173-803c-4fea-9ec8-31ee35c5502a",
                     routeValues);
@@ -499,7 +502,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "64ae0bea-1d71-47c9-a9e5-fe73f5ea0ff4",
                     routeValues);
@@ -542,7 +545,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "fe6f827b-5f64-480f-b8af-1eca3b80e833",
                     routeValues);
@@ -585,7 +588,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "fe6f827b-5f64-480f-b8af-1eca3b80e833",
                     routeValues);
@@ -611,7 +614,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
      * @param {boolean} download - If true, create a downloadable attachment.
      * @param {string} scopePath - Version control path of a folder to return multiple items.
      * @param {TfvcInterfaces.VersionControlRecursionType} recursionLevel - None (just the item), or OneLevel (contents of a folder).
-     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor
+     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
      */
     public async getItem(
         path: string,
@@ -620,7 +624,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
         download?: boolean,
         scopePath?: string,
         recursionLevel?: TfvcInterfaces.VersionControlRecursionType,
-        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor
+        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor,
+        includeContent?: boolean
         ): Promise<TfvcInterfaces.TfvcItem> {
 
         return new Promise<TfvcInterfaces.TfvcItem>(async (resolve, reject) => {
@@ -635,11 +640,12 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 scopePath: scopePath,
                 recursionLevel: recursionLevel,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "ba9fc436-9a38-4578-89d6-e4f3241f5040",
                     routeValues,
@@ -674,7 +680,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
      * @param {boolean} download - If true, create a downloadable attachment.
      * @param {string} scopePath - Version control path of a folder to return multiple items.
      * @param {TfvcInterfaces.VersionControlRecursionType} recursionLevel - None (just the item), or OneLevel (contents of a folder).
-     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor
+     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
      */
     public async getItemContent(
         path: string,
@@ -683,7 +690,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
         download?: boolean,
         scopePath?: string,
         recursionLevel?: TfvcInterfaces.VersionControlRecursionType,
-        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor
+        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor,
+        includeContent?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -698,11 +706,12 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 scopePath: scopePath,
                 recursionLevel: recursionLevel,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "ba9fc436-9a38-4578-89d6-e4f3241f5040",
                     routeValues,
@@ -751,7 +760,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "ba9fc436-9a38-4578-89d6-e4f3241f5040",
                     routeValues,
@@ -786,7 +795,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
      * @param {boolean} download - If true, create a downloadable attachment.
      * @param {string} scopePath - Version control path of a folder to return multiple items.
      * @param {TfvcInterfaces.VersionControlRecursionType} recursionLevel - None (just the item), or OneLevel (contents of a folder).
-     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor
+     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
      */
     public async getItemText(
         path: string,
@@ -795,7 +805,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
         download?: boolean,
         scopePath?: string,
         recursionLevel?: TfvcInterfaces.VersionControlRecursionType,
-        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor
+        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor,
+        includeContent?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -810,11 +821,12 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 scopePath: scopePath,
                 recursionLevel: recursionLevel,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "ba9fc436-9a38-4578-89d6-e4f3241f5040",
                     routeValues,
@@ -841,7 +853,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
      * @param {boolean} download - If true, create a downloadable attachment.
      * @param {string} scopePath - Version control path of a folder to return multiple items.
      * @param {TfvcInterfaces.VersionControlRecursionType} recursionLevel - None (just the item), or OneLevel (contents of a folder).
-     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor
+     * @param {TfvcInterfaces.TfvcVersionDescriptor} versionDescriptor - Version descriptor.  Default is null.
+     * @param {boolean} includeContent - Set to true to include item content when requesting json.  Default is false.
      */
     public async getItemZip(
         path: string,
@@ -850,7 +863,8 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
         download?: boolean,
         scopePath?: string,
         recursionLevel?: TfvcInterfaces.VersionControlRecursionType,
-        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor
+        versionDescriptor?: TfvcInterfaces.TfvcVersionDescriptor,
+        includeContent?: boolean
         ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
@@ -865,11 +879,12 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 scopePath: scopePath,
                 recursionLevel: recursionLevel,
                 versionDescriptor: versionDescriptor,
+                includeContent: includeContent,
             };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "ba9fc436-9a38-4578-89d6-e4f3241f5040",
                     routeValues,
@@ -912,7 +927,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "06166e34-de17-4b60-8cd1-23182a346fda",
                     routeValues,
@@ -963,7 +978,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "a5d9bd7f-b661-4d0e-b9be-d9c16affae54",
                     routeValues,
@@ -1017,7 +1032,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "a5d9bd7f-b661-4d0e-b9be-d9c16affae54",
                     routeValues,
@@ -1068,7 +1083,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "dbaf075b-0445-4c34-9e5b-82292f856522",
                     routeValues,
@@ -1116,7 +1131,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "e36d44fb-e907-4b0a-b194-f83f1ed32ad3",
                     routeValues,
@@ -1167,7 +1182,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "e36d44fb-e907-4b0a-b194-f83f1ed32ad3",
                     routeValues,
@@ -1212,7 +1227,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "tfvc",
                     "a7a0c1c1-373e-425a-b031-a519474d743d",
                     routeValues,
@@ -1228,6 +1243,54 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let ret = this.formatResponse(res.result,
                                               null,
                                               true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Provides File Count and Uncompressed Bytes for a Collection/Project at a particular scope for TFVC.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} scopePath - '$/' for collection, '$/project' for specific project
+     */
+    public async getTfvcStatistics(
+        project?: string,
+        scopePath?: string
+        ): Promise<TfvcInterfaces.TfvcStatistics> {
+
+        return new Promise<TfvcInterfaces.TfvcStatistics>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                scopePath: scopePath,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "tfvc",
+                    "e15c74c0-3605-40e0-aed4-4cc61e549ed8",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<TfvcInterfaces.TfvcStatistics>;
+                res = await this.rest.get<TfvcInterfaces.TfvcStatistics>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
 
                 resolve(ret);
                 

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -10,6 +10,7 @@ import extmgmtm = require("./ExtensionManagementApi");
 import featuremgmtm = require("./FeatureManagementApi");
 import filecontainerm = require('./FileContainerApi');
 import gitm = require('./GitApi');
+//import graphm = require('./GraphApi');
 import locationsm = require('./LocationsApi');
 import notificationm = require('./NotificationApi');
 import policym = require('./PolicyApi');

--- a/api/WikiApi.ts
+++ b/api/WikiApi.ts
@@ -35,6 +35,8 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
         super(baseUrl, handlers, 'node-Wiki-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3";
+
     /**
      * Gets metadata or content of the wiki page for the provided path. Content negotiation is done based on the `Accept` header sent in the request.
      * 

--- a/api/WorkApi.ts
+++ b/api/WorkApi.ts
@@ -21,6 +21,9 @@ import WorkInterfaces = require("./interfaces/WorkInterfaces");
 
 export interface IWorkApi extends basem.ClientApiBase {
     getBacklogConfigurations(teamContext: TfsCoreInterfaces.TeamContext): Promise<WorkInterfaces.BacklogConfiguration>;
+    getBacklogLevelWorkItems(teamContext: TfsCoreInterfaces.TeamContext, backlogId: string): Promise<WorkInterfaces.BacklogLevelWorkItems>;
+    getBacklog(teamContext: TfsCoreInterfaces.TeamContext, id: string): Promise<WorkInterfaces.BacklogLevelConfiguration>;
+    getBacklogs(teamContext: TfsCoreInterfaces.TeamContext): Promise<WorkInterfaces.BacklogLevelConfiguration[]>;
     getColumnSuggestedValues(project?: string): Promise<WorkInterfaces.BoardSuggestedValue[]>;
     getBoardMappingParentItems(teamContext: TfsCoreInterfaces.TeamContext, childBacklogContextCategoryRefName: string, workitemIds: number[]): Promise<WorkInterfaces.ParentChildWIMap[]>;
     getRowSuggestedValues(project?: string): Promise<WorkInterfaces.BoardSuggestedValue[]>;
@@ -61,12 +64,15 @@ export interface IWorkApi extends basem.ClientApiBase {
     updateTeamFieldValues(patch: WorkInterfaces.TeamFieldValuesPatch, teamContext: TfsCoreInterfaces.TeamContext): Promise<WorkInterfaces.TeamFieldValues>;
     getTeamSettings(teamContext: TfsCoreInterfaces.TeamContext): Promise<WorkInterfaces.TeamSetting>;
     updateTeamSettings(teamSettingsPatch: WorkInterfaces.TeamSettingsPatch, teamContext: TfsCoreInterfaces.TeamContext): Promise<WorkInterfaces.TeamSetting>;
+    getIterationWorkItems(teamContext: TfsCoreInterfaces.TeamContext, iterationId: string): Promise<WorkInterfaces.IterationWorkItems>;
 }
 
 export class WorkApi extends basem.ClientApiBase implements IWorkApi {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-Work-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9";
 
     /**
      * Gets backlog configuration for a team
@@ -88,7 +94,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "7799f497-3cb5-4f16-ad4f-5cd06012db64",
                     routeValues);
@@ -103,6 +109,147 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let ret = this.formatResponse(res.result,
                                               WorkInterfaces.TypeInfo.BacklogConfiguration,
                                               false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of work items within a backlog level
+     * 
+     * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
+     * @param {string} backlogId
+     */
+    public async getBacklogLevelWorkItems(
+        teamContext: TfsCoreInterfaces.TeamContext,
+        backlogId: string
+        ): Promise<WorkInterfaces.BacklogLevelWorkItems> {
+
+        return new Promise<WorkInterfaces.BacklogLevelWorkItems>(async (resolve, reject) => {
+            let project = teamContext.projectId || teamContext.project;
+            let team = teamContext.teamId || teamContext.team;
+
+            let routeValues: any = {
+                project: project,
+                team: team,
+                backlogId: backlogId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "work",
+                    "7c468d96-ab1d-4294-a360-92f07e9ccd98",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.BacklogLevelWorkItems>;
+                res = await this.rest.get<WorkInterfaces.BacklogLevelWorkItems>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a backlog level
+     * 
+     * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
+     * @param {string} id - The id of the backlog level
+     */
+    public async getBacklog(
+        teamContext: TfsCoreInterfaces.TeamContext,
+        id: string
+        ): Promise<WorkInterfaces.BacklogLevelConfiguration> {
+
+        return new Promise<WorkInterfaces.BacklogLevelConfiguration>(async (resolve, reject) => {
+            let project = teamContext.projectId || teamContext.project;
+            let team = teamContext.teamId || teamContext.team;
+
+            let routeValues: any = {
+                project: project,
+                team: team,
+                id: id
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "work",
+                    "a93726f9-7867-4e38-b4f2-0bfafc2f6a94",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.BacklogLevelConfiguration>;
+                res = await this.rest.get<WorkInterfaces.BacklogLevelConfiguration>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkInterfaces.TypeInfo.BacklogLevelConfiguration,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * List all backlog levels
+     * 
+     * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
+     */
+    public async getBacklogs(
+        teamContext: TfsCoreInterfaces.TeamContext
+        ): Promise<WorkInterfaces.BacklogLevelConfiguration[]> {
+
+        return new Promise<WorkInterfaces.BacklogLevelConfiguration[]>(async (resolve, reject) => {
+            let project = teamContext.projectId || teamContext.project;
+            let team = teamContext.teamId || teamContext.team;
+
+            let routeValues: any = {
+                project: project,
+                team: team
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "work",
+                    "a93726f9-7867-4e38-b4f2-0bfafc2f6a94",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.BacklogLevelConfiguration[]>;
+                res = await this.rest.get<WorkInterfaces.BacklogLevelConfiguration[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkInterfaces.TypeInfo.BacklogLevelConfiguration,
+                                              true);
 
                 resolve(ret);
                 
@@ -129,7 +276,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "eb7ec5a3-1ba3-4fd1-b834-49a5a387e57d",
                     routeValues);
@@ -183,7 +330,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "186abea3-5c35-432f-9e28-7a15b4312a0e",
                     routeValues,
@@ -225,7 +372,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "bb494cc6-a0f5-4c6c-8dca-ea6912e79eb9",
                     routeValues);
@@ -273,7 +420,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "23ad19fc-3b8e-4877-8462-b3f92bc06b40",
                     routeValues);
@@ -318,7 +465,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "23ad19fc-3b8e-4877-8462-b3f92bc06b40",
                     routeValues);
@@ -368,7 +515,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "23ad19fc-3b8e-4877-8462-b3f92bc06b40",
                     routeValues);
@@ -416,7 +563,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "b30d9f58-1891-4b0a-b168-c46408f919b0",
                     routeValues);
@@ -466,7 +613,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "b30d9f58-1891-4b0a-b168-c46408f919b0",
                     routeValues);
@@ -514,7 +661,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "74412d15-8c1a-4352-a48d-ef1ed5587d57",
                     routeValues);
@@ -565,7 +712,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "74412d15-8c1a-4352-a48d-ef1ed5587d57",
                     routeValues);
@@ -615,7 +762,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "74412d15-8c1a-4352-a48d-ef1ed5587d57",
                     routeValues);
@@ -668,7 +815,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "74412d15-8c1a-4352-a48d-ef1ed5587d57",
                     routeValues);
@@ -716,7 +863,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "b044a3d9-02ea-49c7-91a1-b730949cc896",
                     routeValues);
@@ -766,7 +913,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "b044a3d9-02ea-49c7-91a1-b730949cc896",
                     routeValues);
@@ -814,7 +961,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "07c3b467-bc60-4f05-8e34-599ce288fafc",
                     routeValues);
@@ -864,7 +1011,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "07c3b467-bc60-4f05-8e34-599ce288fafc",
                     routeValues);
@@ -915,7 +1062,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "45fe888c-239e-49fd-958c-df1a1ab21d97",
                     routeValues);
@@ -963,7 +1110,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "45fe888c-239e-49fd-958c-df1a1ab21d97",
                     routeValues);
@@ -1016,7 +1163,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "45fe888c-239e-49fd-958c-df1a1ab21d97",
                     routeValues);
@@ -1064,7 +1211,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c555d7ff-84e1-47df-9923-a3fe0cd8751b",
                     routeValues);
@@ -1114,7 +1261,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c555d7ff-84e1-47df-9923-a3fe0cd8751b",
                     routeValues);
@@ -1170,7 +1317,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "bdd0834e-101f-49f0-a6ae-509f384a12b4",
                     routeValues,
@@ -1219,7 +1366,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c9175577-28a1-4b06-9197-8636af9f64ad",
                     routeValues);
@@ -1267,7 +1414,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c9175577-28a1-4b06-9197-8636af9f64ad",
                     routeValues);
@@ -1296,7 +1443,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
      * Get a team's iterations using timeframe filter
      * 
      * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
-     * @param {string} timeframe - A filter for which iterations are returned based on relative time
+     * @param {string} timeframe - A filter for which iterations are returned based on relative time. Only Current is supported currently.
      */
     public async getTeamIterations(
         teamContext: TfsCoreInterfaces.TeamContext,
@@ -1318,7 +1465,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c9175577-28a1-4b06-9197-8636af9f64ad",
                     routeValues,
@@ -1366,7 +1513,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c9175577-28a1-4b06-9197-8636af9f64ad",
                     routeValues);
@@ -1409,7 +1556,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0b42cb47-cd73-4810-ac90-19c9ba147453",
                     routeValues);
@@ -1453,7 +1600,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0b42cb47-cd73-4810-ac90-19c9ba147453",
                     routeValues);
@@ -1497,7 +1644,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0b42cb47-cd73-4810-ac90-19c9ba147453",
                     routeValues);
@@ -1538,7 +1685,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0b42cb47-cd73-4810-ac90-19c9ba147453",
                     routeValues);
@@ -1584,7 +1731,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0b42cb47-cd73-4810-ac90-19c9ba147453",
                     routeValues);
@@ -1625,7 +1772,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "f901ba42-86d2-4b0c-89c1-3f86d06daa84",
                     routeValues);
@@ -1673,7 +1820,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0863355d-aefd-4d63-8669-984c9b7b0e78",
                     routeValues);
@@ -1723,7 +1870,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "0863355d-aefd-4d63-8669-984c9b7b0e78",
                     routeValues);
@@ -1771,7 +1918,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "2d4faa2e-9150-4cbf-a47a-932b1b4a0773",
                     routeValues);
@@ -1821,7 +1968,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "2d4faa2e-9150-4cbf-a47a-932b1b4a0773",
                     routeValues);
@@ -1866,7 +2013,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "07ced576-58ed-49e6-9c1e-5cb53ab8bf2a",
                     routeValues);
@@ -1913,7 +2060,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "07ced576-58ed-49e6-9c1e-5cb53ab8bf2a",
                     routeValues);
@@ -1958,7 +2105,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c3c1012b-bea7-49d7-b45e-1664e566f84c",
                     routeValues);
@@ -2005,7 +2152,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "work",
                     "c3c1012b-bea7-49d7-b45e-1664e566f84c",
                     routeValues);
@@ -2019,6 +2166,54 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
                 let ret = this.formatResponse(res.result,
                                               WorkInterfaces.TypeInfo.TeamSetting,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get work items for iteration
+     * 
+     * @param {TfsCoreInterfaces.TeamContext} teamContext - The team context for the operation
+     * @param {string} iterationId - ID of the iteration
+     */
+    public async getIterationWorkItems(
+        teamContext: TfsCoreInterfaces.TeamContext,
+        iterationId: string
+        ): Promise<WorkInterfaces.IterationWorkItems> {
+
+        return new Promise<WorkInterfaces.IterationWorkItems>(async (resolve, reject) => {
+            let project = teamContext.projectId || teamContext.project;
+            let team = teamContext.teamId || teamContext.team;
+
+            let routeValues: any = {
+                project: project,
+                team: team,
+                iterationId: iterationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "work",
+                    "5b3ef1a6-d3ab-44cd-bafd-c7f45db850fa",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.IterationWorkItems>;
+                res = await this.rest.get<WorkInterfaces.IterationWorkItems>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
                                               false);
 
                 resolve(ret);

--- a/api/WorkItemTrackingProcessApi.ts
+++ b/api/WorkItemTrackingProcessApi.ts
@@ -19,24 +19,60 @@ import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import WorkItemTrackingProcessInterfaces = require("./interfaces/WorkItemTrackingProcessInterfaces");
 
 export interface IWorkItemTrackingProcessApi extends basem.ClientApiBase {
-    getBehavior(processId: string, behaviorRefName: string, expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand): Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior>;
-    getBehaviors(processId: string, expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand): Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior[]>;
-    getFields(processId: string): Promise<WorkItemTrackingProcessInterfaces.FieldModel[]>;
-    getWorkItemTypeFields(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.FieldModel[]>;
-    createProcess(createRequest: WorkItemTrackingProcessInterfaces.CreateProcessModel): Promise<WorkItemTrackingProcessInterfaces.ProcessModel>;
-    deleteProcess(processTypeId: string): Promise<void>;
-    getProcessById(processTypeId: string, expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel): Promise<WorkItemTrackingProcessInterfaces.ProcessModel>;
-    getProcesses(expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel): Promise<WorkItemTrackingProcessInterfaces.ProcessModel[]>;
-    updateProcess(updateRequest: WorkItemTrackingProcessInterfaces.UpdateProcessModel, processTypeId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessModel>;
-    addWorkItemTypeRule(fieldRule: WorkItemTrackingProcessInterfaces.FieldRuleModel, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
-    deleteWorkItemTypeRule(processId: string, witRefName: string, ruleId: string): Promise<void>;
-    getWorkItemTypeRule(processId: string, witRefName: string, ruleId: string): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
-    getWorkItemTypeRules(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel[]>;
-    updateWorkItemTypeRule(fieldRule: WorkItemTrackingProcessInterfaces.FieldRuleModel, processId: string, witRefName: string, ruleId: string): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
+    createProcessBehavior(behavior: WorkItemTrackingProcessInterfaces.ProcessBehaviorCreateRequest, processId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+    deleteProcessBehavior(processId: string, behaviorRefName: string): Promise<void>;
+    getProcessBehavior(processId: string, behaviorRefName: string, expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+    getProcessBehaviors(processId: string, expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>;
+    updateProcessBehavior(behaviorData: WorkItemTrackingProcessInterfaces.ProcessBehaviorUpdateRequest, processId: string, behaviorRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+    createControlInGroup(control: WorkItemTrackingProcessInterfaces.Control, processId: string, witRefName: string, groupId: string): Promise<WorkItemTrackingProcessInterfaces.Control>;
+    moveControlToGroup(control: WorkItemTrackingProcessInterfaces.Control, processId: string, witRefName: string, groupId: string, controlId: string, removeFromGroupId?: string): Promise<WorkItemTrackingProcessInterfaces.Control>;
+    removeControlFromGroup(processId: string, witRefName: string, groupId: string, controlId: string): Promise<void>;
+    updateControl(control: WorkItemTrackingProcessInterfaces.Control, processId: string, witRefName: string, groupId: string, controlId: string): Promise<WorkItemTrackingProcessInterfaces.Control>;
+    addFieldToWorkItemType(field: WorkItemTrackingProcessInterfaces.AddProcessWorkItemTypeFieldRequest, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+    getAllWorkItemTypeFields(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>;
+    getWorkItemTypeField(processId: string, witRefName: string, fieldRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+    removeWorkItemTypeField(processId: string, witRefName: string, fieldRefName: string): Promise<void>;
+    updateWorkItemTypeField(field: WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeFieldRequest, processId: string, witRefName: string, fieldRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+    addGroup(group: WorkItemTrackingProcessInterfaces.Group, processId: string, witRefName: string, pageId: string, sectionId: string): Promise<WorkItemTrackingProcessInterfaces.Group>;
+    moveGroupToPage(group: WorkItemTrackingProcessInterfaces.Group, processId: string, witRefName: string, pageId: string, sectionId: string, groupId: string, removeFromPageId: string, removeFromSectionId: string): Promise<WorkItemTrackingProcessInterfaces.Group>;
+    moveGroupToSection(group: WorkItemTrackingProcessInterfaces.Group, processId: string, witRefName: string, pageId: string, sectionId: string, groupId: string, removeFromSectionId: string): Promise<WorkItemTrackingProcessInterfaces.Group>;
+    removeGroup(processId: string, witRefName: string, pageId: string, sectionId: string, groupId: string): Promise<void>;
+    updateGroup(group: WorkItemTrackingProcessInterfaces.Group, processId: string, witRefName: string, pageId: string, sectionId: string, groupId: string): Promise<WorkItemTrackingProcessInterfaces.Group>;
+    getFormLayout(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.FormLayout>;
+    createList(picklist: WorkItemTrackingProcessInterfaces.PickList): Promise<WorkItemTrackingProcessInterfaces.PickList>;
+    deleteList(listId: string): Promise<void>;
+    getList(listId: string): Promise<WorkItemTrackingProcessInterfaces.PickList>;
+    getListsMetadata(): Promise<WorkItemTrackingProcessInterfaces.PickListMetadata[]>;
+    updateList(picklist: WorkItemTrackingProcessInterfaces.PickList, listId: string): Promise<WorkItemTrackingProcessInterfaces.PickList>;
+    addPage(page: WorkItemTrackingProcessInterfaces.Page, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.Page>;
+    removePage(processId: string, witRefName: string, pageId: string): Promise<void>;
+    updatePage(page: WorkItemTrackingProcessInterfaces.Page, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.Page>;
+    createNewProcess(createRequest: WorkItemTrackingProcessInterfaces.CreateProcessModel): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+    deleteProcessById(processTypeId: string): Promise<void>;
+    editProcess(updateRequest: WorkItemTrackingProcessInterfaces.UpdateProcessModel, processTypeId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+    getListOfProcesses(expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo[]>;
+    getProcessByItsId(processTypeId: string, expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+    addProcessWorkItemTypeRule(processRuleCreate: WorkItemTrackingProcessInterfaces.CreateProcessRuleRequest, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessRule>;
+    deleteProcessWorkItemTypeRule(processId: string, witRefName: string, ruleId: string): Promise<void>;
+    getProcessWorkItemTypeRule(processId: string, witRefName: string, ruleId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessRule>;
+    getProcessWorkItemTypeRules(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessRule[]>;
+    updateProcessWorkItemTypeRule(processRule: WorkItemTrackingProcessInterfaces.UpdateProcessRuleRequest, processId: string, witRefName: string, ruleId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessRule>;
+    createStateDefinition(stateModel: WorkItemTrackingProcessInterfaces.WorkItemStateInputModel, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+    deleteStateDefinition(processId: string, witRefName: string, stateId: string): Promise<void>;
     getStateDefinition(processId: string, witRefName: string, stateId: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
     getStateDefinitions(processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel[]>;
-    getWorkItemType(processId: string, witRefName: string, expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel>;
-    getWorkItemTypes(processId: string, expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel[]>;
+    hideStateDefinition(hideStateModel: WorkItemTrackingProcessInterfaces.HideStateModel, processId: string, witRefName: string, stateId: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+    updateStateDefinition(stateModel: WorkItemTrackingProcessInterfaces.WorkItemStateInputModel, processId: string, witRefName: string, stateId: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+    createProcessWorkItemType(workItemType: WorkItemTrackingProcessInterfaces.CreateProcessWorkItemTypeRequest, processId: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+    deleteProcessWorkItemType(processId: string, witRefName: string): Promise<void>;
+    getProcessWorkItemType(processId: string, witRefName: string, expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+    getProcessWorkItemTypes(processId: string, expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>;
+    updateProcessWorkItemType(workItemTypeUpdate: WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeRequest, processId: string, witRefName: string): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+    addBehaviorToWorkItemType(behavior: WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior, processId: string, witRefNameForBehaviors: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
+    getBehaviorForWorkItemType(processId: string, witRefNameForBehaviors: string, behaviorRefName: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
+    getBehaviorsForWorkItemType(processId: string, witRefNameForBehaviors: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>;
+    removeBehaviorFromWorkItemType(processId: string, witRefNameForBehaviors: string, behaviorRefName: string): Promise<void>;
+    updateBehaviorToWorkItemType(behavior: WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior, processId: string, witRefNameForBehaviors: string): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
 }
 
 export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements IWorkItemTrackingProcessApi {
@@ -45,19 +81,106 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
+     * Creates a single behavior in the given process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.ProcessBehaviorCreateRequest} behavior
+     * @param {string} processId - The ID of the process
+     */
+    public async createProcessBehavior(
+        behavior: WorkItemTrackingProcessInterfaces.ProcessBehaviorCreateRequest,
+        processId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "d1800200-f184-4e75-a5f2-ad0b04b4373e",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, behavior, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a behavior in the process.
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} behaviorRefName - The reference name of the behavior
+     */
+    public async deleteProcessBehavior(
+        processId: string,
+        behaviorRefName: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                behaviorRefName: behaviorRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "d1800200-f184-4e75-a5f2-ad0b04b4373e",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
      * Returns a behavior of the process.
      * 
      * @param {string} processId - The ID of the process
-     * @param {string} behaviorRefName - Reference name of the behavior
+     * @param {string} behaviorRefName - The reference name of the behavior
      * @param {WorkItemTrackingProcessInterfaces.GetBehaviorsExpand} expand
      */
-    public async getBehavior(
+    public async getProcessBehavior(
         processId: string,
         behaviorRefName: string,
         expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand
-        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 behaviorRefName: behaviorRefName
@@ -69,7 +192,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "d1800200-f184-4e75-a5f2-ad0b04b4373e",
                     routeValues,
@@ -79,11 +202,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemBehavior>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemBehavior>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
                                               false);
 
                 resolve(ret);
@@ -101,12 +224,12 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * @param {string} processId - The ID of the process
      * @param {WorkItemTrackingProcessInterfaces.GetBehaviorsExpand} expand
      */
-    public async getBehaviors(
+    public async getProcessBehaviors(
         processId: string,
         expand?: WorkItemTrackingProcessInterfaces.GetBehaviorsExpand
-        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior[]> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior[]> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemBehavior[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId
             };
@@ -117,7 +240,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "d1800200-f184-4e75-a5f2-ad0b04b4373e",
                     routeValues,
@@ -127,8 +250,988 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemBehavior[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemBehavior[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Replaces a behavior in the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.ProcessBehaviorUpdateRequest} behaviorData
+     * @param {string} processId - The ID of the process
+     * @param {string} behaviorRefName - The reference name of the behavior
+     */
+    public async updateProcessBehavior(
+        behaviorData: WorkItemTrackingProcessInterfaces.ProcessBehaviorUpdateRequest,
+        processId: string,
+        behaviorRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessBehavior>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                behaviorRefName: behaviorRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "d1800200-f184-4e75-a5f2-ad0b04b4373e",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, behaviorData, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Creates a control in a group.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Control} control - The control.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} groupId - The ID of the group to add the control to.
+     */
+    public async createControlInGroup(
+        control: WorkItemTrackingProcessInterfaces.Control,
+        processId: string,
+        witRefName: string,
+        groupId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Control> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Control>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                groupId: groupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1f59b363-a2d0-4b7e-9bc6-eb9f5f3f0e58",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Moves a control to a specified group.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Control} control - The control.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} groupId - The ID of the group to move the control to.
+     * @param {string} controlId - The ID of the control.
+     * @param {string} removeFromGroupId - The group ID to remove the control from.
+     */
+    public async moveControlToGroup(
+        control: WorkItemTrackingProcessInterfaces.Control,
+        processId: string,
+        witRefName: string,
+        groupId: string,
+        controlId: string,
+        removeFromGroupId?: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Control> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Control>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                groupId: groupId,
+                controlId: controlId
+            };
+
+            let queryValues: any = {
+                removeFromGroupId: removeFromGroupId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1f59b363-a2d0-4b7e-9bc6-eb9f5f3f0e58",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a control from the work item form.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} groupId - The ID of the group.
+     * @param {string} controlId - The ID of the control to remove.
+     */
+    public async removeControlFromGroup(
+        processId: string,
+        witRefName: string,
+        groupId: string,
+        controlId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                groupId: groupId,
+                controlId: controlId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1f59b363-a2d0-4b7e-9bc6-eb9f5f3f0e58",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a control on the work item form.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Control} control - The updated control.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} groupId - The ID of the group.
+     * @param {string} controlId - The ID of the control.
+     */
+    public async updateControl(
+        control: WorkItemTrackingProcessInterfaces.Control,
+        processId: string,
+        witRefName: string,
+        groupId: string,
+        controlId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Control> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Control>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                groupId: groupId,
+                controlId: controlId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1f59b363-a2d0-4b7e-9bc6-eb9f5f3f0e58",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Adds a field to a work item type.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.AddProcessWorkItemTypeFieldRequest} field
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     */
+    public async addFieldToWorkItemType(
+        field: WorkItemTrackingProcessInterfaces.AddProcessWorkItemTypeFieldRequest,
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, field, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns a list of all fields in a work item type.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     */
+    public async getAllWorkItemTypeFields(
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns a field in a work item type.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} fieldRefName - The reference name of the field.
+     */
+    public async getWorkItemTypeField(
+        processId: string,
+        witRefName: string,
+        fieldRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                fieldRefName: fieldRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a field from a work item type. Does not permanently delete the field.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} fieldRefName - The reference name of the field.
+     */
+    public async removeWorkItemTypeField(
+        processId: string,
+        witRefName: string,
+        fieldRefName: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                fieldRefName: fieldRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a field in a work item type.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeFieldRequest} field
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} fieldRefName - The reference name of the field.
+     */
+    public async updateWorkItemTypeField(
+        field: WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeFieldRequest,
+        processId: string,
+        witRefName: string,
+        fieldRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                fieldRefName: fieldRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, field, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Adds a group to the work item form.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Group} group - The group.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} pageId - The ID of the page to add the group to.
+     * @param {string} sectionId - The ID of the section to add the group to.
+     */
+    public async addGroup(
+        group: WorkItemTrackingProcessInterfaces.Group,
+        processId: string,
+        witRefName: string,
+        pageId: string,
+        sectionId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Group> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Group>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId,
+                sectionId: sectionId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "766e44e1-36a8-41d7-9050-c343ff02f7a5",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Moves a group to a different page and section.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Group} group - The updated group.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} pageId - The ID of the page the group is in.
+     * @param {string} sectionId - The ID of the section the group is i.n
+     * @param {string} groupId - The ID of the group.
+     * @param {string} removeFromPageId - ID of the page to remove the group from.
+     * @param {string} removeFromSectionId - ID of the section to remove the group from.
+     */
+    public async moveGroupToPage(
+        group: WorkItemTrackingProcessInterfaces.Group,
+        processId: string,
+        witRefName: string,
+        pageId: string,
+        sectionId: string,
+        groupId: string,
+        removeFromPageId: string,
+        removeFromSectionId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Group> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Group>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId,
+                sectionId: sectionId,
+                groupId: groupId
+            };
+
+            let queryValues: any = {
+                removeFromPageId: removeFromPageId,
+                removeFromSectionId: removeFromSectionId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "766e44e1-36a8-41d7-9050-c343ff02f7a5",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Moves a group to a different section.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Group} group - The updated group.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} pageId - The ID of the page the group is in.
+     * @param {string} sectionId - The ID of the section the group is in.
+     * @param {string} groupId - The ID of the group.
+     * @param {string} removeFromSectionId - ID of the section to remove the group from.
+     */
+    public async moveGroupToSection(
+        group: WorkItemTrackingProcessInterfaces.Group,
+        processId: string,
+        witRefName: string,
+        pageId: string,
+        sectionId: string,
+        groupId: string,
+        removeFromSectionId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Group> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Group>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId,
+                sectionId: sectionId,
+                groupId: groupId
+            };
+
+            let queryValues: any = {
+                removeFromSectionId: removeFromSectionId,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "766e44e1-36a8-41d7-9050-c343ff02f7a5",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a group from the work item form.
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     * @param {string} pageId - The ID of the page the group is in
+     * @param {string} sectionId - The ID of the section to the group is in
+     * @param {string} groupId - The ID of the group
+     */
+    public async removeGroup(
+        processId: string,
+        witRefName: string,
+        pageId: string,
+        sectionId: string,
+        groupId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId,
+                sectionId: sectionId,
+                groupId: groupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "766e44e1-36a8-41d7-9050-c343ff02f7a5",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a group in the work item form.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Group} group - The updated group.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     * @param {string} pageId - The ID of the page the group is in.
+     * @param {string} sectionId - The ID of the section the group is in.
+     * @param {string} groupId - The ID of the group.
+     */
+    public async updateGroup(
+        group: WorkItemTrackingProcessInterfaces.Group,
+        processId: string,
+        witRefName: string,
+        pageId: string,
+        sectionId: string,
+        groupId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Group> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Group>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId,
+                sectionId: sectionId,
+                groupId: groupId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "766e44e1-36a8-41d7-9050-c343ff02f7a5",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Gets the form layout.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     */
+    public async getFormLayout(
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.FormLayout> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.FormLayout>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "fa8646eb-43cd-4b71-9564-40106fd63e40",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FormLayout>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.FormLayout>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.FormLayout,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Creates a picklist.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.PickList} picklist - Picklist
+     */
+    public async createList(
+        picklist: WorkItemTrackingProcessInterfaces.PickList
+        ): Promise<WorkItemTrackingProcessInterfaces.PickList> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.PickList>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "01e15468-e27c-4e20-a974-bd957dcccebc",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.PickList>(url, picklist, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a picklist.
+     * 
+     * @param {string} listId - The ID of the list
+     */
+    public async deleteList(
+        listId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                listId: listId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "01e15468-e27c-4e20-a974-bd957dcccebc",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns a picklist.
+     * 
+     * @param {string} listId - The ID of the list
+     */
+    public async getList(
+        listId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.PickList> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.PickList>(async (resolve, reject) => {
+            let routeValues: any = {
+                listId: listId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "01e15468-e27c-4e20-a974-bd957dcccebc",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.PickList>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns meta data of the picklist.
+     * 
+     */
+    public async getListsMetadata(
+        ): Promise<WorkItemTrackingProcessInterfaces.PickListMetadata[]> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.PickListMetadata[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "01e15468-e27c-4e20-a974-bd957dcccebc",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickListMetadata[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.PickListMetadata[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -144,36 +1247,38 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
-     * Returns a list of all fields in a process.
+     * Updates a list.
      * 
-     * @param {string} processId - The ID of the process
+     * @param {WorkItemTrackingProcessInterfaces.PickList} picklist
+     * @param {string} listId - The ID of the list
      */
-    public async getFields(
-        processId: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldModel[]> {
+    public async updateList(
+        picklist: WorkItemTrackingProcessInterfaces.PickList,
+        listId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.PickList> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.PickList>(async (resolve, reject) => {
             let routeValues: any = {
-                processId: processId
+                listId: listId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processes",
-                    "7a0e7a1a-0b34-4ae0-9744-0aaffb7d0ed1",
+                    "01e15468-e27c-4e20-a974-bd957dcccebc",
                     routeValues);
 
                 let url: string = verData.requestUrl;
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.FieldModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.PickList>(url, picklist, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.FieldModel,
-                                              true);
+                                              null,
+                                              false);
 
                 resolve(ret);
                 
@@ -185,17 +1290,19 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
-     * Returns a list of all fields in a work item type.
+     * Adds a page to the work item form.
      * 
-     * @param {string} processId - The ID of the process
-     * @param {string} witRefName - The reference name of the work item type
+     * @param {WorkItemTrackingProcessInterfaces.Page} page - The page.
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
      */
-    public async getWorkItemTypeFields(
+    public async addPage(
+        page: WorkItemTrackingProcessInterfaces.Page,
         processId: string,
         witRefName: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldModel[]> {
+        ): Promise<WorkItemTrackingProcessInterfaces.Page> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.Page>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName
@@ -203,21 +1310,114 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processes",
-                    "bc0ad8dc-e3f3-46b0-b06c-5bf861793196",
+                    "1cc7b29f-6697-4d9d-b0a1-2650d3e1d584",
                     routeValues);
 
                 let url: string = verData.requestUrl;
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.FieldModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Page>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.Page>(url, page, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.FieldModel,
-                                              true);
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.Page,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a page from the work item form
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     * @param {string} pageId - The ID of the page
+     */
+    public async removePage(
+        processId: string,
+        witRefName: string,
+        pageId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                pageId: pageId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1cc7b29f-6697-4d9d-b0a1-2650d3e1d584",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a page on the work item form
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.Page} page - The page
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     */
+    public async updatePage(
+        page: WorkItemTrackingProcessInterfaces.Page,
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.Page> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.Page>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "1cc7b29f-6697-4d9d-b0a1-2650d3e1d584",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Page>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.Page>(url, page, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.Page,
+                                              false);
 
                 resolve(ret);
                 
@@ -231,19 +1431,19 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     /**
      * Creates a process.
      * 
-     * @param {WorkItemTrackingProcessInterfaces.CreateProcessModel} createRequest
+     * @param {WorkItemTrackingProcessInterfaces.CreateProcessModel} createRequest - CreateProcessModel.
      */
-    public async createProcess(
+    public async createNewProcess(
         createRequest: WorkItemTrackingProcessInterfaces.CreateProcessModel
-        ): Promise<WorkItemTrackingProcessInterfaces.ProcessModel> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.ProcessModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>(async (resolve, reject) => {
             let routeValues: any = {
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "02cc6a73-5cfb-427d-8c8e-b49fb086e8af",
                     routeValues);
@@ -252,11 +1452,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessModel>;
-                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessModel>(url, createRequest, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, createRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
                 resolve(ret);
@@ -273,7 +1473,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * 
      * @param {string} processTypeId
      */
-    public async deleteProcess(
+    public async deleteProcessById(
         processTypeId: string
         ): Promise<void> {
 
@@ -284,7 +1484,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "02cc6a73-5cfb-427d-8c8e-b49fb086e8af",
                     routeValues);
@@ -310,42 +1510,37 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
-     * Returns a single process of a specified ID.
+     * Edit a process of a specific ID.
      * 
+     * @param {WorkItemTrackingProcessInterfaces.UpdateProcessModel} updateRequest
      * @param {string} processTypeId
-     * @param {WorkItemTrackingProcessInterfaces.GetProcessExpandLevel} expand
      */
-    public async getProcessById(
-        processTypeId: string,
-        expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel
-        ): Promise<WorkItemTrackingProcessInterfaces.ProcessModel> {
+    public async editProcess(
+        updateRequest: WorkItemTrackingProcessInterfaces.UpdateProcessModel,
+        processTypeId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.ProcessModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>(async (resolve, reject) => {
             let routeValues: any = {
                 processTypeId: processTypeId
             };
 
-            let queryValues: any = {
-                '$expand': expand,
-            };
-            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "02cc6a73-5cfb-427d-8c8e-b49fb086e8af",
-                    routeValues,
-                    queryValues);
+                    routeValues);
 
                 let url: string = verData.requestUrl;
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessModel>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessModel>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, updateRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
                 resolve(ret);
@@ -358,15 +1553,15 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
-     * Returns a list of all processes.
+     * Get list of all processes including system and inherited.
      * 
      * @param {WorkItemTrackingProcessInterfaces.GetProcessExpandLevel} expand
      */
-    public async getProcesses(
+    public async getListOfProcesses(
         expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel
-        ): Promise<WorkItemTrackingProcessInterfaces.ProcessModel[]> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo[]> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.ProcessModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessInfo[]>(async (resolve, reject) => {
             let routeValues: any = {
             };
 
@@ -376,7 +1571,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "02cc6a73-5cfb-427d-8c8e-b49fb086e8af",
                     routeValues,
@@ -386,11 +1581,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessInfo[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               true);
 
                 resolve(ret);
@@ -403,37 +1598,42 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     }
 
     /**
-     * Updates a process of a specific ID.
+     * Get a single process of a specified ID.
      * 
-     * @param {WorkItemTrackingProcessInterfaces.UpdateProcessModel} updateRequest
      * @param {string} processTypeId
+     * @param {WorkItemTrackingProcessInterfaces.GetProcessExpandLevel} expand
      */
-    public async updateProcess(
-        updateRequest: WorkItemTrackingProcessInterfaces.UpdateProcessModel,
-        processTypeId: string
-        ): Promise<WorkItemTrackingProcessInterfaces.ProcessModel> {
+    public async getProcessByItsId(
+        processTypeId: string,
+        expand?: WorkItemTrackingProcessInterfaces.GetProcessExpandLevel
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessInfo> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.ProcessModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessInfo>(async (resolve, reject) => {
             let routeValues: any = {
                 processTypeId: processTypeId
             };
 
+            let queryValues: any = {
+                '$expand': expand,
+            };
+            
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "02cc6a73-5cfb-427d-8c8e-b49fb086e8af",
-                    routeValues);
+                    routeValues,
+                    queryValues);
 
                 let url: string = verData.requestUrl;
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessModel>;
-                res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessModel>(url, updateRequest, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
                 resolve(ret);
@@ -448,17 +1648,17 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     /**
      * Adds a rule to work item type in the process.
      * 
-     * @param {WorkItemTrackingProcessInterfaces.FieldRuleModel} fieldRule
+     * @param {WorkItemTrackingProcessInterfaces.CreateProcessRuleRequest} processRuleCreate
      * @param {string} processId - The ID of the process
      * @param {string} witRefName - The reference name of the work item type
      */
-    public async addWorkItemTypeRule(
-        fieldRule: WorkItemTrackingProcessInterfaces.FieldRuleModel,
+    public async addProcessWorkItemTypeRule(
+        processRuleCreate: WorkItemTrackingProcessInterfaces.CreateProcessRuleRequest,
         processId: string,
         witRefName: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessRule> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessRule>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName
@@ -466,7 +1666,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "76fe3432-d825-479d-a5f6-983bbb78b4f3",
                     routeValues);
@@ -475,11 +1675,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
-                res = await this.rest.create<WorkItemTrackingProcessInterfaces.FieldRuleModel>(url, fieldRule, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessRule>(url, processRuleCreate, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               false);
 
                 resolve(ret);
@@ -498,7 +1698,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * @param {string} witRefName - The reference name of the work item type
      * @param {string} ruleId - The ID of the rule
      */
-    public async deleteWorkItemTypeRule(
+    public async deleteProcessWorkItemTypeRule(
         processId: string,
         witRefName: string,
         ruleId: string
@@ -513,7 +1713,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "76fe3432-d825-479d-a5f6-983bbb78b4f3",
                     routeValues);
@@ -545,13 +1745,13 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * @param {string} witRefName - The reference name of the work item type
      * @param {string} ruleId - The ID of the rule
      */
-    public async getWorkItemTypeRule(
+    public async getProcessWorkItemTypeRule(
         processId: string,
         witRefName: string,
         ruleId: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessRule> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessRule>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName,
@@ -560,7 +1760,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "76fe3432-d825-479d-a5f6-983bbb78b4f3",
                     routeValues);
@@ -569,11 +1769,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.FieldRuleModel>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessRule>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               false);
 
                 resolve(ret);
@@ -591,12 +1791,12 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * @param {string} processId - The ID of the process
      * @param {string} witRefName - The reference name of the work item type
      */
-    public async getWorkItemTypeRules(
+    public async getProcessWorkItemTypeRules(
         processId: string,
         witRefName: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel[]> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessRule[]> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessRule[]>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName
@@ -604,7 +1804,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "76fe3432-d825-479d-a5f6-983bbb78b4f3",
                     routeValues);
@@ -613,11 +1813,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldRuleModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.FieldRuleModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessRule[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               true);
 
                 resolve(ret);
@@ -632,19 +1832,19 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
     /**
      * Updates a rule in the work item type of the process.
      * 
-     * @param {WorkItemTrackingProcessInterfaces.FieldRuleModel} fieldRule
+     * @param {WorkItemTrackingProcessInterfaces.UpdateProcessRuleRequest} processRule
      * @param {string} processId - The ID of the process
      * @param {string} witRefName - The reference name of the work item type
      * @param {string} ruleId - The ID of the rule
      */
-    public async updateWorkItemTypeRule(
-        fieldRule: WorkItemTrackingProcessInterfaces.FieldRuleModel,
+    public async updateProcessWorkItemTypeRule(
+        processRule: WorkItemTrackingProcessInterfaces.UpdateProcessRuleRequest,
         processId: string,
         witRefName: string,
         ruleId: string
-        ): Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessRule> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.FieldRuleModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessRule>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName,
@@ -653,7 +1853,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "76fe3432-d825-479d-a5f6-983bbb78b4f3",
                     routeValues);
@@ -662,8 +1862,101 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FieldRuleModel>;
-                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.FieldRuleModel>(url, fieldRule, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.ProcessRule>(url, processRule, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Creates a state definition in the work item type of the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.WorkItemStateInputModel} stateModel
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     */
+    public async createStateDefinition(
+        stateModel: WorkItemTrackingProcessInterfaces.WorkItemStateInputModel,
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, stateModel, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a state definition in the work item type of the process.
+     * 
+     * @param {string} processId - ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     * @param {string} stateId - ID of the state
+     */
+    public async deleteStateDefinition(
+        processId: string,
+        witRefName: string,
+        stateId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                stateId: stateId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,
@@ -700,7 +1993,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processes",
                     "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
                     routeValues);
@@ -713,7 +2006,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               false);
 
                 resolve(ret);
@@ -744,7 +2037,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processes",
                     "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
                     routeValues);
@@ -757,8 +2050,193 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Hides a state definition in the work item type of the process.Only states with customizationType:System can be hidden.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.HideStateModel} hideStateModel
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     * @param {string} stateId - The ID of the state
+     */
+    public async hideStateDefinition(
+        hideStateModel: WorkItemTrackingProcessInterfaces.HideStateModel,
+        processId: string,
+        witRefName: string,
+        stateId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                stateId: stateId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+                res = await this.rest.replace<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, hideStateModel, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a given state definition in the work item type of the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.WorkItemStateInputModel} stateModel
+     * @param {string} processId - ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     * @param {string} stateId - ID of the state
+     */
+    public async updateStateDefinition(
+        stateModel: WorkItemTrackingProcessInterfaces.WorkItemStateInputModel,
+        processId: string,
+        witRefName: string,
+        stateId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName,
+                stateId: stateId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "31015d57-2dff-4a46-adb3-2fb4ee3dcec9",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, stateModel, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Creates a work item type in the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.CreateProcessWorkItemTypeRequest} workItemType
+     * @param {string} processId - The ID of the process on which to create work item type.
+     */
+    public async createProcessWorkItemType(
+        workItemType: WorkItemTrackingProcessInterfaces.CreateProcessWorkItemTypeRequest,
+        processId: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "e2e9d1a6-432d-4062-8870-bfcb8c324ad7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, workItemType, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a work itewm type in the process.
+     * 
+     * @param {string} processId - The ID of the process.
+     * @param {string} witRefName - The reference name of the work item type.
+     */
+    public async deleteProcessWorkItemType(
+        processId: string,
+        witRefName: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "e2e9d1a6-432d-4062-8870-bfcb8c324ad7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
 
                 resolve(ret);
                 
@@ -774,15 +2252,15 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * 
      * @param {string} processId - The ID of the process
      * @param {string} witRefName - The reference name of the work item type
-     * @param {WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand} expand
+     * @param {WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand} expand - Flag to determine what properties of work item type to return
      */
-    public async getWorkItemType(
+    public async getProcessWorkItemType(
         processId: string,
         witRefName: string,
         expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand
-        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefName: witRefName
@@ -794,7 +2272,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "e2e9d1a6-432d-4062-8870-bfcb8c324ad7",
                     routeValues,
@@ -804,11 +2282,11 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeModel>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeModel>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemTypeModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               false);
 
                 resolve(ret);
@@ -824,14 +2302,14 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
      * Returns a list of all work item types in a process.
      * 
      * @param {string} processId - The ID of the process
-     * @param {WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand} expand
+     * @param {WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand} expand - Flag to determine what properties of work item type to return
      */
-    public async getWorkItemTypes(
+    public async getProcessWorkItemTypes(
         processId: string,
         expand?: WorkItemTrackingProcessInterfaces.GetWorkItemTypeExpand
-        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel[]> {
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]> {
 
-        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId
             };
@@ -842,7 +2320,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.2",
                     "processes",
                     "e2e9d1a6-432d-4062-8870-bfcb8c324ad7",
                     routeValues,
@@ -852,12 +2330,288 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemTypeModel,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a work item type of the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeRequest} workItemTypeUpdate
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefName - The reference name of the work item type
+     */
+    public async updateProcessWorkItemType(
+        workItemTypeUpdate: WorkItemTrackingProcessInterfaces.UpdateProcessWorkItemTypeRequest,
+        processId: string,
+        witRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefName: witRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.2",
+                    "processes",
+                    "e2e9d1a6-432d-4062-8870-bfcb8c324ad7",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, workItemTypeUpdate, options);
+
+                let ret = this.formatResponse(res.result,
+                                              WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Adds a behavior to the work item type of the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior} behavior
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefNameForBehaviors - Work item type reference name for the behavior
+     */
+    public async addBehaviorToWorkItemType(
+        behavior: WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior,
+        processId: string,
+        witRefNameForBehaviors: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefNameForBehaviors: witRefNameForBehaviors
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "6d765a2e-4e1b-4b11-be93-f953be676024",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
+                res = await this.rest.create<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, behavior, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns a behavior for the work item type of the process.
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefNameForBehaviors - Work item type reference name for the behavior
+     * @param {string} behaviorRefName - The reference name of the behavior
+     */
+    public async getBehaviorForWorkItemType(
+        processId: string,
+        witRefNameForBehaviors: string,
+        behaviorRefName: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefNameForBehaviors: witRefNameForBehaviors,
+                behaviorRefName: behaviorRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "6d765a2e-4e1b-4b11-be93-f953be676024",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Returns a list of all behaviors for the work item type of the process.
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefNameForBehaviors - Work item type reference name for the behavior
+     */
+    public async getBehaviorsForWorkItemType(
+        processId: string,
+        witRefNameForBehaviors: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefNameForBehaviors: witRefNameForBehaviors
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "6d765a2e-4e1b-4b11-be93-f953be676024",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>;
+                res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes a behavior for the work item type of the process.
+     * 
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefNameForBehaviors - Work item type reference name for the behavior
+     * @param {string} behaviorRefName - The reference name of the behavior
+     */
+    public async removeBehaviorFromWorkItemType(
+        processId: string,
+        witRefNameForBehaviors: string,
+        behaviorRefName: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefNameForBehaviors: witRefNameForBehaviors,
+                behaviorRefName: behaviorRefName
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "6d765a2e-4e1b-4b11-be93-f953be676024",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Updates a behavior for the work item type of the process.
+     * 
+     * @param {WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior} behavior
+     * @param {string} processId - The ID of the process
+     * @param {string} witRefNameForBehaviors - Work item type reference name for the behavior
+     */
+    public async updateBehaviorToWorkItemType(
+        behavior: WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior,
+        processId: string,
+        witRefNameForBehaviors: string
+        ): Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior> {
+
+        return new Promise<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(async (resolve, reject) => {
+            let routeValues: any = {
+                processId: processId,
+                witRefNameForBehaviors: witRefNameForBehaviors
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "5.0-preview.1",
+                    "processes",
+                    "6d765a2e-4e1b-4b11-be93-f953be676024",
+                    routeValues);
+
+                let url: string = verData.requestUrl;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
+                res = await this.rest.update<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, behavior, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
 
                 resolve(ret);
                 

--- a/api/WorkItemTrackingProcessDefinitionsApi.ts
+++ b/api/WorkItemTrackingProcessDefinitionsApi.ts
@@ -60,9 +60,9 @@ export interface IWorkItemTrackingProcessDefinitionsApi extends basem.ClientApiB
     getWorkItemType(processId: string, witRefName: string, expand?: WorkItemTrackingProcessDefinitionsInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>;
     getWorkItemTypes(processId: string, expand?: WorkItemTrackingProcessDefinitionsInterfaces.GetWorkItemTypeExpand): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel[]>;
     updateWorkItemType(workItemTypeUpdate: WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeUpdateModel, processId: string, witRefName: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>;
-    addFieldToWorkItemType(field: WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel, processId: string, witRefNameForFields: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>;
-    getWorkItemTypeField(processId: string, witRefNameForFields: string, fieldRefName: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>;
-    getWorkItemTypeFields(processId: string, witRefNameForFields: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel[]>;
+    addFieldToWorkItemType(field: WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2, processId: string, witRefNameForFields: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
+    getWorkItemTypeField(processId: string, witRefNameForFields: string, fieldRefName: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
+    getWorkItemTypeFields(processId: string, witRefNameForFields: string): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>;
     removeFieldFromWorkItemType(processId: string, witRefNameForFields: string, fieldRefName: string): Promise<void>;
 }
 
@@ -70,6 +70,8 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-WorkItemTracking-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";
 
     /**
      * Creates a single behavior in the given process.
@@ -89,7 +91,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "47a651f4-fb70-43bf-b96b-7c0ba947142b",
                     routeValues);
@@ -133,7 +135,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "47a651f4-fb70-43bf-b96b-7c0ba947142b",
                     routeValues);
@@ -177,7 +179,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "47a651f4-fb70-43bf-b96b-7c0ba947142b",
                     routeValues);
@@ -218,7 +220,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "47a651f4-fb70-43bf-b96b-7c0ba947142b",
                     routeValues);
@@ -264,7 +266,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "47a651f4-fb70-43bf-b96b-7c0ba947142b",
                     routeValues);
@@ -313,7 +315,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "e2e3166a-627a-4e9b-85b2-d6a097bbd731",
                     routeValues);
@@ -365,7 +367,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "e2e3166a-627a-4e9b-85b2-d6a097bbd731",
                     routeValues);
@@ -415,7 +417,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "e2e3166a-627a-4e9b-85b2-d6a097bbd731",
                     routeValues);
@@ -473,7 +475,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "e2e3166a-627a-4e9b-85b2-d6a097bbd731",
                     routeValues,
@@ -517,7 +519,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "f36c66c7-911d-4163-8938-d3c5d0d7f5aa",
                     routeValues);
@@ -560,7 +562,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "f36c66c7-911d-4163-8938-d3c5d0d7f5aa",
                     routeValues);
@@ -612,7 +614,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "2617828b-e850-4375-a92a-04855704d4c3",
                     routeValues);
@@ -667,7 +669,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "2617828b-e850-4375-a92a-04855704d4c3",
                     routeValues);
@@ -720,7 +722,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "2617828b-e850-4375-a92a-04855704d4c3",
                     routeValues);
@@ -784,7 +786,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "2617828b-e850-4375-a92a-04855704d4c3",
                     routeValues,
@@ -846,7 +848,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "2617828b-e850-4375-a92a-04855704d4c3",
                     routeValues,
@@ -891,7 +893,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "3eacc80a-ddca-4404-857a-6331aac99063",
                     routeValues);
@@ -929,7 +931,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "b45cc931-98e3-44a1-b1cd-2e8e9c6dc1c6",
                     routeValues);
@@ -969,7 +971,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "0b6179e2-23ce-46b2-b094-2ffa5ee70286",
                     routeValues);
@@ -1010,7 +1012,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "0b6179e2-23ce-46b2-b094-2ffa5ee70286",
                     routeValues);
@@ -1051,7 +1053,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "0b6179e2-23ce-46b2-b094-2ffa5ee70286",
                     routeValues);
@@ -1094,7 +1096,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "0b6179e2-23ce-46b2-b094-2ffa5ee70286",
                     routeValues);
@@ -1140,7 +1142,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1b4ac126-59b2-4f37-b4df-0a48ba807edb",
                     routeValues);
@@ -1186,7 +1188,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1b4ac126-59b2-4f37-b4df-0a48ba807edb",
                     routeValues);
@@ -1233,7 +1235,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1b4ac126-59b2-4f37-b4df-0a48ba807edb",
                     routeValues);
@@ -1279,7 +1281,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1326,7 +1328,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1373,7 +1375,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1417,7 +1419,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1466,7 +1468,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1515,7 +1517,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "4303625d-08f4-4461-b14b-32c65bba5599",
                     routeValues);
@@ -1561,7 +1563,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "921dfb88-ef57-4c69-94e5-dd7da2d7031d",
                     routeValues);
@@ -1608,7 +1610,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "921dfb88-ef57-4c69-94e5-dd7da2d7031d",
                     routeValues);
@@ -1652,7 +1654,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "921dfb88-ef57-4c69-94e5-dd7da2d7031d",
                     routeValues);
@@ -1699,7 +1701,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "921dfb88-ef57-4c69-94e5-dd7da2d7031d",
                     routeValues);
@@ -1725,7 +1727,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
     }
 
     /**
-     * Updates a behavior for the work item type of the process.
+     * Updates default work item type for the behavior of the process.
      * 
      * @param {WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior} behavior
      * @param {string} processId - The ID of the process
@@ -1745,7 +1747,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "921dfb88-ef57-4c69-94e5-dd7da2d7031d",
                     routeValues);
@@ -1788,7 +1790,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1ce0acad-4638-49c3-969c-04aa65ba6bea",
                     routeValues);
@@ -1832,7 +1834,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1ce0acad-4638-49c3-969c-04aa65ba6bea",
                     routeValues);
@@ -1882,7 +1884,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1ce0acad-4638-49c3-969c-04aa65ba6bea",
                     routeValues,
@@ -1930,7 +1932,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1ce0acad-4638-49c3-969c-04aa65ba6bea",
                     routeValues,
@@ -1977,7 +1979,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "1ce0acad-4638-49c3-969c-04aa65ba6bea",
                     routeValues);
@@ -2005,17 +2007,17 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
     /**
      * Adds a field to the work item type in the process.
      * 
-     * @param {WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel} field
+     * @param {WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2} field
      * @param {string} processId - The ID of the process
      * @param {string} witRefNameForFields - Work item type reference name for the field
      */
     public async addFieldToWorkItemType(
-        field: WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel,
+        field: WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2,
         processId: string,
         witRefNameForFields: string
-        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel> {
+        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2> {
 
-        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefNameForFields: witRefNameForFields
@@ -2023,7 +2025,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "976713b4-a62e-499e-94dc-eeb869ea9126",
                     routeValues);
@@ -2032,11 +2034,11 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>;
-                res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>(url, field, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
+                res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(url, field, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel,
+                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               false);
 
                 resolve(ret);
@@ -2059,9 +2061,9 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
         processId: string,
         witRefNameForFields: string,
         fieldRefName: string
-        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel> {
+        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2> {
 
-        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefNameForFields: witRefNameForFields,
@@ -2070,7 +2072,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "976713b4-a62e-499e-94dc-eeb869ea9126",
                     routeValues);
@@ -2079,11 +2081,11 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>;
-                res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
+                res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel,
+                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               false);
 
                 resolve(ret);
@@ -2104,9 +2106,9 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
     public async getWorkItemTypeFields(
         processId: string,
         witRefNameForFields: string
-        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel[]> {
+        ): Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]> {
 
-        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel[]>(async (resolve, reject) => {
+        return new Promise<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>(async (resolve, reject) => {
             let routeValues: any = {
                 processId: processId,
                 witRefNameForFields: witRefNameForFields
@@ -2114,7 +2116,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "976713b4-a62e-499e-94dc-eeb869ea9126",
                     routeValues);
@@ -2123,11 +2125,11 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel[]>;
-                res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel[]>(url, options);
+                let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>;
+                res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel,
+                                              WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               true);
 
                 resolve(ret);
@@ -2161,7 +2163,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "4.1-preview.1",
+                    "5.0-preview.1",
                     "processDefinitions",
                     "976713b4-a62e-499e-94dc-eeb869ea9126",
                     routeValues);

--- a/api/interfaces/CoreInterfaces.ts
+++ b/api/interfaces/CoreInterfaces.ts
@@ -94,6 +94,7 @@ export interface ProjectProperty {
 }
 
 export enum ProjectVisibility {
+    SystemPrivate = -2,
     Unchanged = -1,
     Private = 0,
     Organization = 1,
@@ -198,6 +199,10 @@ export interface TeamProjectCollection extends TeamProjectCollectionReference {
      * Project collection description.
      */
     description: string;
+    /**
+     * True if collection supports inherited process customization model.
+     */
+    enableInheritedProcessCustomization: boolean;
     /**
      * Project collection state.
      */
@@ -415,6 +420,8 @@ export interface WebApiTeam extends WebApiTeamRef {
      * Identity REST API Url to this team
      */
     identityUrl: string;
+    projectId: string;
+    projectName: string;
 }
 
 export interface WebApiTeamRef {
@@ -463,7 +470,6 @@ export var TypeInfo = {
     },
     ProjectVisibility: {
         enumValues: {
-            "unchanged": -1,
             "private": 0,
             "organization": 1,
             "public": 2

--- a/api/interfaces/DashboardInterfaces.ts
+++ b/api/interfaces/DashboardInterfaces.ts
@@ -157,6 +157,10 @@ export interface Widget {
      */
     allowedSizes: WidgetSize[];
     /**
+     * Read-Only Property from Dashboard Service. Indicates if settings are blocked for the current user.
+     */
+    areSettingsBlockedForUser: boolean;
+    /**
      * Refers to unique identifier of a feature artifact. Used for pinning+unpinning a specific artifact.
      */
     artifactId: string;

--- a/api/interfaces/ExtensionManagementInterfaces.ts
+++ b/api/interfaces/ExtensionManagementInterfaces.ts
@@ -316,6 +316,10 @@ export interface ContributionNodeQuery {
      */
     contributionIds: string[];
     /**
+     * Contextual information that can be leveraged by contribution constraints
+     */
+    dataProviderContext: DataProviderContext;
+    /**
      * Indicator if contribution provider details should be included in the result.
      */
     includeProviderDetails: boolean;

--- a/api/interfaces/FeatureManagementInterfaces.ts
+++ b/api/interfaces/FeatureManagementInterfaces.ts
@@ -33,13 +33,29 @@ export interface ContributedFeature {
      */
     description: string;
     /**
+     * Extra properties for the feature
+     */
+    featureProperties: { [key: string] : any; };
+    /**
+     * Handler for listening to setter calls on feature value. These listeners are only invoked after a successful set has occured
+     */
+    featureStateChangedListeners: ContributedFeatureListener[];
+    /**
      * The full contribution id of the feature
      */
     id: string;
     /**
+     * If this is set to true, then the id for this feature will be added to the list of claims for the request.
+     */
+    includeAsClaim: boolean;
+    /**
      * The friendly name of the feature
      */
     name: string;
+    /**
+     * Suggested order to display feature in.
+     */
+    order: number;
     /**
      * Rules for overriding a feature value. These rules are run before explicit user/host state values are checked. They are evaluated in order until a rule returns an Enabled or Disabled state (not Undefined)
      */
@@ -52,6 +68,10 @@ export interface ContributedFeature {
      * The service instance id of the service that owns this feature
      */
     serviceInstanceType: string;
+    /**
+     * Tags associated with the feature.
+     */
+    tags: string[];
 }
 
 /**
@@ -70,6 +90,23 @@ export enum ContributedFeatureEnabledValue {
      * The feature is enabled at the specified scope
      */
     Enabled = 1,
+}
+
+export interface ContributedFeatureHandlerSettings {
+    /**
+     * Name of the handler to run
+     */
+    name: string;
+    /**
+     * Properties to feed to the handler
+     */
+    properties: { [key: string] : any; };
+}
+
+/**
+ * An identifier and properties used to pass into a handler for a listener or plugin
+ */
+export interface ContributedFeatureListener extends ContributedFeatureHandlerSettings {
 }
 
 /**
@@ -133,15 +170,7 @@ export interface ContributedFeatureStateQuery {
 /**
  * A rule for dynamically getting the enabled/disabled state of a feature
  */
-export interface ContributedFeatureValueRule {
-    /**
-     * Name of the IContributedFeatureValuePlugin to run
-     */
-    name: string;
-    /**
-     * Properties to feed to the IContributedFeatureValuePlugin
-     */
-    properties: { [key: string] : any; };
+export interface ContributedFeatureValueRule extends ContributedFeatureHandlerSettings {
 }
 
 export var TypeInfo = {

--- a/api/interfaces/GraphInterfaces.ts
+++ b/api/interfaces/GraphInterfaces.ts
@@ -1,0 +1,497 @@
+/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+"use strict";
+
+import IdentitiesInterfaces = require("../interfaces/IdentitiesInterfaces");
+
+
+export interface GraphCachePolicies {
+    /**
+     * Size of the cache
+     */
+    cacheSize: number;
+}
+
+export interface GraphDescriptorResult {
+    /**
+     * This field contains zero or more interesting links about the graph descriptor. These links may be invoked to obtain additional relationships or more detailed information about this graph descriptor.
+     */
+    _links: any;
+    value: string;
+}
+
+/**
+ * Represents a set of data used to communicate with a federated provider on behalf of a particular user.
+ */
+export interface GraphFederatedProviderData {
+    /**
+     * The access token that can be used to communicated with the federated provider on behalf on the target identity, if we were able to successfully acquire one, otherwise <code>null</code>, if we were not.
+     */
+    accessToken: string;
+    /**
+     * Whether or not the immediate provider (i.e. AAD) has indicated that we can call them to attempt to get an access token to communicate with the federated provider on behalf of the target identity.
+     */
+    canQueryAccessToken: boolean;
+    /**
+     * The name of the federated provider, e.g. "github.com".
+     */
+    providerName: string;
+    /**
+     * The descriptor of the graph subject to which this federated provider data corresponds.
+     */
+    subjectDescriptor: string;
+    /**
+     * The version number of this federated provider data, which corresponds to when it was last updated. Can be used to prevent returning stale provider data from the cache when the caller is aware of a newer version, such as to prevent local cache poisoning from a remote cache or store. This is the app layer equivalent of the data layer sequence ID.
+     */
+    version: number;
+}
+
+export interface GraphGlobalExtendedPropertyBatch {
+    propertyNameFilters: string[];
+    subjectDescriptors: string[];
+}
+
+export interface GraphGroup extends GraphMember {
+    /**
+     * A short phrase to help human readers disambiguate groups with similar names
+     */
+    description: string;
+    isCrossProject: boolean;
+    isDeleted: boolean;
+    isGlobalScope: boolean;
+    isRestrictedVisible: boolean;
+    localScopeId: string;
+    scopeId: string;
+    scopeName: string;
+    scopeType: string;
+    securingHostId: string;
+    specialType: string;
+}
+
+/**
+ * Do not attempt to use this type to create a new group. This type does not contain sufficient fields to create a new group.
+ */
+export interface GraphGroupCreationContext {
+    /**
+     * Optional: If provided, we will use this identifier for the storage key of the created group
+     */
+    storageKey: string;
+}
+
+/**
+ * Use this type to create a new group using the mail address as a reference to an existing group from an external AD or AAD backed provider. This is the subset of GraphGroup fields required for creation of a group for the AAD and AD use case.
+ */
+export interface GraphGroupMailAddressCreationContext extends GraphGroupCreationContext {
+    /**
+     * This should be the mail address or the group in the source AD or AAD provider. Example: jamal@contoso.com Team Services will communicate with the source provider to fill all other fields on creation.
+     */
+    mailAddress: string;
+}
+
+/**
+ * Use this type to create a new group using the OriginID as a reference to an existing group from an external AD or AAD backed provider. This is the subset of GraphGroup fields required for creation of a group for the AD and AAD use case.
+ */
+export interface GraphGroupOriginIdCreationContext extends GraphGroupCreationContext {
+    /**
+     * This should be the object id or sid of the group from the source AD or AAD provider. Example: d47d025a-ce2f-4a79-8618-e8862ade30dd Team Services will communicate with the source provider to fill all other fields on creation.
+     */
+    originId: string;
+}
+
+/**
+ * Use this type to create a new Vsts group that is not backed by an external provider.
+ */
+export interface GraphGroupVstsCreationContext extends GraphGroupCreationContext {
+    /**
+     * For internal use only in back compat scenarios.
+     */
+    crossProject: boolean;
+    /**
+     * Used by VSTS groups; if set this will be the group description, otherwise ignored
+     */
+    description: string;
+    descriptor: string;
+    /**
+     * Used by VSTS groups; if set this will be the group DisplayName, otherwise ignored
+     */
+    displayName: string;
+    /**
+     * For internal use only in back compat scenarios.
+     */
+    restrictedVisibility: boolean;
+    /**
+     * For internal use only in back compat scenarios.
+     */
+    specialGroupType: string;
+}
+
+export interface GraphMember extends GraphSubject {
+    /**
+     * This represents the name of the container of origin for a graph member. (For MSA this is "Windows Live ID", for AD the name of the domain, for AAD the tenantID of the directory, for VSTS groups the ScopeId, etc)
+     */
+    domain: string;
+    /**
+     * The email address of record for a given graph member. This may be different than the principal name.
+     */
+    mailAddress: string;
+    /**
+     * This is the PrincipalName of this graph member from the source provider. The source provider may change this field over time and it is not guaranteed to be immutable for the life of the graph member by VSTS.
+     */
+    principalName: string;
+}
+
+export enum GraphMemberSearchFactor {
+    /**
+     * Domain qualified account name (domain\alias)
+     */
+    PrincipalName = 0,
+    /**
+     * Display name
+     */
+    DisplayName = 1,
+    /**
+     * Administrators group
+     */
+    AdministratorsGroup = 2,
+    /**
+     * Find the identity using the identifier (SID)
+     */
+    Identifier = 3,
+    /**
+     * Email address
+     */
+    MailAddress = 4,
+    /**
+     * A general search for an identity.
+     */
+    General = 5,
+    /**
+     * Alternate login username (Basic Auth Alias)
+     */
+    Alias = 6,
+    /**
+     * Find identity using DirectoryAlias
+     */
+    DirectoryAlias = 8,
+}
+
+export interface GraphMembership {
+    /**
+     * This field contains zero or more interesting links about the graph membership. These links may be invoked to obtain additional relationships or more detailed information about this graph membership.
+     */
+    _links: any;
+    containerDescriptor: string;
+    memberDescriptor: string;
+}
+
+export interface GraphMembershipState {
+    /**
+     * This field contains zero or more interesting links about the graph membership state. These links may be invoked to obtain additional relationships or more detailed information about this graph membership state.
+     */
+    _links: any;
+    active: boolean;
+}
+
+export interface GraphMembershipTraversal {
+    /**
+     * Reason why the subject could not be traversed completely
+     */
+    incompletenessReason: string;
+    /**
+     * When true, the subject is traversed completely
+     */
+    isComplete: boolean;
+    /**
+     * The traversed subject descriptor
+     */
+    subjectDescriptor: string;
+    /**
+     * Subject descriptor ids of the traversed members
+     */
+    traversedSubjectIds: string[];
+    /**
+     * Subject descriptors of the traversed members
+     */
+    traversedSubjects: string[];
+}
+
+/**
+ * Who is the provider for this user and what is the identifier and domain that is used to uniquely identify the user.
+ */
+export interface GraphProviderInfo {
+    /**
+     * The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations.
+     */
+    descriptor: string;
+    /**
+     * This represents the name of the container of origin for a graph member. (For MSA this is "Windows Live ID", for AAD the tenantID of the directory.)
+     */
+    domain: string;
+    /**
+     * The type of source provider for the origin identifier (ex: "aad", "msa")
+     */
+    origin: string;
+    /**
+     * The unique identifier from the system of origin. (For MSA this is the PUID in hex notation, for AAD this is the object id.)
+     */
+    originId: string;
+}
+
+export interface GraphScope extends GraphSubject {
+    /**
+     * The subject descriptor that references the administrators group for this scope. Only members of this group can change the contents of this scope or assign other users permissions to access this scope.
+     */
+    administratorDescriptor: string;
+    /**
+     * When true, this scope is also a securing host for one or more scopes.
+     */
+    isGlobal: boolean;
+    /**
+     * The subject descriptor for the closest account or organization in the ancestor tree of this scope.
+     */
+    parentDescriptor: string;
+    /**
+     * The type of this scope. Typically ServiceHost or TeamProject.
+     */
+    scopeType: IdentitiesInterfaces.GroupScopeType;
+    /**
+     * The subject descriptor for the containing organization in the ancestor tree of this scope.
+     */
+    securingHostDescriptor: string;
+}
+
+/**
+ * This type is the subset of fields that can be provided by the user to create a Vsts scope. Scope creation is currently limited to internal back-compat scenarios. End users that attempt to create a scope with this API will fail.
+ */
+export interface GraphScopeCreationContext {
+    /**
+     * Set this field to override the default description of this scope's admin group.
+     */
+    adminGroupDescription: string;
+    /**
+     * All scopes have an Administrator Group that controls access to the contents of the scope. Set this field to use a non-default group name for that administrators group.
+     */
+    adminGroupName: string;
+    /**
+     * Set this optional field if this scope is created on behalf of a user other than the user making the request. This should be the Id of the user that is not the requester.
+     */
+    creatorId: string;
+    /**
+     * The scope must be provided with a unique name within the parent scope. This means the created scope can have a parent or child with the same name, but no siblings with the same name.
+     */
+    name: string;
+    /**
+     * The type of scope being created.
+     */
+    scopeType: IdentitiesInterfaces.GroupScopeType;
+    /**
+     * An optional ID that uniquely represents the scope within it's parent scope. If this parameter is not provided, Vsts will generate on automatically.
+     */
+    storageKey: string;
+}
+
+export interface GraphStorageKeyResult {
+    /**
+     * This field contains zero or more interesting links about the graph storage key. These links may be invoked to obtain additional relationships or more detailed information about this graph storage key.
+     */
+    _links: any;
+    value: string;
+}
+
+export interface GraphSubject extends GraphSubjectBase {
+    /**
+     * [Internal Use Only] The legacy descriptor is here in case you need to access old version IMS using identity descriptor.
+     */
+    legacyDescriptor: string;
+    /**
+     * The type of source provider for the origin identifier (ex:AD, AAD, MSA)
+     */
+    origin: string;
+    /**
+     * The unique identifier from the system of origin. Typically a sid, object id or Guid. Linking and unlinking operations can cause this value to change for a user because the user is not backed by a different provider and has a different unique id in the new provider.
+     */
+    originId: string;
+    /**
+     * This field identifies the type of the graph subject (ex: Group, Scope, User).
+     */
+    subjectKind: string;
+}
+
+export interface GraphSubjectBase {
+    /**
+     * This field contains zero or more interesting links about the graph subject. These links may be invoked to obtain additional relationships or more detailed information about this graph subject.
+     */
+    _links: any;
+    /**
+     * The descriptor is the primary way to reference the graph subject while the system is running. This field will uniquely identify the same graph subject across both Accounts and Organizations.
+     */
+    descriptor: string;
+    /**
+     * This is the non-unique display name of the graph subject. To change this field, you must alter its value in the source provider.
+     */
+    displayName: string;
+    /**
+     * This url is the full route to the source resource of this graph subject.
+     */
+    url: string;
+}
+
+export interface GraphSubjectLookup {
+    lookupKeys: GraphSubjectLookupKey[];
+}
+
+export interface GraphSubjectLookupKey {
+    descriptor: string;
+}
+
+export interface GraphSystemSubject extends GraphSubject {
+}
+
+export enum GraphTraversalDirection {
+    Unknown = 0,
+    Down = 1,
+    Up = 2,
+}
+
+export interface GraphUser extends GraphMember {
+    metadataUpdateDate: Date;
+    /**
+     * The meta type of the user in the origin, such as "member", "guest", etc. See UserMetaType for the set of possible values.
+     */
+    metaType: string;
+}
+
+/**
+ * Do not attempt to use this type to create a new user. Use one of the subclasses instead. This type does not contain sufficient fields to create a new user.
+ */
+export interface GraphUserCreationContext {
+    /**
+     * Optional: If provided, we will use this identifier for the storage key of the created user
+     */
+    storageKey: string;
+}
+
+/**
+ * Use this type to create a new user using the mail address as a reference to an existing user from an external AD or AAD backed provider. This is the subset of GraphUser fields required for creation of a GraphUser for the AD and AAD use case when looking up the user by its mail address in the backing provider.
+ */
+export interface GraphUserMailAddressCreationContext extends GraphUserCreationContext {
+    mailAddress: string;
+}
+
+/**
+ * Use this type to create a new user using the OriginID as a reference to an existing user from an external AD or AAD backed provider. This is the subset of GraphUser fields required for creation of a GraphUser for the AD and AAD use case when looking up the user by its unique ID in the backing provider.
+ */
+export interface GraphUserOriginIdCreationContext extends GraphUserCreationContext {
+    /**
+     * This should be the object id or sid of the user from the source AD or AAD provider. Example: d47d025a-ce2f-4a79-8618-e8862ade30dd Team Services will communicate with the source provider to fill all other fields on creation.
+     */
+    originId: string;
+}
+
+/**
+ * Use this type to create a new user using the principal name as a reference to an existing user from an external AD or AAD backed provider. This is the subset of GraphUser fields required for creation of a GraphUser for the AD and AAD use case when looking up the user by its principal name in the backing provider.
+ */
+export interface GraphUserPrincipalNameCreationContext extends GraphUserCreationContext {
+    /**
+     * This should be the principal name or upn of the user in the source AD or AAD provider. Example: jamal@contoso.com Team Services will communicate with the source provider to fill all other fields on creation.
+     */
+    principalName: string;
+}
+
+export enum IdentityShardingState {
+    Undefined = 0,
+    Enabled = 1,
+    Disabled = 2,
+}
+
+export interface PagedGraphGroups {
+    /**
+     * This will be non-null if there is another page of data. There will never be more than one continuation token returned by a request.
+     */
+    continuationToken: string[];
+    /**
+     * The enumerable list of groups found within a page.
+     */
+    graphGroups: GraphGroup[];
+}
+
+export interface PagedGraphUsers {
+    /**
+     * This will be non-null if there is another page of data. There will never be more than one continuation token returned by a request.
+     */
+    continuationToken: string[];
+    /**
+     * The enumerable set of users found within a page.
+     */
+    graphUsers: GraphUser[];
+}
+
+export var TypeInfo = {
+    GraphMemberSearchFactor: {
+        enumValues: {
+            "principalName": 0,
+            "displayName": 1,
+            "administratorsGroup": 2,
+            "identifier": 3,
+            "mailAddress": 4,
+            "general": 5,
+            "alias": 6,
+            "directoryAlias": 8
+        }
+    },
+    GraphScope: <any>{
+    },
+    GraphScopeCreationContext: <any>{
+    },
+    GraphTraversalDirection: {
+        enumValues: {
+            "unknown": 0,
+            "down": 1,
+            "up": 2
+        }
+    },
+    GraphUser: <any>{
+    },
+    IdentityShardingState: {
+        enumValues: {
+            "undefined": 0,
+            "enabled": 1,
+            "disabled": 2
+        }
+    },
+    PagedGraphUsers: <any>{
+    },
+};
+
+TypeInfo.GraphScope.fields = {
+    scopeType: {
+        enumType: IdentitiesInterfaces.TypeInfo.GroupScopeType
+    }
+};
+
+TypeInfo.GraphScopeCreationContext.fields = {
+    scopeType: {
+        enumType: IdentitiesInterfaces.TypeInfo.GroupScopeType
+    }
+};
+
+TypeInfo.GraphUser.fields = {
+    metadataUpdateDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.PagedGraphUsers.fields = {
+    graphUsers: {
+        isArray: true,
+        typeInfo: TypeInfo.GraphUser
+    }
+};

--- a/api/interfaces/LocationsInterfaces.ts
+++ b/api/interfaces/LocationsInterfaces.ts
@@ -11,6 +11,7 @@
 "use strict";
 
 import IdentitiesInterfaces = require("../interfaces/IdentitiesInterfaces");
+import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
 
 
 export interface AccessMapping {
@@ -43,6 +44,10 @@ export interface ConnectionData {
      * The id for the server.
      */
     deploymentId: string;
+    /**
+     * The type for the server Hosted/OnPremises.
+     */
+    deploymentType: VSSInterfaces.DeploymentFlags;
     /**
      * The instance id for this host.
      */
@@ -199,6 +204,9 @@ export var TypeInfo = {
 };
 
 TypeInfo.ConnectionData.fields = {
+    deploymentType: {
+        enumType: VSSInterfaces.TypeInfo.DeploymentFlags
+    },
     lastUserAccess: {
         isDate: true,
     },

--- a/api/interfaces/NotificationInterfaces.ts
+++ b/api/interfaces/NotificationInterfaces.ts
@@ -21,6 +21,9 @@ export interface ActorNotificationReason extends NotificationReason {
     matchedRoles: string[];
 }
 
+/**
+ * Artifact filter options. Used in "follow" subscriptions.
+ */
 export interface ArtifactFilter extends BaseSubscriptionFilter {
     artifactId: string;
     artifactType: string;
@@ -43,6 +46,36 @@ export interface BlockFilter extends RoleBasedFilter {
 
 export interface BlockSubscriptionChannel {
     type: string;
+}
+
+/**
+ * Default delivery preference for group subscribers. Indicates how the subscriber should be notified.
+ */
+export enum DefaultGroupDeliveryPreference {
+    NoDelivery = -1,
+    EachMember = 2,
+}
+
+export interface DiagnosticIdentity {
+    displayName: string;
+    emailAddress: string;
+    id: string;
+}
+
+export interface DiagnosticNotification {
+    eventId: number;
+    eventType: string;
+    id: number;
+    messages: NotificationDiagnosticLogMessage[];
+    recipients: { [key: string] : DiagnosticRecipient; };
+    result: string;
+    stats: { [key: string] : number; };
+    subscriptionId: string;
+}
+
+export interface DiagnosticRecipient {
+    recipient: DiagnosticIdentity;
+    status: string;
 }
 
 export interface EmailHtmlSubscriptionChannel extends SubscriptionChannelWithAddress {
@@ -92,10 +125,33 @@ export enum EvaluationOperationStatus {
 }
 
 export interface EventBacklogStatus {
-    maxUnprocessedEventAgeMs: number;
+    captureTime: Date;
+    jobId: string;
+    lastEventBatchStartTime: Date;
+    lastEventProcessedTime: Date;
+    lastJobBatchStartTime: Date;
+    lastJobProcessedTime: Date;
+    oldestPendingEventTime: Date;
     publisher: string;
-    timeSinceLastProcessedEventMs: number;
     unprocessedEvents: number;
+}
+
+export interface EventBatch {
+    endTime: any;
+    eventCounts: { [key: string] : number; };
+    eventIds: string;
+    notificationCounts: { [key: string] : number; };
+    preProcessEndTime: any;
+    preProcessStartTime: any;
+    processEndTime: any;
+    processStartTime: any;
+    startTime: any;
+    subscriptionCounts: { [key: string] : number; };
+}
+
+export interface EventProcessingLog extends NotificationJobDiagnosticLog {
+    batches: EventBatch[];
+    matcherResults: MatcherResult[];
 }
 
 /**
@@ -121,6 +177,42 @@ export interface EventsEvaluationResult {
      * Count of matched events.
      */
     matchedCount: number;
+}
+
+/**
+ * A transform request specify the properties of a notification event to be transformed.
+ */
+export interface EventTransformRequest {
+    /**
+     * Event payload.
+     */
+    eventPayload: string;
+    /**
+     * Event type.
+     */
+    eventType: string;
+    /**
+     * System inputs.
+     */
+    systemInputs: { [key: string] : string; };
+}
+
+/**
+ * Result of transforming a notification event.
+ */
+export interface EventTransformResult {
+    /**
+     * Transformed html content.
+     */
+    content: string;
+    /**
+     * Calculated data.
+     */
+    data: any;
+    /**
+     * Calculated system inputs.
+     */
+    systemInputs: { [key: string] : string; };
 }
 
 /**
@@ -198,8 +290,27 @@ export interface FieldValuesQuery extends FormInputInterfaces.InputValuesQuery {
     scope: string;
 }
 
+export interface GeneratedNotification {
+    recipients: DiagnosticIdentity[];
+}
+
 export interface GroupSubscriptionChannel extends SubscriptionChannelWithAddress {
     type: string;
+}
+
+/**
+ * Abstraction interface for the diagnostic log.  Primarily for deserialization.
+ */
+export interface INotificationDiagnosticLog {
+    activityId: string;
+    description: string;
+    endTime: Date;
+    id: string;
+    logType: string;
+    messages: NotificationDiagnosticLogMessage[];
+    properties: { [key: string] : string; };
+    source: string;
+    startTime: Date;
 }
 
 export interface ISubscriptionChannel {
@@ -211,16 +322,88 @@ export interface ISubscriptionFilter {
     type: string;
 }
 
+export interface MatcherResult {
+    matcher: string;
+    stats: { [key: string] : { [key: string] : number; }; };
+}
+
 export interface MessageQueueSubscriptionChannel {
     type: string;
 }
 
+export interface NotificationAdminSettings {
+    /**
+     * The default group delivery preference for groups in this collection
+     */
+    defaultGroupDeliveryPreference: DefaultGroupDeliveryPreference;
+}
+
+export interface NotificationAdminSettingsUpdateParameters {
+    defaultGroupDeliveryPreference: DefaultGroupDeliveryPreference;
+}
+
 export interface NotificationBacklogStatus {
+    captureTime: Date;
     channel: string;
-    maxUnprocessedNotificationAgeMs: number;
+    jobId: string;
+    lastJobBatchStartTime: Date;
+    lastJobProcessedTime: Date;
+    lastNotificationBatchStartTime: Date;
+    lastNotificationProcessedTime: Date;
+    oldestPendingNotificationTime: Date;
     publisher: string;
-    timeSinceLastProcessedNotificationMs: number;
+    /**
+     * Null status is unprocessed
+     */
+    status: string;
     unprocessedNotifications: number;
+}
+
+export interface NotificationBatch {
+    endTime: any;
+    notificationCount: number;
+    notificationIds: string;
+    problematicNotifications: DiagnosticNotification[];
+    startTime: any;
+}
+
+export interface NotificationDeliveryLog extends NotificationJobDiagnosticLog {
+    batches: NotificationBatch[];
+}
+
+/**
+ * Abstract base class for all of the diagnostic logs.
+ */
+export interface NotificationDiagnosticLog {
+    /**
+     * Identifier used for correlating to other diagnostics that may have been recorded elsewhere.
+     */
+    activityId: string;
+    description: string;
+    endTime: Date;
+    errors: number;
+    /**
+     * Unique instance identifier.
+     */
+    id: string;
+    logType: string;
+    messages: NotificationDiagnosticLogMessage[];
+    properties: { [key: string] : string; };
+    /**
+     * This identifier depends on the logType.  For notification jobs, this will be the job Id. For subscription tracing, this will be a special root Guid with the subscription Id encoded.
+     */
+    source: string;
+    startTime: Date;
+    warnings: number;
+}
+
+export interface NotificationDiagnosticLogMessage {
+    /**
+     * Corresponds to .Net TraceLevel enumeration
+     */
+    level: number;
+    message: string;
+    time: any;
 }
 
 export interface NotificationEventBacklogStatus {
@@ -365,6 +548,11 @@ export interface NotificationEventTypeCategory {
     name: string;
 }
 
+export interface NotificationJobDiagnosticLog extends NotificationDiagnosticLog {
+    result: string;
+    stats: { [key: string] : { [key: string] : number; }; };
+}
+
 export enum NotificationOperation {
     None = 0,
     SuspendUnprocessed = 1,
@@ -483,14 +671,13 @@ export interface NotificationSubscriber {
  * Delivery preference for a subscriber. Indicates how the subscriber should be notified.
  */
 export enum NotificationSubscriberDeliveryPreference {
-    None = 0,
+    NoDelivery = -1,
     /**
      * Deliver notifications to the subscriber's preferred email address.
      */
     PreferredEmailAddress = 1,
     EachMember = 2,
-    NoDelivery = -1,
-    NotSet = -2147483648,
+    UseDefault = 3,
 }
 
 /**
@@ -657,29 +844,6 @@ export interface NotificationSubscriptionUpdateParameters {
     userSettings: SubscriptionUserSettings;
 }
 
-export interface NotificationTracing extends NotificationTracingSetParameters {
-    /**
-     * Trace until the specified end date.
-     */
-    endDate: Date;
-    /**
-     * The maximum number of result details to trace.
-     */
-    maxTracedEntries: number;
-    /**
-     * The date and time tracing started.
-     */
-    startDate: Date;
-    /**
-     * Trace until remaining count reaches 0.
-     */
-    tracedEntries: number;
-}
-
-export interface NotificationTracingSetParameters {
-    enabled: boolean;
-}
-
 /**
  * Encapsulates the properties of an operator constraint. An operator constraint defines if some operator is available only for specific scope like a project scope.
  */
@@ -689,6 +853,45 @@ export interface OperatorConstraint {
      * Gets or sets the list of scopes that this type supports.
      */
     supportedScopes: string[];
+}
+
+export interface ProcessedEvent {
+    /**
+     * All of the users that were associtated with this event and their role.
+     */
+    actors: VSSInterfaces.EventActor[];
+    allowedChannels: string;
+    artifactUri: string;
+    deliveryIdentities: ProcessingIdentities;
+    /**
+     * Evaluations for each user
+     */
+    evaluations: { [key: string] : SubscriptionEvaluation; };
+    eventId: number;
+    /**
+     * Which members were excluded from evaluation (only applies to ActorMatcher subscriptions)
+     */
+    exclusions: VSSInterfaces.EventActor[];
+    /**
+     * Which members were included for evaluation (only applies to ActorMatcher subscriptions)
+     */
+    inclusions: VSSInterfaces.EventActor[];
+    notifications: GeneratedNotification[];
+}
+
+export interface ProcessingDiagnosticIdentity extends DiagnosticIdentity {
+    deliveryPreference: string;
+    isActive: boolean;
+    isGroup: boolean;
+    message: string;
+}
+
+export interface ProcessingIdentities {
+    excludedIdentities: { [key: string] : ProcessingDiagnosticIdentity; };
+    includedIdentities: { [key: string] : ProcessingDiagnosticIdentity; };
+    messages: NotificationDiagnosticLogMessage[];
+    missingIdentities: string[];
+    properties: { [key: string] : string; };
 }
 
 export interface RoleBasedFilter extends ExpressionFilter {
@@ -757,10 +960,20 @@ export interface SubscriptionChannelWithAddress {
 }
 
 export interface SubscriptionDiagnostics {
-    /**
-     * Optional. Contol the tracing
-     */
-    notificationTracing: NotificationTracing;
+    deliveryResults: SubscriptionTracing;
+    deliveryTracing: SubscriptionTracing;
+    evaluationTracing: SubscriptionTracing;
+}
+
+export interface SubscriptionEvaluation {
+    clauses: SubscriptionEvaluationClause[];
+    user: DiagnosticIdentity;
+}
+
+export interface SubscriptionEvaluationClause {
+    clause: string;
+    order: number;
+    result: boolean;
 }
 
 /**
@@ -977,9 +1190,17 @@ export enum SubscriptionStatus {
      */
     PendingDeletion = -100,
     /**
+     * Subscription is disabled because the project is invalid
+     */
+    DisabledProjectInvalid = -11,
+    /**
+     * Subscription is disabled because the identity does not have the appropriate permissions
+     */
+    DisabledMissingPermissions = -10,
+    /**
      * Subscription is disabled service due to failures.
      */
-    DisabledBySystem = -9,
+    DisabledFromProbation = -9,
     /**
      * Subscription is disabled because the identity is no longer active
      */
@@ -1052,6 +1273,52 @@ export enum SubscriptionTemplateType {
     None = 3,
 }
 
+export interface SubscriptionTraceDiagnosticLog extends NotificationDiagnosticLog {
+    /**
+     * Indicates the job Id that processed or delivered this subscription
+     */
+    jobId: string;
+    /**
+     * Indicates unique instance identifier for the job that processed or delivered this subscription
+     */
+    jobInstanceId: string;
+    subscriptionId: string;
+}
+
+export interface SubscriptionTraceEventProcessingLog extends SubscriptionTraceDiagnosticLog {
+    channel: string;
+    evaluationIdentities: ProcessingIdentities;
+    /**
+     * Which members opted out from receiving notifications from this subscription
+     */
+    optedOut: DiagnosticIdentity[];
+    processedEvents: { [key: number] : ProcessedEvent; };
+}
+
+export interface SubscriptionTraceNotificationDeliveryLog extends SubscriptionTraceDiagnosticLog {
+    notifications: DiagnosticNotification[];
+}
+
+export interface SubscriptionTracing {
+    enabled: boolean;
+    /**
+     * Trace until the specified end date.
+     */
+    endDate: Date;
+    /**
+     * The maximum number of result details to trace.
+     */
+    maxTracedEntries: number;
+    /**
+     * The date and time tracing started.
+     */
+    startDate: Date;
+    /**
+     * Trace until remaining count reaches 0.
+     */
+    tracedEntries: number;
+}
+
 /**
  * User-managed settings for a group subscription.
  */
@@ -1068,6 +1335,16 @@ export interface UnsupportedFilter extends BaseSubscriptionFilter {
 
 export interface UnsupportedSubscriptionChannel {
     type: string;
+}
+
+export interface UpdateSubscripitonDiagnosticsParameters {
+    deliveryResults: UpdateSubscripitonTracingParameters;
+    deliveryTracing: UpdateSubscripitonTracingParameters;
+    evaluationTracing: UpdateSubscripitonTracingParameters;
+}
+
+export interface UpdateSubscripitonTracingParameters {
+    enabled: boolean;
 }
 
 export interface UserSubscriptionChannel extends SubscriptionChannelWithAddress {
@@ -1101,6 +1378,12 @@ export var TypeInfo = {
     },
     BatchNotificationOperation: <any>{
     },
+    DefaultGroupDeliveryPreference: {
+        enumValues: {
+            "noDelivery": -1,
+            "eachMember": 2
+        }
+    },
     EvaluationOperationStatus: {
         enumValues: {
             "notSet": 0,
@@ -1112,6 +1395,10 @@ export var TypeInfo = {
             "timedOut": 6,
             "notFound": 7
         }
+    },
+    EventBacklogStatus: <any>{
+    },
+    EventProcessingLog: <any>{
     },
     EventPublisherQueryFlags: {
         enumValues: {
@@ -1125,11 +1412,27 @@ export var TypeInfo = {
             "includeFields": 1
         }
     },
+    INotificationDiagnosticLog: <any>{
+    },
+    NotificationAdminSettings: <any>{
+    },
+    NotificationAdminSettingsUpdateParameters: <any>{
+    },
+    NotificationBacklogStatus: <any>{
+    },
+    NotificationDeliveryLog: <any>{
+    },
+    NotificationDiagnosticLog: <any>{
+    },
+    NotificationEventBacklogStatus: <any>{
+    },
     NotificationEventField: <any>{
     },
     NotificationEventFieldType: <any>{
     },
     NotificationEventType: <any>{
+    },
+    NotificationJobDiagnosticLog: <any>{
     },
     NotificationOperation: {
         enumValues: {
@@ -1198,11 +1501,10 @@ export var TypeInfo = {
     },
     NotificationSubscriberDeliveryPreference: {
         enumValues: {
-            "none": 0,
+            "noDelivery": -1,
             "preferredEmailAddress": 1,
             "eachMember": 2,
-            "noDelivery": -1,
-            "notSet": -2147483648
+            "useDefault": 3
         }
     },
     NotificationSubscriberUpdateParameters: <any>{
@@ -1212,8 +1514,6 @@ export var TypeInfo = {
     NotificationSubscriptionTemplate: <any>{
     },
     NotificationSubscriptionUpdateParameters: <any>{
-    },
-    NotificationTracing: <any>{
     },
     SubscriberFlags: {
         enumValues: {
@@ -1286,7 +1586,9 @@ export var TypeInfo = {
         enumValues: {
             "jailedByNotificationsVolume": -200,
             "pendingDeletion": -100,
-            "disabledBySystem": -9,
+            "disabledProjectInvalid": -11,
+            "disabledMissingPermissions": -10,
+            "disabledFromProbation": -9,
             "disabledInactiveIdentity": -8,
             "disabledMessageQueueNotSupported": -7,
             "disabledMissingIdentity": -6,
@@ -1316,6 +1618,14 @@ export var TypeInfo = {
             "none": 3
         }
     },
+    SubscriptionTraceDiagnosticLog: <any>{
+    },
+    SubscriptionTraceEventProcessingLog: <any>{
+    },
+    SubscriptionTraceNotificationDeliveryLog: <any>{
+    },
+    SubscriptionTracing: <any>{
+    },
 };
 
 TypeInfo.ActorNotificationReason.fields = {
@@ -1327,6 +1637,107 @@ TypeInfo.ActorNotificationReason.fields = {
 TypeInfo.BatchNotificationOperation.fields = {
     notificationOperation: {
         enumType: TypeInfo.NotificationOperation
+    }
+};
+
+TypeInfo.EventBacklogStatus.fields = {
+    captureTime: {
+        isDate: true,
+    },
+    lastEventBatchStartTime: {
+        isDate: true,
+    },
+    lastEventProcessedTime: {
+        isDate: true,
+    },
+    lastJobBatchStartTime: {
+        isDate: true,
+    },
+    lastJobProcessedTime: {
+        isDate: true,
+    },
+    oldestPendingEventTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.EventProcessingLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.INotificationDiagnosticLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.NotificationAdminSettings.fields = {
+    defaultGroupDeliveryPreference: {
+        enumType: TypeInfo.DefaultGroupDeliveryPreference
+    }
+};
+
+TypeInfo.NotificationAdminSettingsUpdateParameters.fields = {
+    defaultGroupDeliveryPreference: {
+        enumType: TypeInfo.DefaultGroupDeliveryPreference
+    }
+};
+
+TypeInfo.NotificationBacklogStatus.fields = {
+    captureTime: {
+        isDate: true,
+    },
+    lastJobBatchStartTime: {
+        isDate: true,
+    },
+    lastJobProcessedTime: {
+        isDate: true,
+    },
+    lastNotificationBatchStartTime: {
+        isDate: true,
+    },
+    lastNotificationProcessedTime: {
+        isDate: true,
+    },
+    oldestPendingNotificationTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.NotificationDeliveryLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.NotificationDiagnosticLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.NotificationEventBacklogStatus.fields = {
+    eventBacklogStatus: {
+        isArray: true,
+        typeInfo: TypeInfo.EventBacklogStatus
+    },
+    notificationBacklogStatus: {
+        isArray: true,
+        typeInfo: TypeInfo.NotificationBacklogStatus
     }
 };
 
@@ -1346,6 +1757,15 @@ TypeInfo.NotificationEventType.fields = {
     fields: {
         isDictionary: true,
         dictionaryValueTypeInfo: TypeInfo.NotificationEventField
+    }
+};
+
+TypeInfo.NotificationJobDiagnosticLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
     }
 };
 
@@ -1431,18 +1851,15 @@ TypeInfo.NotificationSubscriptionUpdateParameters.fields = {
     }
 };
 
-TypeInfo.NotificationTracing.fields = {
-    endDate: {
-        isDate: true,
-    },
-    startDate: {
-        isDate: true,
-    }
-};
-
 TypeInfo.SubscriptionDiagnostics.fields = {
-    notificationTracing: {
-        typeInfo: TypeInfo.NotificationTracing
+    deliveryResults: {
+        typeInfo: TypeInfo.SubscriptionTracing
+    },
+    deliveryTracing: {
+        typeInfo: TypeInfo.SubscriptionTracing
+    },
+    evaluationTracing: {
+        typeInfo: TypeInfo.SubscriptionTracing
     }
 };
 
@@ -1471,5 +1888,41 @@ TypeInfo.SubscriptionQuery.fields = {
 TypeInfo.SubscriptionQueryCondition.fields = {
     flags: {
         enumType: TypeInfo.SubscriptionFlags
+    }
+};
+
+TypeInfo.SubscriptionTraceDiagnosticLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.SubscriptionTraceEventProcessingLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.SubscriptionTraceNotificationDeliveryLog.fields = {
+    endTime: {
+        isDate: true,
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.SubscriptionTracing.fields = {
+    endDate: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
     }
 };

--- a/api/interfaces/ProjectAnalysisInterfaces.ts
+++ b/api/interfaces/ProjectAnalysisInterfaces.ts
@@ -31,7 +31,13 @@ export interface CodeChangeTrendItem {
     value: number;
 }
 
-export interface LanguageStatistics {
+export interface LanguageMetricsSecuredObject {
+    namespaceId: string;
+    projectId: string;
+    requiredPermissions: number;
+}
+
+export interface LanguageStatistics extends LanguageMetricsSecuredObject {
     bytes: number;
     files: number;
     filesPercentage: number;
@@ -48,7 +54,7 @@ export interface ProjectActivityMetrics {
     pullRequestsCreatedCount: number;
 }
 
-export interface ProjectLanguageAnalytics {
+export interface ProjectLanguageAnalytics extends LanguageMetricsSecuredObject {
     id: string;
     languageBreakdown: LanguageStatistics[];
     repositoryLanguageAnalytics: RepositoryLanguageAnalytics[];
@@ -62,7 +68,7 @@ export interface RepositoryActivityMetrics {
     repositoryId: string;
 }
 
-export interface RepositoryLanguageAnalytics {
+export interface RepositoryLanguageAnalytics extends LanguageMetricsSecuredObject {
     id: string;
     languageBreakdown: LanguageStatistics[];
     name: string;

--- a/api/interfaces/TaskAgentInterfaces.ts
+++ b/api/interfaces/TaskAgentInterfaces.ts
@@ -2,7 +2,7 @@
  * ---------------------------------------------------------
  * Copyright(C) Microsoft Corporation. All rights reserved.
  * ---------------------------------------------------------
- * 
+ *
  * ---------------------------------------------------------
  * Generated file, DO NOT EDIT
  * ---------------------------------------------------------
@@ -29,9 +29,13 @@ export enum AadLoginPromptOption {
      */
     SelectAccount = 2,
     /**
-     * Force the user to login again.  Ignore current authentication state and force the user to authenticate again. This option should be used instead of Login.
+     * Force the user to login again. <remarks> Ignore current authentication state and force the user to authenticate again. This option should be used instead of Login. </remarks>
      */
     FreshLogin = 3,
+    /**
+     * Force the user to login again with mfa. <remarks> Ignore current authentication state and force the user to authenticate again. This option should be used instead of Login, if MFA is required. </remarks>
+     */
+    FreshLoginWithMfa = 4,
 }
 
 export interface AadOauthTokenRequest {
@@ -86,24 +90,92 @@ export interface AgentRefreshMessage {
     timeout: any;
 }
 
-export interface AgentRequestEvent {
-    eventType: string;
-    planId: string;
-    poolId: number;
-    reservedAgentId: number;
-    result: TaskResult;
-    timeStamp: Date;
-}
-
 export enum AuditAction {
     Add = 1,
     Update = 2,
     Delete = 3,
+    Undelete = 4,
+}
+
+export interface AuthenticationSchemeReference {
+    inputs: { [key: string] : string; };
+    type: string;
 }
 
 export interface AuthorizationHeader {
+    /**
+     * Gets or sets the name of authorization header.
+     */
     name: string;
+    /**
+     * Gets or sets the value of authorization header.
+     */
     value: string;
+}
+
+export interface AzureKeyVaultPermission extends AzureResourcePermission {
+    vault: string;
+}
+
+export interface AzureKeyVaultVariableGroupProviderData extends VariableGroupProviderData {
+    lastRefreshedOn: Date;
+    serviceEndpointId: string;
+    vault: string;
+}
+
+export interface AzureKeyVaultVariableValue extends VariableValue {
+    contentType: string;
+    enabled: boolean;
+    expires: Date;
+}
+
+/**
+ * Azure Management Group
+ */
+export interface AzureManagementGroup {
+    /**
+     * Display name of azure management group
+     */
+    displayName: string;
+    /**
+     * Id of azure management group
+     */
+    id: string;
+    /**
+     * Azure management group name
+     */
+    name: string;
+    /**
+     * Id of tenant from which azure management group belogs
+     */
+    tenantId: string;
+}
+
+/**
+ * Azure management group query result
+ */
+export interface AzureManagementGroupQueryResult {
+    /**
+     * Error message in case of an exception
+     */
+    errorMessage: string;
+    /**
+     * List of azure management groups
+     */
+    value: AzureManagementGroup[];
+}
+
+export interface AzurePermission {
+    provisioned: boolean;
+    resourceProvider: string;
+}
+
+export interface AzureResourcePermission extends AzurePermission {
+    resourceGroup: string;
+}
+
+export interface AzureRoleAssignmentPermission extends AzurePermission {
+    roleAssignmentId: string;
 }
 
 export interface AzureSpnOperationStatus {
@@ -123,9 +195,25 @@ export interface AzureSubscriptionQueryResult {
     value: AzureSubscription[];
 }
 
+export interface ClientCertificate {
+    /**
+     * Gets or sets the value of client certificate.
+     */
+    value: string;
+}
+
+export interface CounterVariable {
+    prefix: string;
+    seed: number;
+    value: number;
+}
+
 export interface DataSource {
+    authenticationScheme: AuthenticationSchemeReference;
     endpointUrl: string;
+    headers: AuthorizationHeader[];
     name: string;
+    resourceUrl: string;
     resultSelector: string;
 }
 
@@ -135,8 +223,19 @@ export interface DataSourceBinding extends DistributedTaskCommonInterfaces.DataS
 export interface DataSourceDetails {
     dataSourceName: string;
     dataSourceUrl: string;
+    headers: AuthorizationHeader[];
     parameters: { [key: string] : string; };
+    resourceUrl: string;
     resultSelector: string;
+}
+
+export interface DemandEquals {
+}
+
+export interface DemandExists {
+}
+
+export interface DemandMinimumVersion {
 }
 
 export interface DependencyBinding {
@@ -154,32 +253,181 @@ export interface DependsOn {
     map: DependencyBinding[];
 }
 
-export interface DeploymentGroup extends DeploymentGroupReference {
-    machineCount: number;
-    machines: DeploymentMachine[];
+export interface DeploymentGatesChangeEvent {
+    gateNames: string[];
 }
 
+/**
+ * Deployment group.
+ */
+export interface DeploymentGroup extends DeploymentGroupReference {
+    /**
+     * Description of the deployment group.
+     */
+    description: string;
+    /**
+     * Number of deployment targets in the deployment group.
+     */
+    machineCount: number;
+    /**
+     * List of deployment targets in the deployment group.
+     */
+    machines: DeploymentMachine[];
+    /**
+     * List of unique tags across all deployment targets in the deployment group.
+     */
+    machineTags: string[];
+}
+
+/**
+ * This is useful in getting a list of deployment groups, filtered for which caller has permissions to take a particular action.
+ */
 export enum DeploymentGroupActionFilter {
+    /**
+     * All deployment groups.
+     */
     None = 0,
+    /**
+     * Only deployment groups for which caller has **manage** permission.
+     */
     Manage = 2,
+    /**
+     * Only deployment groups for which caller has **use** permission.
+     */
     Use = 16,
 }
 
-export enum DeploymentGroupExpands {
-    None = 0,
-    Machines = 2,
+/**
+ * Properties to create Deployment group.
+ */
+export interface DeploymentGroupCreateParameter {
+    /**
+     * Description of the deployment group.
+     */
+    description: string;
+    /**
+     * Name of the deployment group.
+     */
+    name: string;
+    /**
+     * Deployment pool in which deployment agents are registered. This is obsolete. Kept for compatibility. Will be marked obsolete explicitly by M132.
+     */
+    pool: DeploymentGroupCreateParameterPoolProperty;
+    /**
+     * Identifier of the deployment pool in which deployment agents are registered.
+     */
+    poolId: number;
 }
 
-export interface DeploymentGroupReference {
+/**
+ * Properties of Deployment pool to create Deployment group.
+ */
+export interface DeploymentGroupCreateParameterPoolProperty {
+    /**
+     * Deployment pool identifier.
+     */
     id: number;
+}
+
+/**
+ * Properties to be included or expanded in deployment group objects. This is useful when getting a single or list of deployment grouops.
+ */
+export enum DeploymentGroupExpands {
+    /**
+     * No additional properties.
+     */
+    None = 0,
+    /**
+     * Deprecated: Include all the deployment targets.
+     */
+    Machines = 2,
+    /**
+     * Include unique list of tags across all deployment targets.
+     */
+    Tags = 4,
+}
+
+/**
+ * Deployment group metrics.
+ */
+export interface DeploymentGroupMetrics {
+    /**
+     * List of deployment group properties. And types of metrics provided for those properties.
+     */
+    columnsHeader: MetricsColumnsHeader;
+    /**
+     * Deployment group.
+     */
+    deploymentGroup: DeploymentGroupReference;
+    /**
+     * Values of properties and the metrics. E.g. 1: total count of deployment targets for which 'TargetState' is 'offline'. E.g. 2: Average time of deployment to the deployment targets for which 'LastJobStatus' is 'passed' and 'TargetState' is 'online'.
+     */
+    rows: MetricsRow[];
+}
+
+/**
+ * Deployment group reference. This is useful for referring a deployment group in another object.
+ */
+export interface DeploymentGroupReference {
+    /**
+     * Deployment group identifier.
+     */
+    id: number;
+    /**
+     * Name of the deployment group.
+     */
     name: string;
+    /**
+     * Deployment pool in which deployment agents are registered.
+     */
     pool: TaskAgentPoolReference;
+    /**
+     * Project to which the deployment group belongs.
+     */
     project: ProjectReference;
 }
 
+/**
+ * Deployment group update parameter.
+ */
+export interface DeploymentGroupUpdateParameter {
+    /**
+     * Description of the deployment group.
+     */
+    description: string;
+    /**
+     * Name of the deployment group.
+     */
+    name: string;
+}
+
+/**
+ * Deployment target.
+ */
 export interface DeploymentMachine {
-    agent: TaskAgentReference;
+    /**
+     * Deployment agent.
+     */
+    agent: TaskAgent;
+    /**
+     * Deployment target Identifier.
+     */
+    id: number;
+    /**
+     * Tags of the deployment target.
+     */
     tags: string[];
+}
+
+export interface DeploymentMachineChangedData extends DeploymentMachine {
+    addedTags: string[];
+    deletedTags: string[];
+}
+
+export enum DeploymentMachineExpands {
+    None = 0,
+    Capabilities = 2,
+    AssignedRequest = 4,
 }
 
 export interface DeploymentMachineGroup extends DeploymentMachineGroupReference {
@@ -196,20 +444,128 @@ export interface DeploymentMachineGroupReference {
 
 export interface DeploymentMachinesChangeEvent {
     machineGroupReference: DeploymentGroupReference;
-    machines: DeploymentMachine[];
+    machines: DeploymentMachineChangedData[];
+}
+
+/**
+ * Deployment pool summary.
+ */
+export interface DeploymentPoolSummary {
+    /**
+     * List of deployment groups referring to the deployment pool.
+     */
+    deploymentGroups: DeploymentGroupReference[];
+    /**
+     * Number of deployment agents that are offline.
+     */
+    offlineAgentsCount: number;
+    /**
+     * Number of deployment agents that are online.
+     */
+    onlineAgentsCount: number;
+    /**
+     * Deployment pool.
+     */
+    pool: TaskAgentPoolReference;
+}
+
+/**
+ * Properties to be included or expanded in deployment pool summary objects. This is useful when getting a single or list of deployment pool summaries.
+ */
+export enum DeploymentPoolSummaryExpands {
+    /**
+     * No additional properties
+     */
+    None = 0,
+    /**
+     * Include deployment groups referring to the deployment pool.
+     */
+    DeploymentGroups = 2,
+}
+
+/**
+ * Properties to be included or expanded in deployment target objects. This is useful when getting a single or list of deployment targets.
+ */
+export enum DeploymentTargetExpands {
+    /**
+     * No additional properties.
+     */
+    None = 0,
+    /**
+     * Include capabilities of the deployment agent.
+     */
+    Capabilities = 2,
+    /**
+     * Include the job request assigned to the deployment agent.
+     */
+    AssignedRequest = 4,
+    /**
+     * Include the last completed job request of the deployment agent.
+     */
+    LastCompletedRequest = 8,
+}
+
+/**
+ * Deployment target update parameter.
+ */
+export interface DeploymentTargetUpdateParameter {
+    /**
+     * Identifier of the deployment target.
+     */
+    id: number;
+    tags: string[];
+}
+
+export interface DiagnosticLogMetadata {
+    agentId: number;
+    agentName: string;
+    fileName: string;
+    phaseName: string;
+    phaseResult: string;
+    poolId: number;
 }
 
 export interface EndpointAuthorization {
+    /**
+     * Gets or sets the parameters for the selected authorization scheme.
+     */
     parameters: { [key: string] : string; };
+    /**
+     * Gets or sets the scheme used for service endpoint authentication.
+     */
     scheme: string;
 }
 
+/**
+ * Represents url of the service endpoint.
+ */
 export interface EndpointUrl {
+    /**
+     * Gets or sets the dependency bindings.
+     */
     dependsOn: DependsOn;
+    /**
+     * Gets or sets the display name of service endpoint url.
+     */
     displayName: string;
+    /**
+     * Gets or sets the help text of service endpoint url.
+     */
     helpText: string;
+    /**
+     * Gets or sets the visibility of service endpoint url.
+     */
     isVisible: string;
+    /**
+     * Gets or sets the value of service endpoint url.
+     */
     value: string;
+}
+
+export interface EventsConfig {
+}
+
+export interface ExpressionValidationItem extends ValidationItem {
 }
 
 export interface HelpLink {
@@ -217,15 +573,22 @@ export interface HelpLink {
     url: string;
 }
 
-export interface InputValidationItem {
-    isValid: boolean;
-    reason: string;
-    type: string;
+export interface InputBindingContext {
+    /**
+     * Value of the input
+     */
     value: string;
 }
 
+export interface InputValidationItem extends ValidationItem {
+    /**
+     * Provides binding context for the expression to evaluate
+     */
+    context: InputBindingContext;
+}
+
 export interface InputValidationRequest {
-    inputs: { [key: string] : InputValidationItem; };
+    inputs: { [key: string] : ValidationItem; };
 }
 
 export interface Issue {
@@ -250,7 +613,6 @@ export interface JobCancelMessage {
 }
 
 export interface JobCompletedEvent extends JobEvent {
-    outputVariables: { [key: string] : VariableValue; };
     requestId: number;
     result: TaskResult;
 }
@@ -279,7 +641,7 @@ export interface JobEventConfig {
     timeout: string;
 }
 
-export interface JobEventsConfig {
+export interface JobEventsConfig extends EventsConfig {
     jobAssigned: JobEventConfig;
     jobCompleted: JobEventConfig;
     jobStarted: JobEventConfig;
@@ -300,6 +662,7 @@ export interface JobRequestMessage {
     environment: JobEnvironment;
     jobId: string;
     jobName: string;
+    jobRefName: string;
     messageType: string;
     plan: TaskOrchestrationPlanReference;
     timeline: TimelineReference;
@@ -314,6 +677,24 @@ export enum MachineGroupActionFilter {
     Use = 16,
 }
 
+/**
+ * Represents a purchase of resource units in a secondary marketplace.
+ */
+export interface MarketplacePurchasedLicense {
+    /**
+     * The Marketplace display name.
+     */
+    marketplaceName: string;
+    /**
+     * The name of the identity making the purchase as seen by the marketplace
+     */
+    purchaserName: string;
+    /**
+     * The quantity purchased.
+     */
+    purchaseUnitCount: number;
+}
+
 export interface MaskHint {
     type: MaskType;
     value: string;
@@ -322,6 +703,48 @@ export interface MaskHint {
 export enum MaskType {
     Variable = 1,
     Regex = 2,
+}
+
+/**
+ * Meta data for a metrics column.
+ */
+export interface MetricsColumnMetaData {
+    /**
+     * Name.
+     */
+    columnName: string;
+    /**
+     * Data type.
+     */
+    columnValueType: string;
+}
+
+/**
+ * Metrics columns header
+ */
+export interface MetricsColumnsHeader {
+    /**
+     * Properties of deployment group for which metrics are provided. E.g. 1: LastJobStatus E.g. 2: TargetState
+     */
+    dimensions: MetricsColumnMetaData[];
+    /**
+     * The types of metrics. E.g. 1: total count of deployment targets. E.g. 2: Average time of deployment to the deployment targets.
+     */
+    metrics: MetricsColumnMetaData[];
+}
+
+/**
+ * Metrics row.
+ */
+export interface MetricsRow {
+    /**
+     * The values of the properties mentioned as 'Dimensions' in column header. E.g. 1: For a property 'LastJobStatus' - metrics will be provided for 'passed', 'failed', etc. E.g. 2: For a property 'TargetState' - metrics will be provided for 'online', 'offline' targets.
+     */
+    dimensions: string[];
+    /**
+     * Metrics in serialized format. Should be deserialized based on the data type provided in header.
+     */
+    metrics: string[];
 }
 
 /**
@@ -374,6 +797,12 @@ export interface PlanEnvironment {
     variables: { [key: string] : string; };
 }
 
+export enum PlanGroupStatus {
+    Running = 1,
+    Queued = 2,
+    All = 3,
+}
+
 export enum PlanGroupStatusFilter {
     Running = 1,
     Queued = 2,
@@ -383,6 +812,32 @@ export enum PlanGroupStatusFilter {
 export interface ProjectReference {
     id: string;
     name: string;
+}
+
+export interface PublishTaskGroupMetadata {
+    comment: string;
+    parentDefinitionRevision: number;
+    preview: boolean;
+    taskGroupId: string;
+    taskGroupRevision: number;
+}
+
+export interface ResourceLimit {
+    failedToReachAllProviders: boolean;
+    hostId: string;
+    isHosted: boolean;
+    isPremium: boolean;
+    parallelismTag: string;
+    resourceLimitsData: { [key: string] : string; };
+    totalCount: number;
+    totalMinutes: number;
+}
+
+export interface ResourceUsage {
+    resourceLimit: ResourceLimit;
+    runningRequests: TaskAgentJobRequest[];
+    usedCount: number;
+    usedMinutes: number;
 }
 
 export interface ResultTransformationDetails {
@@ -412,10 +867,11 @@ export interface SendJobResponse {
 }
 
 export interface ServerExecutionDefinition {
-    events: JobEventsConfig;
+    events: EventsConfig;
+    handlerName: string;
 }
 
-export interface ServerJobRequestMessage extends JobRequestMessage {
+export interface ServerTaskRequestMessage extends JobRequestMessage {
     taskDefinition: TaskDefinition;
     taskInstance: TaskInstance;
 }
@@ -424,18 +880,21 @@ export interface ServerJobRequestMessage extends JobRequestMessage {
  * Represents an endpoint which may be used by an orchestration job.
  */
 export interface ServiceEndpoint {
+    /**
+     * Gets or sets the identity reference for the administrators group of the service endpoint.
+     */
     administratorsGroup: VSSInterfaces.IdentityRef;
     /**
      * Gets or sets the authorization data for talking to the endpoint.
      */
     authorization: EndpointAuthorization;
     /**
-     * The Gets or sets Identity reference for the user who created the Service endpoint
+     * Gets or sets the identity reference for the user who created the Service endpoint.
      */
     createdBy: VSSInterfaces.IdentityRef;
     data: { [key: string] : string; };
     /**
-     * Gets or Sets description of endpoint
+     * Gets or sets the description of endpoint.
      */
     description: string;
     groupScopeId: string;
@@ -455,6 +914,9 @@ export interface ServiceEndpoint {
      * Error message during creation/deletion of endpoint
      */
     operationStatus: any;
+    /**
+     * Gets or sets the identity reference for the readers group of the service endpoint.
+     */
     readersGroup: VSSInterfaces.IdentityRef;
     /**
      * Gets or sets the type of the endpoint.
@@ -467,9 +929,25 @@ export interface ServiceEndpoint {
 }
 
 export interface ServiceEndpointAuthenticationScheme {
+    /**
+     * Gets or sets the authorization headers of service endpoint authentication scheme.
+     */
     authorizationHeaders: AuthorizationHeader[];
+    /**
+     * Gets or sets the certificates of service endpoint authentication scheme.
+     */
+    clientCertificates: ClientCertificate[];
+    /**
+     * Gets or sets the display name for the service endpoint authentication scheme.
+     */
     displayName: string;
+    /**
+     * Gets or sets the input descriptors for the service endpoint authentication scheme.
+     */
     inputDescriptors: FormInputInterfaces.InputDescriptor[];
+    /**
+     * Gets or sets the scheme for service endpoint authentication.
+     */
     scheme: string;
 }
 
@@ -478,6 +956,56 @@ export interface ServiceEndpointDetails {
     data: { [key: string] : string; };
     type: string;
     url: string;
+}
+
+/**
+ * Represents service endpoint execution data.
+ */
+export interface ServiceEndpointExecutionData {
+    /**
+     * Gets the definition of service endpoint execution owner.
+     */
+    definition: TaskOrchestrationOwner;
+    /**
+     * Gets the finish time of service endpoint execution.
+     */
+    finishTime: Date;
+    /**
+     * Gets the Id of service endpoint execution data.
+     */
+    id: number;
+    /**
+     * Gets the owner of service endpoint execution data.
+     */
+    owner: TaskOrchestrationOwner;
+    /**
+     * Gets the plan type of service endpoint execution data.
+     */
+    planType: string;
+    /**
+     * Gets the result of service endpoint execution.
+     */
+    result: TaskResult;
+    /**
+     * Gets the start time of service endpoint execution.
+     */
+    startTime: Date;
+}
+
+export interface ServiceEndpointExecutionRecord {
+    /**
+     * Gets the execution data of service endpoint execution.
+     */
+    data: ServiceEndpointExecutionData;
+    /**
+     * Gets the Id of service endpoint.
+     */
+    endpointId: string;
+}
+
+export interface ServiceEndpointExecutionRecordsInput {
+    data: ServiceEndpointExecutionData;
+    endpointIds: string[];
 }
 
 export interface ServiceEndpointRequest {
@@ -492,18 +1020,59 @@ export interface ServiceEndpointRequestResult {
     statusCode: string;
 }
 
+/**
+ * Represents type of the service endpoint.
+ */
 export interface ServiceEndpointType {
+    /**
+     * Authentication scheme of service endpoint type.
+     */
     authenticationSchemes: ServiceEndpointAuthenticationScheme[];
+    /**
+     * Data sources of service endpoint type.
+     */
     dataSources: DataSource[];
+    /**
+     * Dependency data of service endpoint type.
+     */
     dependencyData: DependencyData[];
+    /**
+     * Gets or sets the description of service endpoint type.
+     */
     description: string;
+    /**
+     * Gets or sets the display name of service endpoint type.
+     */
     displayName: string;
+    /**
+     * Gets or sets the endpoint url of service endpoint type.
+     */
     endpointUrl: EndpointUrl;
+    /**
+     * Gets or sets the help link of service endpoint type.
+     */
     helpLink: HelpLink;
     helpMarkDown: string;
+    /**
+     * Gets or sets the icon url of service endpoint type.
+     */
     iconUrl: string;
+    /**
+     * Input descriptor of service endpoint type.
+     */
     inputDescriptors: FormInputInterfaces.InputDescriptor[];
+    /**
+     * Gets or sets the name of service endpoint type.
+     */
     name: string;
+    /**
+     * Trusted hosts of a service endpoint type.
+     */
+    trustedHosts: string[];
+    /**
+     * Gets or sets the ui contribution id of service endpoint type.
+     */
+    uiContributionId: string;
 }
 
 export interface TaskAgent extends TaskAgentReference {
@@ -519,6 +1088,10 @@ export interface TaskAgent extends TaskAgentReference {
      * Gets the date on which this agent was created.
      */
     createdOn: Date;
+    /**
+     * Gets the last request which was completed by this agent.
+     */
+    lastCompletedRequest: TaskAgentJobRequest;
     /**
      * Gets or sets the maximum job parallelism allowed on this host.
      */
@@ -554,11 +1127,63 @@ export interface TaskAgentAuthorization {
     publicKey: TaskAgentPublicKey;
 }
 
+export interface TaskAgentCloud {
+    /**
+     * Gets or sets a AcquireAgentEndpoint using which a request can be made to acquire new agent
+     */
+    acquireAgentEndpoint: string;
+    agentCloudId: number;
+    getAgentDefinitionEndpoint: string;
+    getAgentRequestStatusEndpoint: string;
+    name: string;
+    releaseAgentEndpoint: string;
+    /**
+     * Gets or sets the type of the endpoint.
+     */
+    type: string;
+}
+
+export interface TaskAgentCloudRequest {
+    agent: TaskAgentReference;
+    agentCloudId: number;
+    agentConnectedTime: Date;
+    agentData: any;
+    agentSpecification: any;
+    pool: TaskAgentPoolReference;
+    provisionedTime: Date;
+    provisionRequestTime: Date;
+    releaseRequestTime: Date;
+    requestId: string;
+}
+
+export interface TaskAgentCloudType {
+    /**
+     * Gets or sets the display name of agnet cloud type.
+     */
+    displayName: string;
+    /**
+     * Gets or sets the input descriptors
+     */
+    inputDescriptors: FormInputInterfaces.InputDescriptor[];
+    /**
+     * Gets or sets the name of agent cloud type.
+     */
+    name: string;
+}
+
+export interface TaskAgentDelaySource {
+    delays: any[];
+    taskAgent: TaskAgentReference;
+}
+
 export interface TaskAgentJobRequest {
+    agentDelays: TaskAgentDelaySource[];
+    agentSpecification: any;
     assignTime: Date;
     data: { [key: string] : string; };
     definition: TaskOrchestrationOwner;
     demands: any[];
+    expectedDuration: any;
     finishTime: Date;
     hostId: string;
     jobId: string;
@@ -566,8 +1191,11 @@ export interface TaskAgentJobRequest {
     lockedUntil: Date;
     matchedAgents: TaskAgentReference[];
     owner: TaskOrchestrationOwner;
+    planGroup: string;
     planId: string;
     planType: string;
+    poolId: number;
+    queueId: number;
     queueTime: Date;
     receiveTime: Date;
     requestId: number;
@@ -578,11 +1206,36 @@ export interface TaskAgentJobRequest {
 }
 
 /**
+ * This is useful in getting a list of deployment targets, filtered by the result of their last job.
+ */
+export enum TaskAgentJobResultFilter {
+    /**
+     * Only those deployment targets on which last job failed (**Abandoned**, **Canceled**, **Failed**, **Skipped**).
+     */
+    Failed = 1,
+    /**
+     * Only those deployment targets on which last job Passed (**Succeeded**, **Succeeded with issues**).
+     */
+    Passed = 2,
+    /**
+     * Only those deployment targets that never executed a job.
+     */
+    NeverDeployed = 4,
+    /**
+     * All deployment targets.
+     */
+    All = 7,
+}
+
+export interface TaskAgentManualUpdate extends TaskAgentUpdateReason {
+}
+
+/**
  * Provides a contract for receiving messages from the task orchestrator.
  */
 export interface TaskAgentMessage {
     /**
-     * Gets or sets the body of the message. If the IV property is provided the body will need to be decrypted using the TaskAgentSession.EncryptionKey value in addition to the IV.
+     * Gets or sets the body of the message. If the <c>IV</c> property is provided the body will need to be decrypted using the <c>TaskAgentSession.EncryptionKey</c> value in addition to the <c>IV</c>.
      */
     body: string;
     /**
@@ -594,20 +1247,30 @@ export interface TaskAgentMessage {
      */
     messageId: number;
     /**
-     * Gets or sets the message type, describing the data contract found in TaskAgentMessage.Body.
+     * Gets or sets the message type, describing the data contract found in <c>TaskAgentMessage.Body</c>.
      */
     messageType: string;
 }
 
+export interface TaskAgentMinAgentVersionRequiredUpdate extends TaskAgentUpdateReason {
+    jobDefinition: TaskOrchestrationOwner;
+    jobOwner: TaskOrchestrationOwner;
+    minAgentVersion: any;
+}
+
 export interface TaskAgentPool extends TaskAgentPoolReference {
     /**
-     * Gets the administrators group for this agent pool.
+     * Gets or sets an agentCloudId
      */
-    administratorsGroup: VSSInterfaces.IdentityRef;
+    agentCloudId: number;
     /**
      * Gets or sets a value indicating whether or not a queue should be automatically provisioned for each project collection or not.
      */
     autoProvision: boolean;
+    /**
+     * Gets or sets a value indicating whether or not the pool should autosize itself based on the Agent Cloud Provider settings
+     */
+    autoSize: boolean;
     /**
      * Gets the identity who created this pool. The creator of the pool is automatically added into the administrators group for the pool on creation.
      */
@@ -617,22 +1280,10 @@ export interface TaskAgentPool extends TaskAgentPoolReference {
      */
     createdOn: Date;
     /**
-     * Gets the scope identifier for groups/roles which are owned by this pool.
+     * Gets the identity who owns or administrates this pool.
      */
-    groupScopeId: string;
+    owner: VSSInterfaces.IdentityRef;
     properties: any;
-    /**
-     * Gets a value indicating whether or not roles have been provisioned for this pool.
-     */
-    provisioned: boolean;
-    /**
-     * Gets the service accounts group for this agent pool.
-     */
-    serviceAccountsGroup: VSSInterfaces.IdentityRef;
-    /**
-     * Gets the current size of the pool.
-     */
-    size: number;
 }
 
 export enum TaskAgentPoolActionFilter {
@@ -716,7 +1367,7 @@ export interface TaskAgentPoolMaintenanceJob {
      * Status of the maintenance job
      */
     status: TaskAgentPoolMaintenanceJobStatus;
-    targetAgents: TaskAgentReference[];
+    targetAgents: TaskAgentPoolMaintenanceJobTargetAgent[];
     /**
      * The total warning counts during the maintenance job
      */
@@ -734,6 +1385,13 @@ export enum TaskAgentPoolMaintenanceJobStatus {
     Completed = 2,
     Cancelling = 4,
     Queued = 8,
+}
+
+export interface TaskAgentPoolMaintenanceJobTargetAgent {
+    agent: TaskAgentReference;
+    jobId: number;
+    result: TaskAgentPoolMaintenanceJobResult;
+    status: TaskAgentPoolMaintenanceJobStatus;
 }
 
 export interface TaskAgentPoolMaintenanceOptions {
@@ -824,6 +1482,18 @@ export interface TaskAgentPoolReference {
      */
     poolType: TaskAgentPoolType;
     scope: string;
+    /**
+     * Gets the current size of the pool.
+     */
+    size: number;
+}
+
+export interface TaskAgentPoolSummary {
+    columnsHeader: MetricsColumnsHeader;
+    deploymentGroups: DeploymentGroupReference[];
+    pool: TaskAgentPoolReference;
+    queues: TaskAgentQueue[];
+    rows: MetricsRow[];
 }
 
 export enum TaskAgentPoolType {
@@ -846,12 +1516,22 @@ export interface TaskAgentPublicKey {
 }
 
 export interface TaskAgentQueue {
-    groupScopeId: string;
+    /**
+     * Id of the queue
+     */
     id: number;
+    /**
+     * Name of the queue
+     */
     name: string;
+    /**
+     * Pool reference for this queue
+     */
     pool: TaskAgentPoolReference;
+    /**
+     * Project Id
+     */
     projectId: string;
-    provisioned: boolean;
 }
 
 export enum TaskAgentQueueActionFilter {
@@ -862,6 +1542,10 @@ export enum TaskAgentQueueActionFilter {
 
 export interface TaskAgentReference {
     _links: any;
+    /**
+     * Gets the access point of the agent.
+     */
+    accessPoint: string;
     /**
      * Gets or sets a value indicating whether or not this agent should be enabled for job execution.
      */
@@ -874,6 +1558,14 @@ export interface TaskAgentReference {
      * Gets the name of the agent.
      */
     name: string;
+    /**
+     * Gets the OS of the agent.
+     */
+    oSDescription: string;
+    /**
+     * Gets or sets the current provisioning state of this agent
+     */
+    provisioningState: string;
     /**
      * Gets the current connectivity status of the agent.
      */
@@ -912,7 +1604,7 @@ export interface TaskAgentSession {
  */
 export interface TaskAgentSessionKey {
     /**
-     * Gets or sets a value indicating whether or not the key value is encrypted. If this value is true, the property should be decrypted using the RSA key exchanged with the server during registration.
+     * Gets or sets a value indicating whether or not the key value is encrypted. If this value is true, the Value property should be decrypted using the <c>RSA</c> key exchanged with the server during registration.
      */
     encrypted: boolean;
     /**
@@ -926,11 +1618,33 @@ export enum TaskAgentStatus {
     Online = 2,
 }
 
+/**
+ * This is useful in getting a list of deployment targets, filtered by the deployment agent status.
+ */
+export enum TaskAgentStatusFilter {
+    /**
+     * Only deployment targets that are offline.
+     */
+    Offline = 1,
+    /**
+     * Only deployment targets that are online.
+     */
+    Online = 2,
+    /**
+     * All deployment targets.
+     */
+    All = 3,
+}
+
 export interface TaskAgentUpdate {
     /**
      * The current state of this agent update
      */
     currentState: string;
+    /**
+     * The reason of this agent update
+     */
+    reason: TaskAgentUpdateReason;
     /**
      * The identity that request the agent update
      */
@@ -949,6 +1663,18 @@ export interface TaskAgentUpdate {
     targetVersion: PackageVersion;
 }
 
+export interface TaskAgentUpdateReason {
+    code: TaskAgentUpdateReasonType;
+}
+
+export enum TaskAgentUpdateReasonType {
+    Manual = 1,
+    MinAgentVersionRequired = 2,
+}
+
+export interface TaskAssignedEvent extends TaskEvent {
+}
+
 export interface TaskAttachment {
     _links: any;
     createdOn: Date;
@@ -960,7 +1686,8 @@ export interface TaskAttachment {
     type: string;
 }
 
-export interface TaskChangeEvent {
+export interface TaskCompletedEvent extends TaskEvent {
+    result: TaskResult;
 }
 
 export interface TaskDefinition {
@@ -973,6 +1700,7 @@ export interface TaskDefinition {
     dataSourceBindings: DataSourceBinding[];
     definitionType: string;
     demands: any[];
+    deprecated: boolean;
     description: string;
     disabled: boolean;
     execution: { [key: string] : any; };
@@ -986,12 +1714,17 @@ export interface TaskDefinition {
     instanceNameFormat: string;
     minimumAgentVersion: string;
     name: string;
+    outputVariables: TaskOutputVariable[];
     packageLocation: string;
     packageType: string;
+    postJobExecution: { [key: string] : any; };
+    preJobExecution: { [key: string] : any; };
     preview: boolean;
     releaseNotes: string;
     runsOn: string[];
+    satisfies: string[];
     serverOwned: boolean;
+    showEnvironmentVariables: boolean;
     sourceDefinitions: TaskSourceDefinition[];
     sourceLocation: string;
     version: TaskVersion;
@@ -1004,7 +1737,7 @@ export interface TaskDefinitionEndpoint {
      */
     connectionId: string;
     /**
-     * An Json based keyselector to filter response returned by fetching the endpoint Url.A Json based keyselector must be prefixed with "jsonpath:". KeySelector can be used to specify the filter to get the keys for the values specified with Selector.  The following keyselector defines an Json for extracting nodes named 'ServiceName'.  endpoint.KeySelector = "jsonpath://ServiceName";
+     * An Json based keyselector to filter response returned by fetching the endpoint <c>Url</c>.A Json based keyselector must be prefixed with "jsonpath:". KeySelector can be used to specify the filter to get the keys for the values specified with Selector. <example> The following keyselector defines an Json for extracting nodes named 'ServiceName'. <code> endpoint.KeySelector = "jsonpath://ServiceName"; </code></example>
      */
     keySelector: string;
     /**
@@ -1012,7 +1745,7 @@ export interface TaskDefinitionEndpoint {
      */
     scope: string;
     /**
-     * An XPath/Json based selector to filter response returned by fetching the endpoint Url. An XPath based selector must be prefixed with the string "xpath:". A Json based selector must be prefixed with "jsonpath:".  The following selector defines an XPath for extracting nodes named 'ServiceName'.  endpoint.Selector = "xpath://ServiceName";
+     * An XPath/Json based selector to filter response returned by fetching the endpoint <c>Url</c>. An XPath based selector must be prefixed with the string "xpath:". A Json based selector must be prefixed with "jsonpath:". <example> The following selector defines an XPath for extracting nodes named 'ServiceName'. <code> endpoint.Selector = "xpath://ServiceName"; </code></example>
      */
     selector: string;
     /**
@@ -1026,8 +1759,17 @@ export interface TaskDefinitionEndpoint {
 }
 
 export interface TaskDefinitionReference {
+    /**
+     * Gets or sets the definition type. Values can be 'task' or 'metaTask'.
+     */
     definitionType: string;
+    /**
+     * Gets or sets the unique identifier of task.
+     */
     id: string;
+    /**
+     * Gets or sets the version specification of task.
+     */
     versionSpec: string;
 }
 
@@ -1043,6 +1785,10 @@ export enum TaskDefinitionStatus {
     InlineUpdateReceived = 9,
 }
 
+export interface TaskEvent extends JobEvent {
+    taskId: string;
+}
+
 export interface TaskExecution {
     /**
      * The utility task to run.  Specifying this means that this task definition is simply a meta task to call another task. This is useful for tasks that call utility tasks like powershell and commandline
@@ -1055,14 +1801,97 @@ export interface TaskExecution {
 }
 
 export interface TaskGroup extends TaskDefinition {
+    /**
+     * Gets or sets comment.
+     */
     comment: string;
+    /**
+     * Gets or sets the identity who created.
+     */
     createdBy: VSSInterfaces.IdentityRef;
+    /**
+     * Gets or sets date on which it got created.
+     */
     createdOn: Date;
+    /**
+     * Gets or sets as 'true' to indicate as deleted, 'false' otherwise.
+     */
+    deleted: boolean;
+    /**
+     * Gets or sets the identity who modified.
+     */
     modifiedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Gets or sets date on which it got modified.
+     */
     modifiedOn: Date;
+    /**
+     * Gets or sets the owner.
+     */
     owner: string;
+    /**
+     * Gets or sets parent task group Id. This is used while creating a draft task group.
+     */
+    parentDefinitionId: string;
+    /**
+     * Gets or sets revision.
+     */
     revision: number;
+    /**
+     * Gets or sets the tasks.
+     */
     tasks: TaskGroupStep[];
+}
+
+export interface TaskGroupCreateParameter {
+    /**
+     * Sets author name of the task group.
+     */
+    author: string;
+    /**
+     * Sets category of the task group.
+     */
+    category: string;
+    /**
+     * Sets description of the task group.
+     */
+    description: string;
+    /**
+     * Sets friendly name of the task group.
+     */
+    friendlyName: string;
+    /**
+     * Sets url icon of the task group.
+     */
+    iconUrl: string;
+    /**
+     * Sets input for the task group.
+     */
+    inputs: TaskInputDefinition[];
+    /**
+     * Sets display name of the task group.
+     */
+    instanceNameFormat: string;
+    /**
+     * Sets name of the task group.
+     */
+    name: string;
+    /**
+     * Sets parent task group Id. This is used while creating a draft task group.
+     */
+    parentDefinitionId: string;
+    /**
+     * Sets RunsOn of the task group. Value can be 'Agent', 'Server' or 'DeploymentGroup'.
+     */
+    runsOn: string[];
+    /**
+     * Sets tasks for the task group.
+     */
+    tasks: TaskGroupStep[];
+    /**
+     * Sets version of the task group.
+     */
+    version: TaskVersion;
 }
 
 export interface TaskGroupDefinition {
@@ -1071,6 +1900,25 @@ export interface TaskGroupDefinition {
     name: string;
     tags: string[];
     visibleRule: string;
+}
+
+export enum TaskGroupExpands {
+    None = 0,
+    Tasks = 2,
+}
+
+/**
+ * Specifies the desired ordering of taskGroups.
+ */
+export enum TaskGroupQueryOrder {
+    /**
+     * Order by createdon ascending.
+     */
+    CreatedOnAscending = 0,
+    /**
+     * Order by createdon descending.
+     */
+    CreatedOnDescending = 1,
 }
 
 export interface TaskGroupRevision {
@@ -1083,26 +1931,129 @@ export interface TaskGroupRevision {
     taskGroupId: string;
 }
 
+/**
+ * Represents tasks in the task group.
+ */
 export interface TaskGroupStep {
+    /**
+     * Gets or sets as 'true' to run the task always, 'false' otherwise.
+     */
     alwaysRun: boolean;
+    /**
+     * Gets or sets condition for the task.
+     */
+    condition: string;
+    /**
+     * Gets or sets as 'true' to continue on error, 'false' otherwise.
+     */
     continueOnError: boolean;
+    /**
+     * Gets or sets the display name.
+     */
     displayName: string;
+    /**
+     * Gets or sets as task is enabled or not.
+     */
     enabled: boolean;
+    /**
+     * Gets or sets dictionary of inputs.
+     */
     inputs: { [key: string] : string; };
+    /**
+     * Gets or sets the reference of the task.
+     */
     task: TaskDefinitionReference;
+    /**
+     * Gets or sets the maximum time, in minutes, that a task is allowed to execute on agent before being cancelled by server. A zero value indicates an infinite timeout.
+     */
     timeoutInMinutes: number;
+}
+
+export interface TaskGroupUpdateParameter {
+    /**
+     * Sets author name of the task group.
+     */
+    author: string;
+    /**
+     * Sets category of the task group.
+     */
+    category: string;
+    /**
+     * Sets comment of the task group.
+     */
+    comment: string;
+    /**
+     * Sets description of the task group.
+     */
+    description: string;
+    /**
+     * Sets friendly name of the task group.
+     */
+    friendlyName: string;
+    /**
+     * Sets url icon of the task group.
+     */
+    iconUrl: string;
+    /**
+     * Sets the unique identifier of this field.
+     */
+    id: string;
+    /**
+     * Sets input for the task group.
+     */
+    inputs: TaskInputDefinition[];
+    /**
+     * Sets display name of the task group.
+     */
+    instanceNameFormat: string;
+    /**
+     * Sets name of the task group.
+     */
+    name: string;
+    /**
+     * Gets or sets parent task group Id. This is used while creating a draft task group.
+     */
+    parentDefinitionId: string;
+    /**
+     * Sets revision of the task group.
+     */
+    revision: number;
+    /**
+     * Sets RunsOn of the task group. Value can be 'Agent', 'Server' or 'DeploymentGroup'.
+     */
+    runsOn: string[];
+    /**
+     * Sets tasks for the task group.
+     */
+    tasks: TaskGroupStep[];
+    /**
+     * Sets version of the task group.
+     */
+    version: TaskVersion;
 }
 
 export interface TaskHubLicenseDetails {
     enterpriseUsersCount: number;
+    failedToReachAllProviders: boolean;
+    freeHostedLicenseCount: number;
     freeLicenseCount: number;
     hasLicenseCountEverUpdated: boolean;
     hostedAgentMinutesFreeCount: number;
     hostedAgentMinutesUsedCount: number;
+    hostedLicensesArePremium: boolean;
+    marketplacePurchasedHostedLicenses: MarketplacePurchasedLicense[];
     msdnUsersCount: number;
+    /**
+     * Microsoft-hosted licenses purchased from VSTS directly.
+     */
     purchasedHostedLicenseCount: number;
+    /**
+     * Self-hosted licenses purchased from VSTS directly.
+     */
     purchasedLicenseCount: number;
+    totalHostedLicenseCount: number;
     totalLicenseCount: number;
+    totalPrivateLicenseCount: number;
 }
 
 export interface TaskInputDefinition extends DistributedTaskCommonInterfaces.TaskInputDefinitionBase {
@@ -1114,7 +2065,9 @@ export interface TaskInstance extends TaskReference {
     continueOnError: boolean;
     displayName: string;
     enabled: boolean;
+    environment: { [key: string] : string; };
     instanceId: string;
+    refName: string;
     timeoutInMinutes: number;
 }
 
@@ -1156,6 +2109,7 @@ export interface TaskOrchestrationJob extends TaskOrchestrationItem {
     executionTimeout: any;
     instanceId: string;
     name: string;
+    refName: string;
     tasks: TaskInstance[];
     variables: { [key: string] : string; };
 }
@@ -1170,7 +2124,6 @@ export interface TaskOrchestrationPlan extends TaskOrchestrationPlanReference {
     environment: PlanEnvironment;
     finishTime: Date;
     implementation: TaskOrchestrationContainer;
-    planGroup: string;
     requestedById: string;
     requestedForId: string;
     result: TaskResult;
@@ -1180,11 +2133,23 @@ export interface TaskOrchestrationPlan extends TaskOrchestrationPlanReference {
     timeline: TimelineReference;
 }
 
+export interface TaskOrchestrationPlanGroup {
+    planGroup: string;
+    project: ProjectReference;
+    runningRequests: TaskAgentJobRequest[];
+}
+
+export interface TaskOrchestrationPlanGroupsQueueMetrics {
+    count: number;
+    status: PlanGroupStatus;
+}
+
 export interface TaskOrchestrationPlanReference {
     artifactLocation: string;
     artifactUri: string;
     definition: TaskOrchestrationOwner;
     owner: TaskOrchestrationOwner;
+    planGroup: string;
     planId: string;
     planType: string;
     scopeIdentifier: string;
@@ -1216,6 +2181,11 @@ export interface TaskOrchestrationQueuedPlanGroup {
     plans: TaskOrchestrationQueuedPlan[];
     project: ProjectReference;
     queuePosition: number;
+}
+
+export interface TaskOutputVariable {
+    description: string;
+    name: string;
 }
 
 export interface TaskPackageMetadata {
@@ -1252,6 +2222,9 @@ export enum TaskResult {
 export interface TaskSourceDefinition extends DistributedTaskCommonInterfaces.TaskSourceDefinitionBase {
 }
 
+export interface TaskStartedEvent extends TaskEvent {
+}
+
 export interface TaskVersion {
     isTest: boolean;
     major: number;
@@ -1280,14 +2253,22 @@ export interface TimelineRecord {
     order: number;
     parentId: string;
     percentComplete: number;
+    refName: string;
     result: TaskResult;
     resultCode: string;
     startTime: Date;
     state: TimelineRecordState;
     task: TaskReference;
     type: string;
+    variables: { [key: string] : VariableValue; };
     warningCount: number;
     workerName: string;
+}
+
+export interface TimelineRecordFeedLinesWrapper {
+    count: number;
+    stepId: string;
+    value: string[];
 }
 
 export enum TimelineRecordState {
@@ -1302,14 +2283,68 @@ export interface TimelineReference {
     location: string;
 }
 
+export interface ValidationItem {
+    /**
+     * Tells whether the current input is valid or not
+     */
+    isValid: boolean;
+    /**
+     * Reason for input validation failure
+     */
+    reason: string;
+    /**
+     * Type of validation item
+     */
+    type: string;
+    /**
+     * Value to validate. The conditional expression to validate for the input for "expression" type Eg:eq(variables['Build.SourceBranch'], 'refs/heads/master');eq(value, 'refs/heads/master')
+     */
+    value: string;
+}
+
+/**
+ * A variable group is a collection of related variables.
+ */
 export interface VariableGroup {
+    /**
+     * Gets or sets the identity who created the variable group.
+     */
     createdBy: VSSInterfaces.IdentityRef;
+    /**
+     * Gets or sets the time when variable group was created.
+     */
     createdOn: Date;
+    /**
+     * Gets or sets description of the variable group.
+     */
     description: string;
+    /**
+     * Gets or sets id of the variable group.
+     */
     id: number;
+    /**
+     * Gets or sets the identity who modified the variable group.
+     */
     modifiedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Gets or sets the time when variable group was modified
+     */
     modifiedOn: Date;
+    /**
+     * Gets or sets name of the variable group.
+     */
     name: string;
+    /**
+     * Gets or sets provider data.
+     */
+    providerData: VariableGroupProviderData;
+    /**
+     * Gets or sets type of the variable group.
+     */
+    type: string;
+    /**
+     * Gets or sets variables contained in the variable group.
+     */
     variables: { [key: string] : VariableValue; };
 }
 
@@ -1317,6 +2352,49 @@ export enum VariableGroupActionFilter {
     None = 0,
     Manage = 2,
     Use = 16,
+}
+
+export interface VariableGroupParameters {
+    /**
+     * Sets description of the variable group.
+     */
+    description: string;
+    /**
+     * Sets name of the variable group.
+     */
+    name: string;
+    /**
+     * Sets provider data.
+     */
+    providerData: VariableGroupProviderData;
+    /**
+     * Sets type of the variable group.
+     */
+    type: string;
+    /**
+     * Sets variables contained in the variable group.
+     */
+    variables: { [key: string] : VariableValue; };
+}
+
+/**
+ * Defines provider data of the variable group.
+ */
+export interface VariableGroupProviderData {
+}
+
+/**
+ * Specifies the desired ordering of variableGroups.
+ */
+export enum VariableGroupQueryOrder {
+    /**
+     * Order by id ascending.
+     */
+    IdAscending = 0,
+    /**
+     * Order by id descending.
+     */
+    IdDescending = 1,
 }
 
 export interface VariableValue {
@@ -1330,7 +2408,8 @@ export var TypeInfo = {
             "noOption": 0,
             "login": 1,
             "selectAccount": 2,
-            "freshLogin": 3
+            "freshLogin": 3,
+            "freshLoginWithMfa": 4
         }
     },
     AgentChangeEvent: <any>{
@@ -1343,14 +2422,17 @@ export var TypeInfo = {
     },
     AgentQueuesEvent: <any>{
     },
-    AgentRequestEvent: <any>{
-    },
     AuditAction: {
         enumValues: {
             "add": 1,
             "update": 2,
-            "delete": 3
+            "delete": 3,
+            "undelete": 4
         }
+    },
+    AzureKeyVaultVariableGroupProviderData: <any>{
+    },
+    AzureKeyVaultVariableValue: <any>{
     },
     DeploymentGroup: <any>{
     },
@@ -1364,18 +2446,46 @@ export var TypeInfo = {
     DeploymentGroupExpands: {
         enumValues: {
             "none": 0,
-            "machines": 2
+            "machines": 2,
+            "tags": 4
         }
+    },
+    DeploymentGroupMetrics: <any>{
     },
     DeploymentGroupReference: <any>{
     },
     DeploymentMachine: <any>{
+    },
+    DeploymentMachineChangedData: <any>{
+    },
+    DeploymentMachineExpands: {
+        enumValues: {
+            "none": 0,
+            "capabilities": 2,
+            "assignedRequest": 4
+        }
     },
     DeploymentMachineGroup: <any>{
     },
     DeploymentMachineGroupReference: <any>{
     },
     DeploymentMachinesChangeEvent: <any>{
+    },
+    DeploymentPoolSummary: <any>{
+    },
+    DeploymentPoolSummaryExpands: {
+        enumValues: {
+            "none": 0,
+            "deploymentGroups": 2
+        }
+    },
+    DeploymentTargetExpands: {
+        enumValues: {
+            "none": 0,
+            "capabilities": 2,
+            "assignedRequest": 4,
+            "lastCompletedRequest": 8
+        }
     },
     Issue: <any>{
     },
@@ -1412,12 +2522,21 @@ export var TypeInfo = {
     },
     PlanEnvironment: <any>{
     },
+    PlanGroupStatus: {
+        enumValues: {
+            "running": 1,
+            "queued": 2,
+            "all": 3
+        }
+    },
     PlanGroupStatusFilter: {
         enumValues: {
             "running": 1,
             "queued": 2,
             "all": 3
         }
+    },
+    ResourceUsage: <any>{
     },
     SecureFile: <any>{
     },
@@ -1428,9 +2547,15 @@ export var TypeInfo = {
             "use": 16
         }
     },
-    ServerJobRequestMessage: <any>{
+    ServerTaskRequestMessage: <any>{
     },
     ServiceEndpointAuthenticationScheme: <any>{
+    },
+    ServiceEndpointExecutionData: <any>{
+    },
+    ServiceEndpointExecutionRecord: <any>{
+    },
+    ServiceEndpointExecutionRecordsInput: <any>{
     },
     ServiceEndpointRequestResult: <any>{
     },
@@ -1438,7 +2563,25 @@ export var TypeInfo = {
     },
     TaskAgent: <any>{
     },
+    TaskAgentCloudRequest: <any>{
+    },
+    TaskAgentCloudType: <any>{
+    },
+    TaskAgentDelaySource: <any>{
+    },
     TaskAgentJobRequest: <any>{
+    },
+    TaskAgentJobResultFilter: {
+        enumValues: {
+            "failed": 1,
+            "passed": 2,
+            "neverDeployed": 4,
+            "all": 7
+        }
+    },
+    TaskAgentManualUpdate: <any>{
+    },
+    TaskAgentMinAgentVersionRequiredUpdate: <any>{
     },
     TaskAgentPool: <any>{
     },
@@ -1468,6 +2611,8 @@ export var TypeInfo = {
             "queued": 8
         }
     },
+    TaskAgentPoolMaintenanceJobTargetAgent: <any>{
+    },
     TaskAgentPoolMaintenanceSchedule: <any>{
     },
     TaskAgentPoolMaintenanceScheduleDays: {
@@ -1484,6 +2629,8 @@ export var TypeInfo = {
         }
     },
     TaskAgentPoolReference: <any>{
+    },
+    TaskAgentPoolSummary: <any>{
     },
     TaskAgentPoolType: {
         enumValues: {
@@ -1510,9 +2657,26 @@ export var TypeInfo = {
             "online": 2
         }
     },
+    TaskAgentStatusFilter: {
+        enumValues: {
+            "offline": 1,
+            "online": 2,
+            "all": 3
+        }
+    },
     TaskAgentUpdate: <any>{
     },
+    TaskAgentUpdateReason: <any>{
+    },
+    TaskAgentUpdateReasonType: {
+        enumValues: {
+            "manual": 1,
+            "minAgentVersionRequired": 2
+        }
+    },
     TaskAttachment: <any>{
+    },
+    TaskCompletedEvent: <any>{
     },
     TaskDefinitionStatus: {
         enumValues: {
@@ -1528,6 +2692,18 @@ export var TypeInfo = {
         }
     },
     TaskGroup: <any>{
+    },
+    TaskGroupExpands: {
+        enumValues: {
+            "none": 0,
+            "tasks": 2
+        }
+    },
+    TaskGroupQueryOrder: {
+        enumValues: {
+            "createdOnAscending": 0,
+            "createdOnDescending": 1
+        }
     },
     TaskGroupRevision: <any>{
     },
@@ -1546,6 +2722,10 @@ export var TypeInfo = {
     TaskOrchestrationJob: <any>{
     },
     TaskOrchestrationPlan: <any>{
+    },
+    TaskOrchestrationPlanGroup: <any>{
+    },
+    TaskOrchestrationPlanGroupsQueueMetrics: <any>{
     },
     TaskOrchestrationPlanState: {
         enumValues: {
@@ -1588,6 +2768,12 @@ export var TypeInfo = {
             "use": 16
         }
     },
+    VariableGroupQueryOrder: {
+        enumValues: {
+            "idAscending": 0,
+            "idDescending": 1
+        }
+    },
 };
 
 TypeInfo.AgentChangeEvent.fields = {
@@ -1599,7 +2785,7 @@ TypeInfo.AgentChangeEvent.fields = {
     },
     timeStamp: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.AgentJobRequestMessage.fields = {
@@ -1608,35 +2794,38 @@ TypeInfo.AgentJobRequestMessage.fields = {
     },
     lockedUntil: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.AgentPoolEvent.fields = {
     pool: {
         typeInfo: TypeInfo.TaskAgentPool
-    },
+    }
 };
 
 TypeInfo.AgentQueueEvent.fields = {
     queue: {
         typeInfo: TypeInfo.TaskAgentQueue
-    },
+    }
 };
 
 TypeInfo.AgentQueuesEvent.fields = {
     queues: {
         isArray: true,
         typeInfo: TypeInfo.TaskAgentQueue
-    },
+    }
 };
 
-TypeInfo.AgentRequestEvent.fields = {
-    result: {
-        enumType: TypeInfo.TaskResult
-    },
-    timeStamp: {
+TypeInfo.AzureKeyVaultVariableGroupProviderData.fields = {
+    lastRefreshedOn: {
         isDate: true,
-    },
+    }
+};
+
+TypeInfo.AzureKeyVaultVariableValue.fields = {
+    expires: {
+        isDate: true,
+    }
 };
 
 TypeInfo.DeploymentGroup.fields = {
@@ -1646,19 +2835,31 @@ TypeInfo.DeploymentGroup.fields = {
     },
     pool: {
         typeInfo: TypeInfo.TaskAgentPoolReference
-    },
+    }
+};
+
+TypeInfo.DeploymentGroupMetrics.fields = {
+    deploymentGroup: {
+        typeInfo: TypeInfo.DeploymentGroupReference
+    }
 };
 
 TypeInfo.DeploymentGroupReference.fields = {
     pool: {
         typeInfo: TypeInfo.TaskAgentPoolReference
-    },
+    }
 };
 
 TypeInfo.DeploymentMachine.fields = {
     agent: {
-        typeInfo: TypeInfo.TaskAgentReference
-    },
+        typeInfo: TypeInfo.TaskAgent
+    }
+};
+
+TypeInfo.DeploymentMachineChangedData.fields = {
+    agent: {
+        typeInfo: TypeInfo.TaskAgent
+    }
 };
 
 TypeInfo.DeploymentMachineGroup.fields = {
@@ -1668,13 +2869,13 @@ TypeInfo.DeploymentMachineGroup.fields = {
     },
     pool: {
         typeInfo: TypeInfo.TaskAgentPoolReference
-    },
+    }
 };
 
 TypeInfo.DeploymentMachineGroupReference.fields = {
     pool: {
         typeInfo: TypeInfo.TaskAgentPoolReference
-    },
+    }
 };
 
 TypeInfo.DeploymentMachinesChangeEvent.fields = {
@@ -1683,26 +2884,36 @@ TypeInfo.DeploymentMachinesChangeEvent.fields = {
     },
     machines: {
         isArray: true,
-        typeInfo: TypeInfo.DeploymentMachine
+        typeInfo: TypeInfo.DeploymentMachineChangedData
+    }
+};
+
+TypeInfo.DeploymentPoolSummary.fields = {
+    deploymentGroups: {
+        isArray: true,
+        typeInfo: TypeInfo.DeploymentGroupReference
     },
+    pool: {
+        typeInfo: TypeInfo.TaskAgentPoolReference
+    }
 };
 
 TypeInfo.Issue.fields = {
     type: {
         enumType: TypeInfo.IssueType
-    },
+    }
 };
 
 TypeInfo.JobAssignedEvent.fields = {
     request: {
         typeInfo: TypeInfo.TaskAgentJobRequest
-    },
+    }
 };
 
 TypeInfo.JobCompletedEvent.fields = {
     result: {
         enumType: TypeInfo.TaskResult
-    },
+    }
 };
 
 TypeInfo.JobEnvironment.fields = {
@@ -1713,32 +2924,39 @@ TypeInfo.JobEnvironment.fields = {
     secureFiles: {
         isArray: true,
         typeInfo: TypeInfo.SecureFile
-    },
+    }
 };
 
 TypeInfo.JobRequestMessage.fields = {
     environment: {
         typeInfo: TypeInfo.JobEnvironment
-    },
+    }
 };
 
 TypeInfo.MaskHint.fields = {
     type: {
         enumType: TypeInfo.MaskType
-    },
+    }
 };
 
 TypeInfo.PackageMetadata.fields = {
     createdOn: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.PlanEnvironment.fields = {
     mask: {
         isArray: true,
         typeInfo: TypeInfo.MaskHint
-    },
+    }
+};
+
+TypeInfo.ResourceUsage.fields = {
+    runningRequests: {
+        isArray: true,
+        typeInfo: TypeInfo.TaskAgentJobRequest
+    }
 };
 
 TypeInfo.SecureFile.fields = {
@@ -1747,20 +2965,44 @@ TypeInfo.SecureFile.fields = {
     },
     modifiedOn: {
         isDate: true,
-    },
+    }
 };
 
-TypeInfo.ServerJobRequestMessage.fields = {
+TypeInfo.ServerTaskRequestMessage.fields = {
     environment: {
         typeInfo: TypeInfo.JobEnvironment
-    },
+    }
 };
 
 TypeInfo.ServiceEndpointAuthenticationScheme.fields = {
     inputDescriptors: {
         isArray: true,
         typeInfo: FormInputInterfaces.TypeInfo.InputDescriptor
+    }
+};
+
+TypeInfo.ServiceEndpointExecutionData.fields = {
+    finishTime: {
+        isDate: true,
     },
+    result: {
+        enumType: TypeInfo.TaskResult
+    },
+    startTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.ServiceEndpointExecutionRecord.fields = {
+    data: {
+        typeInfo: TypeInfo.ServiceEndpointExecutionData
+    }
+};
+
+TypeInfo.ServiceEndpointExecutionRecordsInput.fields = {
+    data: {
+        typeInfo: TypeInfo.ServiceEndpointExecutionData
+    }
 };
 
 TypeInfo.ServiceEndpointRequestResult.fields = {
@@ -1774,7 +3016,7 @@ TypeInfo.ServiceEndpointType.fields = {
     inputDescriptors: {
         isArray: true,
         typeInfo: FormInputInterfaces.TypeInfo.InputDescriptor
-    },
+    }
 };
 
 TypeInfo.TaskAgent.fields = {
@@ -1784,6 +3026,9 @@ TypeInfo.TaskAgent.fields = {
     createdOn: {
         isDate: true,
     },
+    lastCompletedRequest: {
+        typeInfo: TypeInfo.TaskAgentJobRequest
+    },
     pendingUpdate: {
         typeInfo: TypeInfo.TaskAgentUpdate
     },
@@ -1792,10 +3037,48 @@ TypeInfo.TaskAgent.fields = {
     },
     statusChangedOn: {
         isDate: true,
+    }
+};
+
+TypeInfo.TaskAgentCloudRequest.fields = {
+    agent: {
+        typeInfo: TypeInfo.TaskAgentReference
     },
+    agentConnectedTime: {
+        isDate: true,
+    },
+    pool: {
+        typeInfo: TypeInfo.TaskAgentPoolReference
+    },
+    provisionedTime: {
+        isDate: true,
+    },
+    provisionRequestTime: {
+        isDate: true,
+    },
+    releaseRequestTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TaskAgentCloudType.fields = {
+    inputDescriptors: {
+        isArray: true,
+        typeInfo: FormInputInterfaces.TypeInfo.InputDescriptor
+    }
+};
+
+TypeInfo.TaskAgentDelaySource.fields = {
+    taskAgent: {
+        typeInfo: TypeInfo.TaskAgentReference
+    }
 };
 
 TypeInfo.TaskAgentJobRequest.fields = {
+    agentDelays: {
+        isArray: true,
+        typeInfo: TypeInfo.TaskAgentDelaySource
+    },
     assignTime: {
         isDate: true,
     },
@@ -1820,7 +3103,19 @@ TypeInfo.TaskAgentJobRequest.fields = {
     },
     result: {
         enumType: TypeInfo.TaskResult
-    },
+    }
+};
+
+TypeInfo.TaskAgentManualUpdate.fields = {
+    code: {
+        enumType: TypeInfo.TaskAgentUpdateReasonType
+    }
+};
+
+TypeInfo.TaskAgentMinAgentVersionRequiredUpdate.fields = {
+    code: {
+        enumType: TypeInfo.TaskAgentUpdateReasonType
+    }
 };
 
 TypeInfo.TaskAgentPool.fields = {
@@ -1829,7 +3124,7 @@ TypeInfo.TaskAgentPool.fields = {
     },
     poolType: {
         enumType: TypeInfo.TaskAgentPoolType
-    },
+    }
 };
 
 TypeInfo.TaskAgentPoolMaintenanceDefinition.fields = {
@@ -1838,7 +3133,7 @@ TypeInfo.TaskAgentPoolMaintenanceDefinition.fields = {
     },
     scheduleSetting: {
         typeInfo: TypeInfo.TaskAgentPoolMaintenanceSchedule
-    },
+    }
 };
 
 TypeInfo.TaskAgentPoolMaintenanceJob.fields = {
@@ -1862,44 +3157,79 @@ TypeInfo.TaskAgentPoolMaintenanceJob.fields = {
     },
     targetAgents: {
         isArray: true,
+        typeInfo: TypeInfo.TaskAgentPoolMaintenanceJobTargetAgent
+    }
+};
+
+TypeInfo.TaskAgentPoolMaintenanceJobTargetAgent.fields = {
+    agent: {
         typeInfo: TypeInfo.TaskAgentReference
     },
+    result: {
+        enumType: TypeInfo.TaskAgentPoolMaintenanceJobResult
+    },
+    status: {
+        enumType: TypeInfo.TaskAgentPoolMaintenanceJobStatus
+    }
 };
 
 TypeInfo.TaskAgentPoolMaintenanceSchedule.fields = {
     daysToBuild: {
         enumType: TypeInfo.TaskAgentPoolMaintenanceScheduleDays
-    },
+    }
 };
 
 TypeInfo.TaskAgentPoolReference.fields = {
     poolType: {
         enumType: TypeInfo.TaskAgentPoolType
+    }
+};
+
+TypeInfo.TaskAgentPoolSummary.fields = {
+    deploymentGroups: {
+        isArray: true,
+        typeInfo: TypeInfo.DeploymentGroupReference
     },
+    pool: {
+        typeInfo: TypeInfo.TaskAgentPoolReference
+    },
+    queues: {
+        isArray: true,
+        typeInfo: TypeInfo.TaskAgentQueue
+    }
 };
 
 TypeInfo.TaskAgentQueue.fields = {
     pool: {
         typeInfo: TypeInfo.TaskAgentPoolReference
-    },
+    }
 };
 
 TypeInfo.TaskAgentReference.fields = {
     status: {
         enumType: TypeInfo.TaskAgentStatus
-    },
+    }
 };
 
 TypeInfo.TaskAgentSession.fields = {
     agent: {
         typeInfo: TypeInfo.TaskAgentReference
-    },
+    }
 };
 
 TypeInfo.TaskAgentUpdate.fields = {
+    reason: {
+        typeInfo: TypeInfo.TaskAgentUpdateReason
+    },
     requestTime: {
         isDate: true,
-    },
+    }
+};
+
+TypeInfo.TaskAgentUpdateReason.fields = {
+    code: {
+        enumType: TypeInfo.TaskAgentUpdateReasonType
+    }
 };
 
 TypeInfo.TaskAttachment.fields = {
@@ -1908,7 +3238,13 @@ TypeInfo.TaskAttachment.fields = {
     },
     lastChangedOn: {
         isDate: true,
-    },
+    }
+};
+
+TypeInfo.TaskCompletedEvent.fields = {
+    result: {
+        enumType: TypeInfo.TaskResult
+    }
 };
 
 TypeInfo.TaskGroup.fields = {
@@ -1917,7 +3253,7 @@ TypeInfo.TaskGroup.fields = {
     },
     modifiedOn: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.TaskGroupRevision.fields = {
@@ -1926,7 +3262,7 @@ TypeInfo.TaskGroupRevision.fields = {
     },
     changeType: {
         enumType: TypeInfo.AuditAction
-    },
+    }
 };
 
 TypeInfo.TaskLog.fields = {
@@ -1935,7 +3271,7 @@ TypeInfo.TaskLog.fields = {
     },
     lastChangedOn: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.TaskOrchestrationContainer.fields = {
@@ -1948,19 +3284,19 @@ TypeInfo.TaskOrchestrationContainer.fields = {
     },
     rollback: {
         typeInfo: TypeInfo.TaskOrchestrationContainer
-    },
+    }
 };
 
 TypeInfo.TaskOrchestrationItem.fields = {
     itemType: {
         enumType: TypeInfo.TaskOrchestrationItemType
-    },
+    }
 };
 
 TypeInfo.TaskOrchestrationJob.fields = {
     itemType: {
         enumType: TypeInfo.TaskOrchestrationItemType
-    },
+    }
 };
 
 TypeInfo.TaskOrchestrationPlan.fields = {
@@ -1981,7 +3317,20 @@ TypeInfo.TaskOrchestrationPlan.fields = {
     },
     state: {
         enumType: TypeInfo.TaskOrchestrationPlanState
-    },
+    }
+};
+
+TypeInfo.TaskOrchestrationPlanGroup.fields = {
+    runningRequests: {
+        isArray: true,
+        typeInfo: TypeInfo.TaskAgentJobRequest
+    }
+};
+
+TypeInfo.TaskOrchestrationPlanGroupsQueueMetrics.fields = {
+    status: {
+        enumType: TypeInfo.PlanGroupStatus
+    }
 };
 
 TypeInfo.TaskOrchestrationQueuedPlan.fields = {
@@ -1990,14 +3339,14 @@ TypeInfo.TaskOrchestrationQueuedPlan.fields = {
     },
     queueTime: {
         isDate: true,
-    },
+    }
 };
 
 TypeInfo.TaskOrchestrationQueuedPlanGroup.fields = {
     plans: {
         isArray: true,
         typeInfo: TypeInfo.TaskOrchestrationQueuedPlan
-    },
+    }
 };
 
 TypeInfo.Timeline.fields = {
@@ -2007,7 +3356,7 @@ TypeInfo.Timeline.fields = {
     records: {
         isArray: true,
         typeInfo: TypeInfo.TimelineRecord
-    },
+    }
 };
 
 TypeInfo.TimelineRecord.fields = {
@@ -2029,7 +3378,7 @@ TypeInfo.TimelineRecord.fields = {
     },
     state: {
         enumType: TypeInfo.TimelineRecordState
-    },
+    }
 };
 
 TypeInfo.VariableGroup.fields = {
@@ -2038,5 +3387,5 @@ TypeInfo.VariableGroup.fields = {
     },
     modifiedOn: {
         isDate: true,
-    },
+    }
 };

--- a/api/interfaces/TestInterfaces.ts
+++ b/api/interfaces/TestInterfaces.ts
@@ -14,12 +14,64 @@ import TfsCoreInterfaces = require("../interfaces/CoreInterfaces");
 import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
 
 
+export interface AfnStrip {
+    /**
+     * Auxiliary Url to be consumed by MTM
+     */
+    auxiliaryUrl: string;
+    /**
+     * Creation date of the AfnStrip
+     */
+    creationDate: Date;
+    /**
+     * File name of the attachment created
+     */
+    fileName: string;
+    /**
+     * ID of AfnStrip. This is same as the attachment ID.
+     */
+    id: number;
+    /**
+     * Project identifier which contains AfnStrip
+     */
+    project: string;
+    /**
+     * Service in which this attachment is stored in
+     */
+    storedIn: string;
+    /**
+     * Afn strip stream.
+     */
+    stream: string;
+    /**
+     * ID of the testcase.
+     */
+    testCaseId: number;
+    /**
+     * Backing test result id.
+     */
+    testResultId: number;
+    /**
+     * Backing test run id.
+     */
+    testRunId: number;
+    /**
+     * Byte stream (uncompressed) length of Afn strip.
+     */
+    unCompressedStreamLength: number;
+    /**
+     * Url of the attachment created.
+     */
+    url: string;
+}
+
 export interface AggregatedDataForResultTrend {
     /**
      * This is tests execution duration.
      */
     duration: any;
     resultsByOutcome: { [key: number] : AggregatedResultsByOutcome; };
+    runSummaryByState: { [key: number] : AggregatedRunsByState; };
     testResultsContext: TestResultsContext;
     totalTests: number;
 }
@@ -30,6 +82,8 @@ export interface AggregatedResultsAnalysis {
     previousContext: TestResultsContext;
     resultsByOutcome: { [key: number] : AggregatedResultsByOutcome; };
     resultsDifference: AggregatedResultsDifference;
+    runSummaryByOutcome: { [key: number] : AggregatedRunsByOutcome; };
+    runSummaryByState: { [key: number] : AggregatedRunsByState; };
     totalTests: number;
 }
 
@@ -48,6 +102,17 @@ export interface AggregatedResultsDifference {
     increaseInOtherTests: number;
     increaseInPassedTests: number;
     increaseInTotalTests: number;
+}
+
+export interface AggregatedRunsByOutcome {
+    outcome: TestRunOutcome;
+    runsCount: number;
+}
+
+export interface AggregatedRunsByState {
+    resultsByOutcome: { [key: number] : AggregatedResultsByOutcome; };
+    runsCount: number;
+    state: TestRunState;
 }
 
 /**
@@ -77,35 +142,106 @@ export interface BatchResponse {
 export interface BuildConfiguration {
     branchName: string;
     buildDefinitionId: number;
+    buildSystem: string;
+    creationDate: Date;
     flavor: string;
     id: number;
     number: string;
     platform: string;
     project: ShallowReference;
+    repositoryGuid: string;
     repositoryId: number;
+    repositoryType: string;
     sourceVersion: string;
     uri: string;
 }
 
+/**
+ * Build Coverage Detail
+ */
 export interface BuildCoverage {
+    /**
+     * Code Coverage File Url
+     */
     codeCoverageFileUrl: string;
+    /**
+     * Build Configuration
+     */
     configuration: BuildConfiguration;
+    /**
+     * Last Error
+     */
     lastError: string;
+    /**
+     * List of Modules
+     */
     modules: ModuleCoverage[];
+    /**
+     * State
+     */
     state: string;
 }
 
+/**
+ * Reference to a build.
+ */
 export interface BuildReference {
+    /**
+     * Branch name.
+     */
     branchName: string;
+    /**
+     * Build system.
+     */
     buildSystem: string;
+    /**
+     * Build Definition ID.
+     */
     definitionId: number;
+    /**
+     * Build ID.
+     */
     id: number;
+    /**
+     * Build Number.
+     */
     number: string;
+    /**
+     * Repository ID.
+     */
     repositoryId: string;
+    /**
+     * Build URI.
+     */
     uri: string;
 }
 
+export interface BuildReference2 {
+    branchName: string;
+    buildConfigurationId: number;
+    buildDefinitionId: number;
+    buildDeleted: boolean;
+    buildFlavor: string;
+    buildId: number;
+    buildNumber: string;
+    buildPlatform: string;
+    buildSystem: string;
+    buildUri: string;
+    coverageId: number;
+    createdDate: Date;
+    projectId: string;
+    repoId: string;
+    repoType: string;
+    sourceVersion: string;
+}
+
+/**
+ * Detail About Clone Operation.
+ */
 export interface CloneOperationInformation {
+    /**
+     * Clone Statistics
+     */
     cloneStatistics: CloneStatistics;
     /**
      * If the operation is complete, the DateTime of completion. If operation is not complete, this is DateTime.MaxValue
@@ -161,10 +297,25 @@ export interface CloneOperationInformation {
     url: string;
 }
 
+/**
+ * Enum of type Clone Operation Type.
+ */
 export enum CloneOperationState {
+    /**
+     * value for Failed State
+     */
     Failed = 2,
+    /**
+     * value for Inprogress state
+     */
     InProgress = 1,
+    /**
+     * Value for Queued State
+     */
     Queued = 0,
+    /**
+     * value for Success state
+     */
     Succeeded = 3,
 }
 
@@ -284,6 +435,23 @@ export interface CodeCoverageSummary {
     deltaBuild: ShallowReference;
 }
 
+export interface CodeCoverageSummary2 {
+    buildConfigurationId: number;
+    covered: number;
+    label: string;
+    position: number;
+    projectId: string;
+    total: number;
+}
+
+export interface Coverage2 {
+    coverageId: number;
+    dateCreated: Date;
+    dateModified: Date;
+    lastError: string;
+    state: number;
+}
+
 /**
  * Used to choose which coverage data is returned by a QueryXXXCoverage() call.
  */
@@ -310,8 +478,17 @@ export interface CoverageStatistics {
     linesPartiallyCovered: number;
 }
 
+/**
+ * A custom field information.
+ */
 export interface CustomTestField {
+    /**
+     * Field Name.
+     */
     fieldName: string;
+    /**
+     * Field value.
+     */
     value: any;
 }
 
@@ -339,6 +516,11 @@ export enum CustomTestFieldType {
     Guid = 14,
 }
 
+export interface DatedTestFieldData {
+    date: Date;
+    value: TestFieldData;
+}
+
 /**
  * This is a temporary class to provide the details for the test run environment.
  */
@@ -348,9 +530,21 @@ export interface DtlEnvironmentDetails {
     subscriptionName: string;
 }
 
+/**
+ * Failing since information of a test result.
+ */
 export interface FailingSince {
+    /**
+     * Build reference since failing.
+     */
     build: BuildReference;
+    /**
+     * Time since failing.
+     */
     date: Date;
+    /**
+     * Release reference since failing.
+     */
     release: ReleaseReference;
 }
 
@@ -371,6 +565,21 @@ export interface FunctionCoverage {
     namespace: string;
     sourceFile: string;
     statistics: CoverageStatistics;
+}
+
+export interface FunctionCoverage2 {
+    blocksCovered: number;
+    blocksNotCovered: number;
+    class: string;
+    coverageId: number;
+    functionId: number;
+    linesCovered: number;
+    linesNotCovered: number;
+    linesPartiallyCovered: number;
+    moduleId: number;
+    name: string;
+    namespace: string;
+    sourceFile: string;
 }
 
 export interface LastResultDetails {
@@ -400,6 +609,10 @@ export interface LinkedWorkItemsQueryResult {
 export interface ModuleCoverage {
     blockCount: number;
     blockData: number[];
+    /**
+     * Code Coverage File Url
+     */
+    fileUrl: string;
     functions: FunctionCoverage[];
     name: string;
     signature: string;
@@ -407,49 +620,148 @@ export interface ModuleCoverage {
     statistics: CoverageStatistics;
 }
 
+export interface ModuleCoverage2 {
+    blockCount: number;
+    blockData: number[];
+    blockDataLength: number;
+    blocksCovered: number;
+    blocksNotCovered: number;
+    coverageFileUrl: string;
+    coverageId: number;
+    linesCovered: number;
+    linesNotCovered: number;
+    linesPartiallyCovered: number;
+    moduleId: number;
+    name: string;
+    signature: string;
+    signatureAge: number;
+}
+
 export interface NameValuePair {
     name: string;
     value: string;
 }
 
+/**
+ * A model class used for creating and updating test plans.
+ */
 export interface PlanUpdateModel {
+    /**
+     * Area path to which the test plan belongs. This should be set to area path of the team that works on this test plan.
+     */
     area: ShallowReference;
     automatedTestEnvironment: TestEnvironment;
     automatedTestSettings: TestSettings;
+    /**
+     * Build ID of the build whose quality is tested by the tests in this test plan. For automated testing, this build ID is used to find the test binaries that contain automated test methods.
+     */
     build: ShallowReference;
+    /**
+     * The Build Definition that generates a build associated with this test plan.
+     */
     buildDefinition: ShallowReference;
+    /**
+     * IDs of configurations to be applied when new test suites and test cases are added to the test plan.
+     */
     configurationIds: number[];
+    /**
+     * Description of the test plan.
+     */
     description: string;
+    /**
+     * End date for the test plan.
+     */
     endDate: string;
+    /**
+     * Iteration path assigned to the test plan. This indicates when the target iteration by which the testing in this plan is supposed to be complete and the product is ready to be released.
+     */
     iteration: string;
     manualTestEnvironment: TestEnvironment;
     manualTestSettings: TestSettings;
+    /**
+     * Name of the test plan.
+     */
     name: string;
+    /**
+     * Owner of the test plan.
+     */
     owner: VSSInterfaces.IdentityRef;
+    /**
+     * Release Environment to be used to deploy the build and run automated tests from this test plan.
+     */
     releaseEnvironmentDefinition: ReleaseEnvironmentDefinitionReference;
+    /**
+     * Start date for the test plan.
+     */
     startDate: string;
+    /**
+     * State of the test plan.
+     */
     state: string;
     status: string;
+    /**
+     * Test Outcome settings
+     */
+    testOutcomeSettings: TestOutcomeSettings;
 }
 
+/**
+ * Adding test cases to a suite creates one of more test points based on the default configurations and testers assigned to the test suite. PointAssignment is the list of test points that were created for each of the test cases that were added to the test suite.
+ */
 export interface PointAssignment {
+    /**
+     * Configuration that was assigned to the test case.
+     */
     configuration: ShallowReference;
+    /**
+     * Tester that was assigned to the test case
+     */
     tester: VSSInterfaces.IdentityRef;
 }
 
+/**
+ * Filter class for test point.
+ */
 export interface PointsFilter {
+    /**
+     * List of Configurations for filtering.
+     */
     configurationNames: string[];
+    /**
+     * List of test case id for filtering.
+     */
     testcaseIds: number[];
+    /**
+     * List of tester for filtering.
+     */
     testers: VSSInterfaces.IdentityRef[];
 }
 
+/**
+ * Model to update test point.
+ */
 export interface PointUpdateModel {
+    /**
+     * Outcome to update.
+     */
     outcome: string;
+    /**
+     * Reset test point to active.
+     */
     resetToActive: boolean;
+    /**
+     * Tester to update. Type IdentityRef.
+     */
     tester: VSSInterfaces.IdentityRef;
 }
 
+/**
+ * Test point workitem property.
+ */
 export interface PointWorkItemProperty {
+    /**
+     * key value pair of test point work item property.
+     */
     workItem: { key: string; value: any };
 }
 
@@ -464,19 +776,82 @@ export interface QueryModel {
     query: string;
 }
 
+/**
+ * Reference to release environment resource.
+ */
 export interface ReleaseEnvironmentDefinitionReference {
+    /**
+     * ID of the release definition that contains the release environment definition.
+     */
     definitionId: number;
+    /**
+     * ID of the release environment definition.
+     */
     environmentDefinitionId: number;
 }
 
+/**
+ * Reference to a release.
+ */
 export interface ReleaseReference {
+    attempt: number;
+    creationDate: Date;
+    /**
+     * Release definition ID.
+     */
     definitionId: number;
+    environmentCreationDate: Date;
+    /**
+     * Release environment definition ID.
+     */
     environmentDefinitionId: number;
+    /**
+     * Release environment definition name.
+     */
     environmentDefinitionName: string;
+    /**
+     * Release environment ID.
+     */
     environmentId: number;
+    /**
+     * Release environment name.
+     */
     environmentName: string;
+    /**
+     * Release ID.
+     */
     id: number;
+    /**
+     * Release name.
+     */
     name: string;
+}
+
+export interface ReleaseReference2 {
+    attempt: number;
+    environmentCreationDate: Date;
+    projectId: string;
+    releaseCreationDate: Date;
+    releaseDefId: number;
+    releaseEnvDefId: number;
+    releaseEnvId: number;
+    releaseEnvName: string;
+    releaseEnvUri: string;
+    releaseId: number;
+    releaseName: string;
+    releaseRefId: number;
+    releaseUri: string;
+}
+
+export interface RequirementsToTestsMapping2 {
+    createdBy: string;
+    creationDate: Date;
+    deletedBy: string;
+    deletionDate: Date;
+    isMigratedToWIT: boolean;
+    projectId: string;
+    testMetadataId: number;
+    workItemId: number;
 }
 
 export interface Response {
@@ -486,34 +861,105 @@ export interface Response {
     url: string;
 }
 
+/**
+ * Additional details with test result
+ */
 export enum ResultDetails {
+    /**
+     * Core fields of test result. Core fields includes State, Outcome, Priority, AutomatedTestName, AutomatedTestStorage, Comments, ErrorMessage etc.
+     */
     None = 0,
+    /**
+     * Test iteration details in a test result.
+     */
     Iterations = 1,
+    /**
+     * Workitems associated with a test result.
+     */
     WorkItems = 2,
+    /**
+     * Subresults in a test result.
+     */
+    SubResults = 4,
+    /**
+     * Point and plan detail in a test result.
+     */
+    Point = 8,
+}
+
+/**
+ * Hierarchy type of the result/subresults.
+ */
+export enum ResultGroupType {
+    /**
+     * Leaf node of test result.
+     */
+    None = 0,
+    /**
+     * Hierarchy type of test result.
+     */
+    Rerun = 1,
+    /**
+     * Hierarchy type of test result.
+     */
+    DataDriven = 2,
+    /**
+     * Hierarchy type of test result.
+     */
+    OrderedTest = 3,
+    /**
+     * Unknown hierarchy type.
+     */
+    Generic = 4,
 }
 
 /**
  * The top level entity that is being cloned as part of a Clone operation
  */
 export enum ResultObjectType {
+    /**
+     * Suite Clone
+     */
     TestSuite = 0,
+    /**
+     * Plan Clone
+     */
     TestPlan = 1,
 }
 
+/**
+ * Test result retention settings
+ */
 export interface ResultRetentionSettings {
+    /**
+     * Automated test result retention duration in days
+     */
     automatedResultsRetentionDuration: number;
+    /**
+     * Last Updated by identity
+     */
     lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last updated date
+     */
     lastUpdatedDate: Date;
+    /**
+     * Manual test result retention duration in days
+     */
     manualResultsRetentionDuration: number;
 }
 
 export interface ResultsFilter {
     automatedTestName: string;
     branch: string;
+    executedIn: Service;
     groupBy: string;
     maxCompleteDate: Date;
     resultsCount: number;
+    testCaseId: number;
     testCaseReferenceIds: number[];
+    testPlanId: number;
+    testPointIds: number[];
     testResultsContext: TestResultsContext;
     trendDays: number;
 }
@@ -530,36 +976,113 @@ export interface ResultUpdateResponseModel {
     revision: number;
 }
 
+/**
+ * Test run create details.
+ */
 export interface RunCreateModel {
+    /**
+     * true if test run is automated, false otherwise. By default it will be false.
+     */
     automated: boolean;
+    /**
+     * An abstracted reference to the build that it belongs.
+     */
     build: ShallowReference;
+    /**
+     * Drop location of the build used for test run.
+     */
     buildDropLocation: string;
+    /**
+     * Flavor of the build used for test run. (E.g: Release, Debug)
+     */
     buildFlavor: string;
+    /**
+     * Platform of the build used for test run. (E.g.: x86, amd64)
+     */
     buildPlatform: string;
+    buildReference: BuildConfiguration;
+    /**
+     * Comments entered by those analyzing the run.
+     */
     comment: string;
+    /**
+     * Completed date time of the run.
+     */
     completeDate: string;
+    /**
+     * IDs of the test configurations associated with the run.
+     */
     configurationIds: number[];
+    /**
+     * Name of the test controller used for automated run.
+     */
     controller: string;
     customTestFields: CustomTestField[];
+    /**
+     * An abstracted reference to DtlAutEnvironment.
+     */
     dtlAutEnvironment: ShallowReference;
+    /**
+     * An abstracted reference to DtlTestEnvironment.
+     */
     dtlTestEnvironment: ShallowReference;
+    /**
+     * Due date and time for test run.
+     */
     dueDate: string;
     environmentDetails: DtlEnvironmentDetails;
+    /**
+     * Error message associated with the run.
+     */
     errorMessage: string;
     filter: RunFilter;
+    /**
+     * The iteration in which to create the run. Root iteration of the team project will be default
+     */
     iteration: string;
+    /**
+     * Name of the test run.
+     */
     name: string;
+    /**
+     * Display name of the owner of the run.
+     */
     owner: VSSInterfaces.IdentityRef;
+    /**
+     * An abstracted reference to the plan that it belongs.
+     */
     plan: ShallowReference;
+    /**
+     * IDs of the test points to use in the run.
+     */
     pointIds: number[];
+    /**
+     * URI of release environment associated with the run.
+     */
     releaseEnvironmentUri: string;
+    releaseReference: ReleaseReference;
+    /**
+     * URI of release associated with the run.
+     */
     releaseUri: string;
     runTimeout: any;
     sourceWorkflow: string;
+    /**
+     * Start date time of the run.
+     */
     startDate: string;
+    /**
+     * The state of the run. Valid states - NotStarted, InProgress, Waiting
+     */
     state: string;
     testConfigurationsMapping: string;
+    /**
+     * ID of the test environment associated with the run.
+     */
     testEnvironmentId: string;
+    /**
+     * An abstracted reference to the test settings resource.
+     */
     testSettings: ShallowReference;
     type: string;
 }
@@ -578,38 +1101,95 @@ export interface RunFilter {
     testCaseFilter: string;
 }
 
+/**
+ * Test run statistics.
+ */
 export interface RunStatistic {
     count: number;
+    /**
+     * Test run outcome
+     */
     outcome: string;
     resolutionState: TestResolutionState;
+    /**
+     * State of the test run
+     */
     state: string;
 }
 
 export interface RunUpdateModel {
+    /**
+     * An abstracted reference to the build that it belongs.
+     */
     build: ShallowReference;
     buildDropLocation: string;
     buildFlavor: string;
     buildPlatform: string;
+    /**
+     * Comments entered by those analyzing the run.
+     */
     comment: string;
+    /**
+     * Completed date time of the run.
+     */
     completedDate: string;
+    /**
+     * Name of the test controller used for automated run.
+     */
     controller: string;
     deleteInProgressResults: boolean;
+    /**
+     * An abstracted reference to DtlAutEnvironment.
+     */
     dtlAutEnvironment: ShallowReference;
+    /**
+     * An abstracted reference to DtlEnvironment.
+     */
     dtlEnvironment: ShallowReference;
     dtlEnvironmentDetails: DtlEnvironmentDetails;
+    /**
+     * Due date and time for test run.
+     */
     dueDate: string;
+    /**
+     * Error message associated with the run.
+     */
     errorMessage: string;
+    /**
+     * The iteration in which to create the run.
+     */
     iteration: string;
+    /**
+     * Log entries associated with the run. Use a comma-separated list of multiple log entry objects. { logEntry }, { logEntry }, ...
+     */
     logEntries: TestMessageLogDetails[];
+    /**
+     * Name of the test run.
+     */
     name: string;
     releaseEnvironmentUri: string;
     releaseUri: string;
     sourceWorkflow: string;
+    /**
+     * Start date time of the run.
+     */
     startedDate: string;
+    /**
+     * The state of the test run Below are the valid values - NotStarted, InProgress, Completed, Aborted, Waiting
+     */
     state: string;
     substate: TestRunSubstate;
     testEnvironmentId: string;
+    /**
+     * An abstracted reference to test setting resource.
+     */
     testSettings: ShallowReference;
+}
+
+export enum Service {
+    Any = 0,
+    Tcm = 1,
+    Tfs = 2,
 }
 
 /**
@@ -617,7 +1197,7 @@ export interface RunUpdateModel {
  */
 export interface ShallowReference {
     /**
-     * Id of the resource
+     * ID of the resource
      */
     id: string;
     /**
@@ -630,157 +1210,552 @@ export interface ShallowReference {
     url: string;
 }
 
-export interface SharedStepModel {
+export interface ShallowTestCaseResult {
+    automatedTestStorage: string;
     id: number;
+    isReRun: boolean;
+    outcome: string;
+    owner: string;
+    priority: number;
+    refId: number;
+    runId: number;
+    testCaseTitle: string;
+}
+
+/**
+ * Reference to shared step workitem.
+ */
+export interface SharedStepModel {
+    /**
+     * WorkItem shared step ID.
+     */
+    id: number;
+    /**
+     * Shared step workitem revision.
+     */
     revision: number;
 }
 
+/**
+ * Suite create model
+ */
 export interface SuiteCreateModel {
+    /**
+     * Name of test suite.
+     */
     name: string;
+    /**
+     * For query based suites, query string that defines the suite.
+     */
     queryString: string;
+    /**
+     * For requirements test suites, the IDs of the requirements.
+     */
     requirementIds: number[];
+    /**
+     * Type of test suite to create. It can have value from DynamicTestSuite, StaticTestSuite and RequirementTestSuite.
+     */
     suiteType: string;
 }
 
+/**
+ * A suite entry defines properties for a test suite.
+ */
 export interface SuiteEntry {
     /**
-     * Id of child suite in a suite
+     * Id of child suite in the test suite.
      */
     childSuiteId: number;
     /**
-     * Sequence number for the test case or child suite in the suite
+     * Sequence number for the test case or child test suite in the test suite.
      */
     sequenceNumber: number;
     /**
-     * Id for the suite
+     * Id for the test suite.
      */
     suiteId: number;
     /**
-     * Id of a test case in a suite
+     * Id of a test case in the test suite.
      */
     testCaseId: number;
 }
 
+/**
+ * A model to define sequence of test suite entries in a test suite.
+ */
 export interface SuiteEntryUpdateModel {
     /**
-     * Id of child suite in a suite
+     * Id of the child suite in the test suite.
      */
     childSuiteId: number;
     /**
-     * Updated sequence number for the test case or child suite in the suite
+     * Updated sequence number for the test case or child test suite in the test suite.
      */
     sequenceNumber: number;
     /**
-     * Id of a test case in a suite
+     * Id of the test case in the test suite.
      */
     testCaseId: number;
 }
 
+/**
+ * Option to get details in response
+ */
+export enum SuiteExpand {
+    /**
+     * Include children in response.
+     */
+    Children = 1,
+    /**
+     * Include default testers in response.
+     */
+    DefaultTesters = 2,
+}
+
+/**
+ * Test case for the suite.
+ */
 export interface SuiteTestCase {
+    /**
+     * Point Assignment for test suite's test case.
+     */
     pointAssignments: PointAssignment[];
+    /**
+     * Test case workItem reference.
+     */
     testCase: WorkItemReference;
 }
 
+/**
+ * Test suite update model.
+ */
+export interface SuiteTestCaseUpdateModel {
+    /**
+     * Shallow reference of configurations for the test cases in the suite.
+     */
+    configurations: ShallowReference[];
+}
+
+/**
+ * Test suite update model.
+ */
 export interface SuiteUpdateModel {
+    /**
+     * Shallow reference of default configurations for the suite.
+     */
     defaultConfigurations: ShallowReference[];
+    /**
+     * Shallow reference of test suite.
+     */
     defaultTesters: ShallowReference[];
+    /**
+     * Specifies if the default configurations have to be inherited from the parent test suite in which the test suite is created.
+     */
     inheritDefaultConfigurations: boolean;
+    /**
+     * Test suite name
+     */
     name: string;
+    /**
+     * Shallow reference of the parent.
+     */
     parent: ShallowReference;
+    /**
+     * For query based suites, the new query string.
+     */
     queryString: string;
 }
 
-export interface TestActionResultModel extends TestResultModelBase {
+export interface TCMPropertyBag2 {
+    artifactId: number;
+    artifactType: number;
+    name: string;
+    value: string;
+}
+
+export interface TestActionResult2 {
     actionPath: string;
+    comment: string;
+    creationDate: Date;
+    dateCompleted: Date;
+    dateStarted: Date;
+    duration: number;
+    errorMessage: string;
     iterationId: number;
+    lastUpdated: Date;
+    outcome: number;
+    sharedStepId: number;
+    sharedStepRevision: number;
+    testResultId: number;
+    testRunId: number;
+}
+
+/**
+ * Represents a test step result.
+ */
+export interface TestActionResultModel extends TestResultModelBase {
+    /**
+     * Path identifier test step in test case workitem.
+     */
+    actionPath: string;
+    /**
+     * Iteration ID of test action result.
+     */
+    iterationId: number;
+    /**
+     * Reference to shared step workitem.
+     */
     sharedStepModel: SharedStepModel;
     /**
      * This is step Id of test case. For shared step, it is step Id of shared step in test case workitem; step Id in shared step. Example: TestCase workitem has two steps: 1) Normal step with Id = 1 2) Shared Step with Id = 2. Inside shared step: a) Normal Step with Id = 1 Value for StepIdentifier for First step: "1" Second step: "2;1"
      */
     stepIdentifier: string;
+    /**
+     * Url of test action result.
+     */
     url: string;
 }
 
 export interface TestAttachment {
+    /**
+     * Attachment type.
+     */
     attachmentType: AttachmentType;
+    /**
+     * Comment associated with attachment.
+     */
     comment: string;
+    /**
+     * Attachment created date.
+     */
     createdDate: Date;
+    /**
+     * Attachment file name
+     */
     fileName: string;
+    /**
+     * ID of the attachment.
+     */
     id: number;
+    /**
+     * Attachment size.
+     */
+    size: number;
+    /**
+     * Attachment Url.
+     */
     url: string;
 }
 
+/**
+ * Reference to test attachment.
+ */
 export interface TestAttachmentReference {
+    /**
+     * ID of the attachment.
+     */
     id: number;
+    /**
+     * Url to download the attachment.
+     */
     url: string;
 }
 
+/**
+ * Test attachment request model
+ */
 export interface TestAttachmentRequestModel {
+    /**
+     * Attachment type By Default it will be GeneralAttachment. It can be one of the following type. { GeneralAttachment, AfnStrip, BugFilingData, CodeCoverage, IntermediateCollectorData, RunConfig, TestImpactDetails, TmiTestRunDeploymentFiles, TmiTestRunReverseDeploymentFiles, TmiTestResultDetail, TmiTestRunSummary }
+     */
     attachmentType: string;
+    /**
+     * Comment associated with attachment
+     */
     comment: string;
+    /**
+     * Attachment filename
+     */
     fileName: string;
+    /**
+     * Base64 encoded file stream
+     */
     stream: string;
 }
 
-export interface TestCaseResult {
-    afnStripId: number;
-    area: ShallowReference;
-    associatedBugs: ShallowReference[];
+export interface TestAuthoringDetails {
+    configurationId: number;
+    pointId: number;
+    suiteId: number;
+    testerId: string;
+}
+
+export interface TestCaseMetadata2 {
+    container: string;
+    name: string;
+    projectId: string;
+    testMetadataId: number;
+}
+
+export interface TestCaseReference2 {
+    areaId: number;
     automatedTestId: string;
     automatedTestName: string;
+    automatedTestNameHash: number[];
     automatedTestStorage: string;
+    automatedTestStorageHash: number[];
+    automatedTestType: string;
+    configurationId: number;
+    createdBy: string;
+    creationDate: Date;
+    lastRefTestRunDate: Date;
+    owner: string;
+    priority: number;
+    projectId: string;
+    testCaseId: number;
+    testCaseRefId: number;
+    testCaseRevision: number;
+    testCaseTitle: string;
+    testPointId: number;
+}
+
+/**
+ * Represents a test result.
+ */
+export interface TestCaseResult {
+    /**
+     * Test attachment ID of action recording.
+     */
+    afnStripId: number;
+    /**
+     * Reference to area path of test.
+     */
+    area: ShallowReference;
+    /**
+     * Reference to bugs linked to test result.
+     */
+    associatedBugs: ShallowReference[];
+    /**
+     * ID representing test method in a dll.
+     */
+    automatedTestId: string;
+    /**
+     * Fully qualified name of test executed.
+     */
+    automatedTestName: string;
+    /**
+     * Container to which test belongs.
+     */
+    automatedTestStorage: string;
+    /**
+     * Type of automated test.
+     */
     automatedTestType: string;
     automatedTestTypeId: string;
+    /**
+     * Shallow reference to build associated with test result.
+     */
     build: ShallowReference;
+    /**
+     * Reference to build associated with test result.
+     */
     buildReference: BuildReference;
+    /**
+     * Comment in a test result.
+     */
     comment: string;
+    /**
+     * Time when test execution completed.
+     */
     completedDate: Date;
+    /**
+     * Machine name where test executed.
+     */
     computerName: string;
+    /**
+     * Test configuration of a test result.
+     */
     configuration: ShallowReference;
+    /**
+     * Timestamp when test result created.
+     */
     createdDate: Date;
+    /**
+     * Additional properties of test result.
+     */
     customFields: CustomTestField[];
+    /**
+     * Duration of test execution in milliseconds.
+     */
     durationInMs: number;
+    /**
+     * Error message in test execution.
+     */
     errorMessage: string;
+    /**
+     * Information when test results started failing.
+     */
     failingSince: FailingSince;
+    /**
+     * Failure type of test result.
+     */
     failureType: string;
+    /**
+     * ID of a test result.
+     */
     id: number;
+    /**
+     * Test result details of test iterations.
+     */
     iterationDetails: TestIterationDetailsModel[];
+    /**
+     * Reference to identity last updated test result.
+     */
     lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last updated datetime of test result.
+     */
     lastUpdatedDate: Date;
+    /**
+     * Test outcome of test result.
+     */
     outcome: string;
+    /**
+     * Reference to test owner.
+     */
     owner: VSSInterfaces.IdentityRef;
+    /**
+     * Priority of test executed.
+     */
     priority: number;
+    /**
+     * Reference to team project.
+     */
     project: ShallowReference;
+    /**
+     * Shallow reference to release associated with test result.
+     */
     release: ShallowReference;
+    /**
+     * Reference to release associated with test result.
+     */
     releaseReference: ReleaseReference;
     resetCount: number;
+    /**
+     * Resolution state of test result.
+     */
     resolutionState: string;
+    /**
+     * ID of resolution state.
+     */
     resolutionStateId: number;
+    /**
+     * Hierarchy type of the result, default value of None means its leaf node.
+     */
+    resultGroupType: ResultGroupType;
+    /**
+     * Revision number of test result.
+     */
     revision: number;
+    /**
+     * Reference to identity executed the test.
+     */
     runBy: VSSInterfaces.IdentityRef;
+    /**
+     * Stacktrace.
+     */
     stackTrace: string;
+    /**
+     * Time when test execution started.
+     */
     startedDate: Date;
+    /**
+     * State of test result.
+     */
     state: string;
+    /**
+     * List of sub results inside a test result, if ResultGroupType is not None, it holds corresponding type sub results.
+     */
+    subResults: TestSubResult[];
+    /**
+     * Reference to the test executed.
+     */
     testCase: ShallowReference;
+    /**
+     * Reference ID of test used by test result.
+     */
     testCaseReferenceId: number;
+    /**
+     * Name of test.
+     */
+    testCaseRevision: number;
+    /**
+     * Name of test.
+     */
     testCaseTitle: string;
+    /**
+     * Reference to test plan test case workitem is part of.
+     */
     testPlan: ShallowReference;
+    /**
+     * Reference to the test point executed.
+     */
     testPoint: ShallowReference;
+    /**
+     * Reference to test run.
+     */
     testRun: ShallowReference;
+    /**
+     * Reference to test suite test case workitem is part of.
+     */
     testSuite: ShallowReference;
+    /**
+     * Url of test result.
+     */
     url: string;
 }
 
+/**
+ * Test attachment information in a test iteration.
+ */
 export interface TestCaseResultAttachmentModel {
+    /**
+     * Path identifier test step in test case workitem.
+     */
+    actionPath: string;
+    /**
+     * Attachment ID.
+     */
     id: number;
+    /**
+     * Iteration ID.
+     */
     iterationId: number;
+    /**
+     * Name of attachment.
+     */
     name: string;
+    /**
+     * Attachment size.
+     */
     size: number;
+    /**
+     * Url to attachment.
+     */
     url: string;
 }
 
+/**
+ * Reference to a test result.
+ */
 export interface TestCaseResultIdentifier {
+    /**
+     * Test result ID.
+     */
     testResultId: number;
+    /**
+     * Test run ID.
+     */
     testRunId: number;
 }
 
@@ -805,6 +1780,9 @@ export interface TestCaseResultUpdateModel {
     testResult: ShallowReference;
 }
 
+/**
+ * Test configuration
+ */
 export interface TestConfiguration {
     /**
      * Area of the configuration
@@ -875,6 +1853,10 @@ export interface TestEnvironment {
     environmentName: string;
 }
 
+export interface TestExecutionReportData {
+    reportData: DatedTestFieldData[];
+}
+
 export interface TestFailureDetails {
     count: number;
     testResults: TestCaseResultIdentifier[];
@@ -887,18 +1869,135 @@ export interface TestFailuresAnalysis {
     previousContext: TestResultsContext;
 }
 
-export interface TestIterationDetailsModel {
-    actionResults: TestActionResultModel[];
-    attachments: TestCaseResultAttachmentModel[];
-    comment: string;
-    completedDate: Date;
-    durationInMs: number;
-    errorMessage: string;
+export interface TestFailureType {
     id: number;
+    name: string;
+    project: ShallowReference;
+}
+
+export interface TestFieldData {
+    dimensions: { [key: string] : any; };
+    measure: number;
+}
+
+export interface TestFieldsEx2 {
+    fieldId: number;
+    fieldName: string;
+    fieldType: number;
+    isResultScoped: boolean;
+    isRunScoped: boolean;
+    isSystemField: boolean;
+    projectId: string;
+}
+
+/**
+ * Filter to get TestCase result history.
+ */
+export interface TestHistoryQuery {
+    /**
+     * Automated test name of the TestCase.
+     */
+    automatedTestName: string;
+    /**
+     * Results to be get for a particular branches.
+     */
+    branch: string;
+    /**
+     * Get the results history only for this BuildDefinationId. This to get used in query GroupBy should be Branch. If this is provided, Branch will have no use.
+     */
+    buildDefinitionId: number;
+    /**
+     * It will be filled by server. If not null means there are some results still to be get, and we need to call this REST API with this ContinuousToken.
+     */
+    continuationToken: string;
+    /**
+     * Group the result on the basis of TestResultGroupBy. This can be Branch, Environment or null(if results are fetched by BuildDefinitionId)
+     */
+    groupBy: TestResultGroupBy;
+    /**
+     * History to get between time interval MaxCompleteDate and  (MaxCompleteDate - TrendDays). Default is current date time.
+     */
+    maxCompleteDate: Date;
+    /**
+     * Get the results history only for this ReleaseEnvDefinitionId. This to get used in query GroupBy should be Environment.
+     */
+    releaseEnvDefinitionId: number;
+    /**
+     * List of TestResultHistoryForGroup which are grouped by GroupBy
+     */
+    resultsForGroup: TestResultHistoryForGroup[];
+    /**
+     * Number of days for which history to collect. Maximum supported value is 7 days. Default is 7 days.
+     */
+    trendDays: number;
+}
+
+/**
+ * Represents a test iteration result.
+ */
+export interface TestIterationDetailsModel {
+    /**
+     * Test step results in an iteration.
+     */
+    actionResults: TestActionResultModel[];
+    /**
+     * Refence to attachments in test iteration result.
+     */
+    attachments: TestCaseResultAttachmentModel[];
+    /**
+     * Comment in test iteration result.
+     */
+    comment: string;
+    /**
+     * Time when execution completed.
+     */
+    completedDate: Date;
+    /**
+     * Duration of execution.
+     */
+    durationInMs: number;
+    /**
+     * Error message in test iteration result execution.
+     */
+    errorMessage: string;
+    /**
+     * ID of test iteration result.
+     */
+    id: number;
+    /**
+     * Test outcome if test iteration result.
+     */
     outcome: string;
+    /**
+     * Test parameters in an iteration.
+     */
     parameters: TestResultParameterModel[];
+    /**
+     * Time when execution started.
+     */
     startedDate: Date;
+    /**
+     * Url to test iteration result.
+     */
     url: string;
+}
+
+/**
+ * Represents Test Log store endpoint details.
+ */
+export interface TestLogStoreEndpointDetails {
+    /**
+     * Test log store connection Uri.
+     */
+    blobContainerSASUri: string;
+    /**
+     * Test Run Id.
+     */
+    runId: number;
+}
+
+export interface TestMessageLog2 {
+    testMessageLogId: number;
 }
 
 /**
@@ -917,6 +2016,15 @@ export interface TestMessageLogDetails {
      * Message of the resource
      */
     message: string;
+}
+
+export interface TestMessageLogEntry2 {
+    dateCreated: Date;
+    entryId: number;
+    logLevel: number;
+    logUser: string;
+    message: string;
+    testMessageLogId: number;
 }
 
 export interface TestMethod {
@@ -997,30 +2105,105 @@ export enum TestOutcome {
     MaxValue = 14,
 }
 
+export interface TestOutcomeSettings {
+    /**
+     * Value to configure how test outcomes for the same tests across suites are shown
+     */
+    syncOutcomeAcrossSuites: boolean;
+}
+
+export interface TestParameter2 {
+    actionPath: string;
+    actual: number[];
+    creationDate: Date;
+    dataType: number;
+    dateModified: Date;
+    expected: number[];
+    iterationId: number;
+    parameterName: string;
+    testResultId: number;
+    testRunId: number;
+}
+
+/**
+ * The test plan resource.
+ */
 export interface TestPlan {
+    /**
+     * Area of the test plan.
+     */
     area: ShallowReference;
     automatedTestEnvironment: TestEnvironment;
     automatedTestSettings: TestSettings;
+    /**
+     * Build to be tested.
+     */
     build: ShallowReference;
+    /**
+     * The Build Definition that generates a build associated with this test plan.
+     */
     buildDefinition: ShallowReference;
     clientUrl: string;
+    /**
+     * Description of the test plan.
+     */
     description: string;
+    /**
+     * End date for the test plan.
+     */
     endDate: Date;
+    /**
+     * ID of the test plan.
+     */
     id: number;
+    /**
+     * Iteration path of the test plan.
+     */
     iteration: string;
     manualTestEnvironment: TestEnvironment;
     manualTestSettings: TestSettings;
+    /**
+     * Name of the test plan.
+     */
     name: string;
+    /**
+     * Owner of the test plan.
+     */
     owner: VSSInterfaces.IdentityRef;
     previousBuild: ShallowReference;
+    /**
+     * Project which contains the test plan.
+     */
     project: ShallowReference;
+    /**
+     * Release Environment to be used to deploy the build and run automated tests from this test plan.
+     */
     releaseEnvironmentDefinition: ReleaseEnvironmentDefinitionReference;
+    /**
+     * Revision of the test plan.
+     */
     revision: number;
+    /**
+     * Root test suite of the test plan.
+     */
     rootSuite: ShallowReference;
+    /**
+     * Start date for the test plan.
+     */
     startDate: Date;
+    /**
+     * State of the test plan.
+     */
     state: string;
+    /**
+     * Value to configure how same tests across test suites under a test plan need to behave
+     */
+    testOutcomeSettings: TestOutcomeSettings;
     updatedBy: VSSInterfaces.IdentityRef;
     updatedDate: Date;
+    /**
+     * URL of the test plan resource.
+     */
     url: string;
 }
 
@@ -1044,42 +2227,186 @@ export interface TestPlansWithSelection {
     plans: TestPlan[];
 }
 
+/**
+ * Test point.
+ */
 export interface TestPoint {
+    /**
+     * AssignedTo. Type IdentityRef.
+     */
     assignedTo: VSSInterfaces.IdentityRef;
+    /**
+     * Automated.
+     */
     automated: boolean;
+    /**
+     * Comment associated with test point.
+     */
     comment: string;
+    /**
+     * Configuration. Type ShallowReference.
+     */
     configuration: ShallowReference;
+    /**
+     * Failure type of test point.
+     */
     failureType: string;
+    /**
+     * ID of the test point.
+     */
     id: number;
+    /**
+     * Last resolution state id of test point.
+     */
     lastResolutionStateId: number;
+    /**
+     * Last result of test point. Type ShallowReference.
+     */
     lastResult: ShallowReference;
+    /**
+     * Last result details of test point. Type LastResultDetails.
+     */
     lastResultDetails: LastResultDetails;
+    /**
+     * Last result state of test point.
+     */
     lastResultState: string;
+    /**
+     * LastRun build number of test point.
+     */
     lastRunBuildNumber: string;
+    /**
+     * Last testRun of test point. Type ShallowReference.
+     */
     lastTestRun: ShallowReference;
+    /**
+     * Test point last updated by. Type IdentityRef.
+     */
     lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last updated date of test point.
+     */
     lastUpdatedDate: Date;
+    /**
+     * Outcome of test point.
+     */
     outcome: string;
+    /**
+     * Revision number.
+     */
     revision: number;
+    /**
+     * State of test point.
+     */
     state: string;
+    /**
+     * Suite of test point. Type ShallowReference.
+     */
     suite: ShallowReference;
+    /**
+     * TestCase associated to test point. Type WorkItemReference.
+     */
     testCase: WorkItemReference;
+    /**
+     * TestPlan of test point. Type ShallowReference.
+     */
     testPlan: ShallowReference;
+    /**
+     * Test point Url.
+     */
     url: string;
+    /**
+     * Work item properties of test point.
+     */
     workItemProperties: any[];
 }
 
+export interface TestPointReference {
+    id: number;
+    state: TestPointState;
+}
+
+export interface TestPointsEvent {
+    projectName: string;
+    testPoints: TestPointReference[];
+}
+
+/**
+ * Test point query class.
+ */
 export interface TestPointsQuery {
+    /**
+     * Order by results.
+     */
     orderBy: string;
+    /**
+     * List of test points
+     */
     points: TestPoint[];
+    /**
+     * Filter
+     */
     pointsFilter: PointsFilter;
+    /**
+     * List of workitem fields to get.
+     */
     witFields: string[];
+}
+
+export enum TestPointState {
+    /**
+     * Default
+     */
+    None = 0,
+    /**
+     * The test point needs to be executed in order for the test pass to be considered complete.  Either the test has not been run before or the previous run failed.
+     */
+    Ready = 1,
+    /**
+     * The test has passed successfully and does not need to be re-run for the test pass to be considered complete.
+     */
+    Completed = 2,
+    /**
+     * The test point needs to be executed but is not able to.
+     */
+    NotReady = 3,
+    /**
+     * The test is being executed.
+     */
+    InProgress = 4,
+    MaxValue = 4,
+}
+
+export interface TestPointsUpdatedEvent extends TestPointsEvent {
 }
 
 export interface TestResolutionState {
     id: number;
     name: string;
     project: ShallowReference;
+}
+
+export interface TestResult2 {
+    afnStripId: number;
+    computerName: string;
+    creationDate: Date;
+    dateCompleted: Date;
+    dateStarted: Date;
+    effectivePointState: number;
+    failureType: number;
+    lastUpdated: Date;
+    lastUpdatedBy: string;
+    outcome: number;
+    owner: string;
+    projectId: string;
+    resetCount: number;
+    resolutionStateId: number;
+    revision: number;
+    runBy: string;
+    state: number;
+    testCaseRefId: number;
+    testResultId: number;
+    testRunId: number;
 }
 
 export interface TestResultCreateModel {
@@ -1116,6 +2443,20 @@ export interface TestResultDocument {
     payload: TestResultPayload;
 }
 
+/**
+ * Group by for results
+ */
+export enum TestResultGroupBy {
+    /**
+     * Group the results by branches
+     */
+    Branch = 1,
+    /**
+     * Group the results by environment
+     */
+    Environment = 2,
+}
+
 export interface TestResultHistory {
     groupByField: string;
     resultsForGroup: TestResultHistoryDetailsForGroup[];
@@ -1126,24 +2467,78 @@ export interface TestResultHistoryDetailsForGroup {
     latestResult: TestCaseResult;
 }
 
+/**
+ * List of test results filtered on the basis of GroupByValue
+ */
+export interface TestResultHistoryForGroup {
+    /**
+     * Display name of the group.
+     */
+    displayName: string;
+    /**
+     * Name or Id of the group identifier by which results are grouped together.
+     */
+    groupByValue: string;
+    /**
+     * List of results for GroupByValue
+     */
+    results: TestCaseResult[];
+}
+
 export interface TestResultModelBase {
+    /**
+     * Comment in result.
+     */
     comment: string;
+    /**
+     * Time when execution completed.
+     */
     completedDate: Date;
+    /**
+     * Duration of execution.
+     */
     durationInMs: number;
+    /**
+     * Error message in result.
+     */
     errorMessage: string;
+    /**
+     * Test outcome of result.
+     */
     outcome: string;
+    /**
+     * Time when execution started.
+     */
     startedDate: Date;
 }
 
+/**
+ * Test parameter information in a test iteration.
+ */
 export interface TestResultParameterModel {
+    /**
+     * Test step path where parameter is referenced.
+     */
     actionPath: string;
+    /**
+     * Iteration ID.
+     */
     iterationId: number;
+    /**
+     * Name of parameter.
+     */
     parameterName: string;
     /**
      * This is step Id of test case. For shared step, it is step Id of shared step in test case workitem; step Id in shared step. Example: TestCase workitem has two steps: 1) Normal step with Id = 1 2) Shared Step with Id = 2. Inside shared step: a) Normal Step with Id = 1 Value for StepIdentifier for First step: "1" Second step: "2;1"
      */
     stepIdentifier: string;
+    /**
+     * Url of test parameter.
+     */
     url: string;
+    /**
+     * Value of parameter.
+     */
     value: string;
 }
 
@@ -1151,6 +2546,16 @@ export interface TestResultPayload {
     comment: string;
     name: string;
     stream: string;
+}
+
+export interface TestResultReset2 {
+    auditIdentity: string;
+    dateModified: Date;
+    projectId: string;
+    revision: number;
+    testResultId: number;
+    testResultRV: number[];
+    testRunId: number;
 }
 
 export interface TestResultsContext {
@@ -1173,6 +2578,21 @@ export interface TestResultsDetailsForGroup {
     groupByValue: any;
     results: TestCaseResult[];
     resultsCountByOutcome: { [key: number] : AggregatedResultsByOutcome; };
+}
+
+export interface TestResultsEx2 {
+    bitValue: boolean;
+    creationDate: Date;
+    dateTimeValue: Date;
+    fieldId: number;
+    fieldName: string;
+    floatValue: number;
+    guidValue: string;
+    intValue: number;
+    projectId: string;
+    stringValue: string;
+    testResultId: number;
+    testRunId: number;
 }
 
 export interface TestResultsGroupsForBuild {
@@ -1225,10 +2645,25 @@ export interface TestResultTrendFilter {
     trendDays: number;
 }
 
+/**
+ * Test run details.
+ */
 export interface TestRun {
+    /**
+     * Build associated with this test run.
+     */
     build: ShallowReference;
+    /**
+     * Build configuration details associated with this test run.
+     */
     buildConfiguration: BuildConfiguration;
+    /**
+     * Comments entered by those analyzing the run.
+     */
     comment: string;
+    /**
+     * Completed date time of the run.
+     */
     completedDate: Date;
     controller: string;
     createdDate: Date;
@@ -1237,45 +2672,222 @@ export interface TestRun {
     dtlAutEnvironment: ShallowReference;
     dtlEnvironment: ShallowReference;
     dtlEnvironmentCreationDetails: DtlEnvironmentDetails;
+    /**
+     * Due date and time for test run.
+     */
     dueDate: Date;
+    /**
+     * Error message associated with the run.
+     */
     errorMessage: string;
     filter: RunFilter;
+    /**
+     * ID of the test run.
+     */
     id: number;
     incompleteTests: number;
+    /**
+     * true if test run is automated, false otherwise.
+     */
     isAutomated: boolean;
+    /**
+     * The iteration to which the run belongs.
+     */
     iteration: string;
+    /**
+     * Team foundation ID of the last updated the test run.
+     */
     lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last updated date and time
+     */
     lastUpdatedDate: Date;
+    /**
+     * Name of the test run.
+     */
     name: string;
     notApplicableTests: number;
+    /**
+     * Team Foundation ID of the owner of the runs.
+     */
     owner: VSSInterfaces.IdentityRef;
+    /**
+     * Number of passed tests in the run
+     */
     passedTests: number;
     phase: string;
+    /**
+     * Test plan associated with this test run.
+     */
     plan: ShallowReference;
     postProcessState: string;
+    /**
+     * Project associated with this run.
+     */
     project: ShallowReference;
     release: ReleaseReference;
     releaseEnvironmentUri: string;
     releaseUri: string;
     revision: number;
     runStatistics: RunStatistic[];
+    /**
+     * Start date time of the run.
+     */
     startedDate: Date;
+    /**
+     * The state of the run. { NotStarted, InProgress, Waiting }
+     */
     state: string;
     substate: TestRunSubstate;
+    /**
+     * Test environment associated with the run.
+     */
     testEnvironment: TestEnvironment;
     testMessageLogId: number;
     testSettings: ShallowReference;
+    /**
+     * Total tests in the run
+     */
     totalTests: number;
     unanalyzedTests: number;
+    /**
+     * Url of the test run
+     */
     url: string;
     webAccessUrl: string;
 }
 
+export interface TestRun2 {
+    buildConfigurationId: number;
+    buildNumber: string;
+    comment: string;
+    completeDate: Date;
+    controller: string;
+    coverageId: number;
+    creationDate: Date;
+    dropLocation: string;
+    dueDate: Date;
+    errorMessage: string;
+    incompleteTests: number;
+    isAutomated: boolean;
+    isBvt: boolean;
+    isMigrated: boolean;
+    iterationId: number;
+    lastUpdated: Date;
+    lastUpdatedBy: string;
+    legacySharePath: string;
+    maxReservedResultId: number;
+    notApplicableTests: number;
+    owner: string;
+    passedTests: number;
+    postProcessState: number;
+    projectId: string;
+    publicTestSettingsId: number;
+    releaseEnvironmentUri: string;
+    releaseUri: string;
+    revision: number;
+    startDate: Date;
+    state: number;
+    testEnvironmentId: string;
+    testMessageLogId: number;
+    testPlanId: number;
+    testRunContextId: number;
+    testRunId: number;
+    testSettingsId: number;
+    title: string;
+    totalTests: number;
+    type: number;
+    unanalyzedTests: number;
+    version: number;
+}
+
+export interface TestRunCanceledEvent extends TestRunEvent {
+}
+
+export interface TestRunContext2 {
+    buildRefId: number;
+    projectId: string;
+    releaseRefId: number;
+    sourceWorkflow: string;
+    testRunContextId: number;
+}
+
+/**
+ * Test Run Code Coverage Details
+ */
 export interface TestRunCoverage {
+    /**
+     * Last Error
+     */
     lastError: string;
+    /**
+     * List of Modules Coverage
+     */
     modules: ModuleCoverage[];
+    /**
+     * State
+     */
     state: string;
+    /**
+     * Reference of test Run.
+     */
     testRun: ShallowReference;
+}
+
+export interface TestRunCreatedEvent extends TestRunEvent {
+}
+
+export interface TestRunEvent {
+    testRun: TestRun;
+}
+
+export interface TestRunEx2 {
+    bitValue: boolean;
+    createdDate: Date;
+    dateTimeValue: Date;
+    fieldId: number;
+    fieldName: string;
+    floatValue: number;
+    guidValue: string;
+    intValue: number;
+    projectId: string;
+    stringValue: string;
+    testRunId: number;
+}
+
+export interface TestRunExtended2 {
+    autEnvironmentUrl: string;
+    csmContent: string;
+    csmParameters: string;
+    projectId: string;
+    sourceFilter: string;
+    subscriptionName: string;
+    substate: number;
+    testCaseFilter: string;
+    testEnvironmentUrl: string;
+    testRunId: number;
+}
+
+/**
+ * The types of outcomes for test run.
+ */
+export enum TestRunOutcome {
+    /**
+     * Run with zero failed tests and has atleast one impacted test
+     */
+    Passed = 0,
+    /**
+     * Run with at-least one failed test.
+     */
+    Failed = 1,
+    /**
+     * Run with no impacted tests.
+     */
+    NotImpacted = 2,
+    /**
+     * Runs with All tests in other category.
+     */
+    Others = 3,
 }
 
 /**
@@ -1294,6 +2906,9 @@ export enum TestRunPublishContext {
      * Run is published for any Context.
      */
     All = 3,
+}
+
+export interface TestRunStartedEvent extends TestRunEvent {
 }
 
 /**
@@ -1330,6 +2945,9 @@ export enum TestRunState {
     NeedsInvestigation = 6,
 }
 
+/**
+ * Test run statistics.
+ */
 export interface TestRunStatistic {
     run: ShallowReference;
     runStatistics: RunStatistic[];
@@ -1350,6 +2968,22 @@ export enum TestRunSubstate {
     CancellationInProgress = 8,
 }
 
+export interface TestRunSummary2 {
+    isRerun: boolean;
+    projectId: string;
+    resultCount: number;
+    resultDuration: number;
+    runDuration: number;
+    testOutcome: number;
+    testRunCompletedDate: Date;
+    testRunContextId: number;
+    testRunId: number;
+    testRunStatsId: number;
+}
+
+/**
+ * Test Session
+ */
 export interface TestSession {
     /**
      * Area path of the test session
@@ -1429,7 +3063,7 @@ export interface TestSessionExploredWorkItemReference extends TestSessionWorkIte
 }
 
 /**
- * Represents the state of the test session.
+ * Represents the source from which the test session was created
  */
 export enum TestSessionSource {
     /**
@@ -1537,36 +3171,243 @@ export interface TestSettings {
     testSettingsName: string;
 }
 
-export interface TestSuite {
-    areaUri: string;
-    children: TestSuite[];
-    defaultConfigurations: ShallowReference[];
-    defaultTesters: ShallowReference[];
-    id: number;
-    inheritDefaultConfigurations: boolean;
-    lastError: string;
-    lastPopulatedDate: Date;
+/**
+ * Represents the test settings of the run. Used to create test settings and fetch test settings
+ */
+export interface TestSettings2 {
+    /**
+     * Area path required to create test settings
+     */
+    areaPath: string;
+    createdBy: VSSInterfaces.IdentityRef;
+    createdDate: Date;
+    /**
+     * Description of the test settings. Used in create test settings.
+     */
+    description: string;
+    /**
+     * Indicates if the tests settings is public or private.Used in create test settings.
+     */
+    isPublic: boolean;
     lastUpdatedBy: VSSInterfaces.IdentityRef;
     lastUpdatedDate: Date;
-    name: string;
-    parent: ShallowReference;
-    plan: ShallowReference;
-    project: ShallowReference;
-    queryString: string;
-    requirementId: number;
-    revision: number;
-    state: string;
-    suites: ShallowReference[];
-    suiteType: string;
-    testCaseCount: number;
-    testCasesUrl: string;
-    text: string;
+    /**
+     * Xml string of machine roles. Used in create test settings.
+     */
+    machineRoles: string;
+    /**
+     * Test settings content.
+     */
+    testSettingsContent: string;
+    /**
+     * Test settings id.
+     */
+    testSettingsId: number;
+    /**
+     * Test settings name.
+     */
+    testSettingsName: string;
+}
+
+/**
+ * Represents a sub result of a test result.
+ */
+export interface TestSubResult {
+    /**
+     * Comment in sub result.
+     */
+    comment: string;
+    /**
+     * Time when test execution completed.
+     */
+    completedDate: Date;
+    /**
+     * Machine where test executed.
+     */
+    computerName: string;
+    /**
+     * Reference to test configuration.
+     */
+    configuration: ShallowReference;
+    /**
+     * Additional properties of sub result.
+     */
+    customFields: CustomTestField[];
+    /**
+     * Name of sub result.
+     */
+    displayName: string;
+    /**
+     * Duration of test execution.
+     */
+    durationInMs: number;
+    /**
+     * Error message in sub result.
+     */
+    errorMessage: string;
+    /**
+     * ID of sub result.
+     */
+    id: number;
+    /**
+     * Time when result last updated.
+     */
+    lastUpdatedDate: Date;
+    /**
+     * Outcome of sub result.
+     */
+    outcome: string;
+    /**
+     * Immediate parent ID of sub result.
+     */
+    parentId: number;
+    /**
+     * Hierarchy type of the result, default value of None means its leaf node.
+     */
+    resultGroupType: ResultGroupType;
+    /**
+     * Index number of sub result.
+     */
+    sequenceId: number;
+    /**
+     * Stacktrace.
+     */
+    stackTrace: string;
+    /**
+     * Time when test execution started.
+     */
+    startedDate: Date;
+    /**
+     * List of sub results inside a sub result, if ResultGroupType is not None, it holds corresponding type sub results.
+     */
+    subResults: TestSubResult[];
+    /**
+     * Reference to test result.
+     */
+    testResult: TestCaseResultIdentifier;
+    /**
+     * Url of sub result.
+     */
     url: string;
 }
 
+/**
+ * Test suite
+ */
+export interface TestSuite {
+    /**
+     * Area uri of the test suite.
+     */
+    areaUri: string;
+    /**
+     * Child test suites of current test suite.
+     */
+    children: TestSuite[];
+    /**
+     * Test suite default configuration.
+     */
+    defaultConfigurations: ShallowReference[];
+    /**
+     * Test suite default testers.
+     */
+    defaultTesters: ShallowReference[];
+    /**
+     * Id of test suite.
+     */
+    id: number;
+    /**
+     * Default configuration was inherited or not.
+     */
+    inheritDefaultConfigurations: boolean;
+    /**
+     * Last error for test suite.
+     */
+    lastError: string;
+    /**
+     * Last populated date.
+     */
+    lastPopulatedDate: Date;
+    /**
+     * IdentityRef of user who has updated test suite recently.
+     */
+    lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last update date.
+     */
+    lastUpdatedDate: Date;
+    /**
+     * Name of test suite.
+     */
+    name: string;
+    /**
+     * Test suite parent shallow reference.
+     */
+    parent: ShallowReference;
+    /**
+     * Test plan to which the test suite belongs.
+     */
+    plan: ShallowReference;
+    /**
+     * Test suite project shallow reference.
+     */
+    project: ShallowReference;
+    /**
+     * Test suite query string, for dynamic suites.
+     */
+    queryString: string;
+    /**
+     * Test suite requirement id.
+     */
+    requirementId: number;
+    /**
+     * Test suite revision.
+     */
+    revision: number;
+    /**
+     * State of test suite.
+     */
+    state: string;
+    /**
+     * List of shallow reference of suites.
+     */
+    suites: ShallowReference[];
+    /**
+     * Test suite type.
+     */
+    suiteType: string;
+    /**
+     * Test cases count.
+     */
+    testCaseCount: number;
+    /**
+     * Test case url.
+     */
+    testCasesUrl: string;
+    /**
+     * Used in tree view. If test suite is root suite then, it is name of plan otherwise title of the suite.
+     */
+    text: string;
+    /**
+     * Url of test suite.
+     */
+    url: string;
+}
+
+/**
+ * Test suite clone request
+ */
 export interface TestSuiteCloneRequest {
+    /**
+     * Clone options for cloning the test suite.
+     */
     cloneOptions: CloneOptions;
+    /**
+     * Suite id under which, we have to clone the suite.
+     */
     destinationSuiteId: number;
+    /**
+     * Destination suite project name.
+     */
     destinationSuiteProjectName: string;
 }
 
@@ -1620,16 +3461,23 @@ export interface WorkItemReference {
 }
 
 export interface WorkItemToTestLinks {
+    executedIn: Service;
     tests: TestMethod[];
     workItem: WorkItemReference;
 }
 
 export var TypeInfo = {
+    AfnStrip: <any>{
+    },
     AggregatedDataForResultTrend: <any>{
     },
     AggregatedResultsAnalysis: <any>{
     },
     AggregatedResultsByOutcome: <any>{
+    },
+    AggregatedRunsByOutcome: <any>{
+    },
+    AggregatedRunsByState: <any>{
     },
     AttachmentType: {
         enumValues: {
@@ -1649,6 +3497,12 @@ export var TypeInfo = {
     },
     BatchResponse: <any>{
     },
+    BuildConfiguration: <any>{
+    },
+    BuildCoverage: <any>{
+    },
+    BuildReference2: <any>{
+    },
     CloneOperationInformation: <any>{
     },
     CloneOperationState: {
@@ -1658,6 +3512,8 @@ export var TypeInfo = {
             "queued": 0,
             "succeeded": 3
         }
+    },
+    Coverage2: <any>{
     },
     CoverageQueryFlags: {
         enumValues: {
@@ -1687,9 +3543,17 @@ export var TypeInfo = {
             "guid": 14
         }
     },
+    DatedTestFieldData: <any>{
+    },
     FailingSince: <any>{
     },
     LastResultDetails: <any>{
+    },
+    ReleaseReference: <any>{
+    },
+    ReleaseReference2: <any>{
+    },
+    RequirementsToTestsMapping2: <any>{
     },
     Response: <any>{
     },
@@ -1697,7 +3561,18 @@ export var TypeInfo = {
         enumValues: {
             "none": 0,
             "iterations": 1,
-            "workItems": 2
+            "workItems": 2,
+            "subResults": 4,
+            "point": 8
+        }
+    },
+    ResultGroupType: {
+        enumValues: {
+            "none": 0,
+            "rerun": 1,
+            "dataDriven": 2,
+            "orderedTest": 3,
+            "generic": 4
         }
     },
     ResultObjectType: {
@@ -1712,11 +3587,30 @@ export var TypeInfo = {
     },
     ResultUpdateRequestModel: <any>{
     },
+    RunCreateModel: <any>{
+    },
     RunUpdateModel: <any>{
+    },
+    Service: {
+        enumValues: {
+            "any": 0,
+            "tcm": 1,
+            "tfs": 2
+        }
+    },
+    SuiteExpand: {
+        enumValues: {
+            "children": 1,
+            "defaultTesters": 2
+        }
+    },
+    TestActionResult2: <any>{
     },
     TestActionResultModel: <any>{
     },
     TestAttachment: <any>{
+    },
+    TestCaseReference2: <any>{
     },
     TestCaseResult: <any>{
     },
@@ -1728,11 +3622,17 @@ export var TypeInfo = {
             "inactive": 2
         }
     },
+    TestExecutionReportData: <any>{
+    },
     TestFailuresAnalysis: <any>{
+    },
+    TestHistoryQuery: <any>{
     },
     TestIterationDetailsModel: <any>{
     },
     TestMessageLogDetails: <any>{
+    },
+    TestMessageLogEntry2: <any>{
     },
     TestOutcome: {
         enumValues: {
@@ -1754,6 +3654,8 @@ export var TypeInfo = {
             "maxValue": 14
         }
     },
+    TestParameter2: <any>{
+    },
     TestPlan: <any>{
     },
     TestPlanCloneRequest: <any>{
@@ -1764,13 +3666,41 @@ export var TypeInfo = {
     },
     TestPoint: <any>{
     },
+    TestPointReference: <any>{
+    },
+    TestPointsEvent: <any>{
+    },
     TestPointsQuery: <any>{
+    },
+    TestPointState: {
+        enumValues: {
+            "none": 0,
+            "ready": 1,
+            "completed": 2,
+            "notReady": 3,
+            "inProgress": 4,
+            "maxValue": 4
+        }
+    },
+    TestPointsUpdatedEvent: <any>{
+    },
+    TestResult2: <any>{
+    },
+    TestResultGroupBy: {
+        enumValues: {
+            "branch": 1,
+            "environment": 2
+        }
     },
     TestResultHistory: <any>{
     },
     TestResultHistoryDetailsForGroup: <any>{
     },
+    TestResultHistoryForGroup: <any>{
+    },
     TestResultModelBase: <any>{
+    },
+    TestResultReset2: <any>{
     },
     TestResultsContext: <any>{
     },
@@ -1784,6 +3714,8 @@ export var TypeInfo = {
     },
     TestResultsDetailsForGroup: <any>{
     },
+    TestResultsEx2: <any>{
+    },
     TestResultsQuery: <any>{
     },
     TestResultSummary: <any>{
@@ -1792,12 +3724,32 @@ export var TypeInfo = {
     },
     TestRun: <any>{
     },
+    TestRun2: <any>{
+    },
+    TestRunCanceledEvent: <any>{
+    },
+    TestRunCreatedEvent: <any>{
+    },
+    TestRunEvent: <any>{
+    },
+    TestRunEx2: <any>{
+    },
+    TestRunOutcome: {
+        enumValues: {
+            "passed": 0,
+            "failed": 1,
+            "notImpacted": 2,
+            "others": 3
+        }
+    },
     TestRunPublishContext: {
         enumValues: {
             "build": 1,
             "release": 2,
             "all": 3
         }
+    },
+    TestRunStartedEvent: <any>{
     },
     TestRunState: {
         enumValues: {
@@ -1822,6 +3774,8 @@ export var TypeInfo = {
             "analyzed": 7,
             "cancellationInProgress": 8
         }
+    },
+    TestRunSummary2: <any>{
     },
     TestSession: <any>{
     },
@@ -1848,10 +3802,22 @@ export var TypeInfo = {
             "declined": 5
         }
     },
+    TestSettings2: <any>{
+    },
+    TestSubResult: <any>{
+    },
     TestSuite: <any>{
     },
     TestSummaryForWorkItem: <any>{
     },
+    WorkItemToTestLinks: <any>{
+    },
+};
+
+TypeInfo.AfnStrip.fields = {
+    creationDate: {
+        isDate: true,
+    }
 };
 
 TypeInfo.AggregatedDataForResultTrend.fields = {
@@ -1859,6 +3825,11 @@ TypeInfo.AggregatedDataForResultTrend.fields = {
         isDictionary: true,
         dictionaryKeyEnumType: TypeInfo.TestOutcome,
         dictionaryValueTypeInfo: TypeInfo.AggregatedResultsByOutcome
+    },
+    runSummaryByState: {
+        isDictionary: true,
+        dictionaryKeyEnumType: TypeInfo.TestRunState,
+        dictionaryValueTypeInfo: TypeInfo.AggregatedRunsByState
     },
     testResultsContext: {
         typeInfo: TypeInfo.TestResultsContext
@@ -1878,6 +3849,16 @@ TypeInfo.AggregatedResultsAnalysis.fields = {
         isDictionary: true,
         dictionaryKeyEnumType: TypeInfo.TestOutcome,
         dictionaryValueTypeInfo: TypeInfo.AggregatedResultsByOutcome
+    },
+    runSummaryByOutcome: {
+        isDictionary: true,
+        dictionaryKeyEnumType: TypeInfo.TestRunOutcome,
+        dictionaryValueTypeInfo: TypeInfo.AggregatedRunsByOutcome
+    },
+    runSummaryByState: {
+        isDictionary: true,
+        dictionaryKeyEnumType: TypeInfo.TestRunState,
+        dictionaryValueTypeInfo: TypeInfo.AggregatedRunsByState
     }
 };
 
@@ -1887,11 +3868,46 @@ TypeInfo.AggregatedResultsByOutcome.fields = {
     }
 };
 
+TypeInfo.AggregatedRunsByOutcome.fields = {
+    outcome: {
+        enumType: TypeInfo.TestRunOutcome
+    }
+};
+
+TypeInfo.AggregatedRunsByState.fields = {
+    resultsByOutcome: {
+        isDictionary: true,
+        dictionaryKeyEnumType: TypeInfo.TestOutcome,
+        dictionaryValueTypeInfo: TypeInfo.AggregatedResultsByOutcome
+    },
+    state: {
+        enumType: TypeInfo.TestRunState
+    }
+};
+
 TypeInfo.BatchResponse.fields = {
     responses: {
         isArray: true,
         typeInfo: TypeInfo.Response
     },
+};
+
+TypeInfo.BuildConfiguration.fields = {
+    creationDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.BuildCoverage.fields = {
+    configuration: {
+        typeInfo: TypeInfo.BuildConfiguration
+    }
+};
+
+TypeInfo.BuildReference2.fields = {
+    createdDate: {
+        isDate: true,
+    }
 };
 
 TypeInfo.CloneOperationInformation.fields = {
@@ -1909,6 +3925,15 @@ TypeInfo.CloneOperationInformation.fields = {
     }
 };
 
+TypeInfo.Coverage2.fields = {
+    dateCreated: {
+        isDate: true,
+    },
+    dateModified: {
+        isDate: true,
+    }
+};
+
 TypeInfo.CustomTestFieldDefinition.fields = {
     fieldType: {
         enumType: TypeInfo.CustomTestFieldType
@@ -1918,14 +3943,50 @@ TypeInfo.CustomTestFieldDefinition.fields = {
     }
 };
 
-TypeInfo.FailingSince.fields = {
+TypeInfo.DatedTestFieldData.fields = {
     date: {
         isDate: true,
     }
 };
 
+TypeInfo.FailingSince.fields = {
+    date: {
+        isDate: true,
+    },
+    release: {
+        typeInfo: TypeInfo.ReleaseReference
+    }
+};
+
 TypeInfo.LastResultDetails.fields = {
     dateCompleted: {
+        isDate: true,
+    }
+};
+
+TypeInfo.ReleaseReference.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    environmentCreationDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.ReleaseReference2.fields = {
+    environmentCreationDate: {
+        isDate: true,
+    },
+    releaseCreationDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.RequirementsToTestsMapping2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    deletionDate: {
         isDate: true,
     }
 };
@@ -1940,6 +4001,9 @@ TypeInfo.ResultRetentionSettings.fields = {
 };
 
 TypeInfo.ResultsFilter.fields = {
+    executedIn: {
+        enumType: TypeInfo.Service
+    },
     maxCompleteDate: {
         isDate: true,
     },
@@ -1959,6 +4023,15 @@ TypeInfo.ResultUpdateRequestModel.fields = {
     }
 };
 
+TypeInfo.RunCreateModel.fields = {
+    buildReference: {
+        typeInfo: TypeInfo.BuildConfiguration
+    },
+    releaseReference: {
+        typeInfo: TypeInfo.ReleaseReference
+    }
+};
+
 TypeInfo.RunUpdateModel.fields = {
     logEntries: {
         isArray: true,
@@ -1966,6 +4039,21 @@ TypeInfo.RunUpdateModel.fields = {
     },
     substate: {
         enumType: TypeInfo.TestRunSubstate
+    }
+};
+
+TypeInfo.TestActionResult2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    dateCompleted: {
+        isDate: true,
+    },
+    dateStarted: {
+        isDate: true,
+    },
+    lastUpdated: {
+        isDate: true,
     }
 };
 
@@ -1987,6 +4075,15 @@ TypeInfo.TestAttachment.fields = {
     }
 };
 
+TypeInfo.TestCaseReference2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    lastRefTestRunDate: {
+        isDate: true,
+    }
+};
+
 TypeInfo.TestCaseResult.fields = {
     completedDate: {
         isDate: true,
@@ -2004,8 +4101,18 @@ TypeInfo.TestCaseResult.fields = {
     lastUpdatedDate: {
         isDate: true,
     },
+    releaseReference: {
+        typeInfo: TypeInfo.ReleaseReference
+    },
+    resultGroupType: {
+        enumType: TypeInfo.ResultGroupType
+    },
     startedDate: {
         isDate: true,
+    },
+    subResults: {
+        isArray: true,
+        typeInfo: TypeInfo.TestSubResult
     }
 };
 
@@ -2018,9 +4125,29 @@ TypeInfo.TestConfiguration.fields = {
     }
 };
 
+TypeInfo.TestExecutionReportData.fields = {
+    reportData: {
+        isArray: true,
+        typeInfo: TypeInfo.DatedTestFieldData
+    }
+};
+
 TypeInfo.TestFailuresAnalysis.fields = {
     previousContext: {
         typeInfo: TypeInfo.TestResultsContext
+    }
+};
+
+TypeInfo.TestHistoryQuery.fields = {
+    groupBy: {
+        enumType: TypeInfo.TestResultGroupBy
+    },
+    maxCompleteDate: {
+        isDate: true,
+    },
+    resultsForGroup: {
+        isArray: true,
+        typeInfo: TypeInfo.TestResultHistoryForGroup
     }
 };
 
@@ -2039,6 +4166,21 @@ TypeInfo.TestIterationDetailsModel.fields = {
 
 TypeInfo.TestMessageLogDetails.fields = {
     dateCreated: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TestMessageLogEntry2.fields = {
+    dateCreated: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TestParameter2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    dateModified: {
         isDate: true,
     }
 };
@@ -2091,10 +4233,45 @@ TypeInfo.TestPoint.fields = {
     }
 };
 
+TypeInfo.TestPointReference.fields = {
+    state: {
+        enumType: TypeInfo.TestPointState
+    }
+};
+
+TypeInfo.TestPointsEvent.fields = {
+    testPoints: {
+        isArray: true,
+        typeInfo: TypeInfo.TestPointReference
+    }
+};
+
 TypeInfo.TestPointsQuery.fields = {
     points: {
         isArray: true,
         typeInfo: TypeInfo.TestPoint
+    }
+};
+
+TypeInfo.TestPointsUpdatedEvent.fields = {
+    testPoints: {
+        isArray: true,
+        typeInfo: TypeInfo.TestPointReference
+    }
+};
+
+TypeInfo.TestResult2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    dateCompleted: {
+        isDate: true,
+    },
+    dateStarted: {
+        isDate: true,
+    },
+    lastUpdated: {
+        isDate: true,
     }
 };
 
@@ -2111,6 +4288,13 @@ TypeInfo.TestResultHistoryDetailsForGroup.fields = {
     }
 };
 
+TypeInfo.TestResultHistoryForGroup.fields = {
+    results: {
+        isArray: true,
+        typeInfo: TypeInfo.TestCaseResult
+    }
+};
+
 TypeInfo.TestResultModelBase.fields = {
     completedDate: {
         isDate: true,
@@ -2120,9 +4304,18 @@ TypeInfo.TestResultModelBase.fields = {
     }
 };
 
+TypeInfo.TestResultReset2.fields = {
+    dateModified: {
+        isDate: true,
+    }
+};
+
 TypeInfo.TestResultsContext.fields = {
     contextType: {
         enumType: TypeInfo.TestResultsContextType
+    },
+    release: {
+        typeInfo: TypeInfo.ReleaseReference
     }
 };
 
@@ -2142,6 +4335,15 @@ TypeInfo.TestResultsDetailsForGroup.fields = {
         isDictionary: true,
         dictionaryKeyEnumType: TypeInfo.TestOutcome,
         dictionaryValueTypeInfo: TypeInfo.AggregatedResultsByOutcome
+    }
+};
+
+TypeInfo.TestResultsEx2.fields = {
+    creationDate: {
+        isDate: true,
+    },
+    dateTimeValue: {
+        isDate: true,
     }
 };
 
@@ -2177,6 +4379,9 @@ TypeInfo.TestResultTrendFilter.fields = {
 };
 
 TypeInfo.TestRun.fields = {
+    buildConfiguration: {
+        typeInfo: TypeInfo.BuildConfiguration
+    },
     completedDate: {
         isDate: true,
     },
@@ -2189,11 +4394,71 @@ TypeInfo.TestRun.fields = {
     lastUpdatedDate: {
         isDate: true,
     },
+    release: {
+        typeInfo: TypeInfo.ReleaseReference
+    },
     startedDate: {
         isDate: true,
     },
     substate: {
         enumType: TypeInfo.TestRunSubstate
+    }
+};
+
+TypeInfo.TestRun2.fields = {
+    completeDate: {
+        isDate: true,
+    },
+    creationDate: {
+        isDate: true,
+    },
+    dueDate: {
+        isDate: true,
+    },
+    lastUpdated: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TestRunCanceledEvent.fields = {
+    testRun: {
+        typeInfo: TypeInfo.TestRun
+    }
+};
+
+TypeInfo.TestRunCreatedEvent.fields = {
+    testRun: {
+        typeInfo: TypeInfo.TestRun
+    }
+};
+
+TypeInfo.TestRunEvent.fields = {
+    testRun: {
+        typeInfo: TypeInfo.TestRun
+    }
+};
+
+TypeInfo.TestRunEx2.fields = {
+    createdDate: {
+        isDate: true,
+    },
+    dateTimeValue: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TestRunStartedEvent.fields = {
+    testRun: {
+        typeInfo: TypeInfo.TestRun
+    }
+};
+
+TypeInfo.TestRunSummary2.fields = {
+    testRunCompletedDate: {
+        isDate: true,
     }
 };
 
@@ -2224,6 +4489,34 @@ TypeInfo.TestSessionExploredWorkItemReference.fields = {
     }
 };
 
+TypeInfo.TestSettings2.fields = {
+    createdDate: {
+        isDate: true,
+    },
+    lastUpdatedDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.TestSubResult.fields = {
+    completedDate: {
+        isDate: true,
+    },
+    lastUpdatedDate: {
+        isDate: true,
+    },
+    resultGroupType: {
+        enumType: TypeInfo.ResultGroupType
+    },
+    startedDate: {
+        isDate: true,
+    },
+    subResults: {
+        isArray: true,
+        typeInfo: TypeInfo.TestSubResult
+    }
+};
+
 TypeInfo.TestSuite.fields = {
     children: {
         isArray: true,
@@ -2240,5 +4533,11 @@ TypeInfo.TestSuite.fields = {
 TypeInfo.TestSummaryForWorkItem.fields = {
     summary: {
         typeInfo: TypeInfo.AggregatedDataForResultTrend
+    }
+};
+
+TypeInfo.WorkItemToTestLinks.fields = {
+    executedIn: {
+        enumType: TypeInfo.Service
     }
 };

--- a/api/interfaces/TfvcInterfaces.ts
+++ b/api/interfaces/TfvcInterfaces.ts
@@ -80,6 +80,10 @@ export interface GitRepository {
     parentRepository: GitRepositoryRef;
     project: TfsCoreInterfaces.TeamProjectReference;
     remoteUrl: string;
+    /**
+     * Compressed size (bytes) of the repository.
+     */
+    size: number;
     sshUrl: string;
     url: string;
     validRemoteUrls: string[];
@@ -114,6 +118,7 @@ export enum ItemContentType {
 
 export interface ItemModel {
     _links: any;
+    content: string;
     contentMetadata: FileContentMetadata;
     isFolder: boolean;
     isSymLink: boolean;
@@ -291,6 +296,7 @@ export interface TfvcChangesetSearchCriteria {
      * Path of item to search under
      */
     itemPath: string;
+    mappings: TfvcMappingFilter[];
     /**
      * If provided, only include changesets created before this date (string) Think of a better name for this.
      */
@@ -319,6 +325,10 @@ export interface TfvcChangesetsRequestData {
 export interface TfvcItem extends ItemModel {
     changeDate: Date;
     deletionId: number;
+    /**
+     * File encoding from database, -1 represents binary.
+     */
+    encoding: number;
     /**
      * MD5 hash as a base 64 string, applies to files only.
      */
@@ -380,6 +390,11 @@ export interface TfvcLabelRequestData {
     maxItemCount: number;
     name: string;
     owner: string;
+}
+
+export interface TfvcMappingFilter {
+    exclude: boolean;
+    serverPath: string;
 }
 
 export interface TfvcMergeSource {
@@ -471,6 +486,17 @@ export interface TfvcShelvesetRequestData {
      * Owner's ID. Could be a name or a guid.
      */
     owner: string;
+}
+
+export interface TfvcStatistics {
+    /**
+     * Id of the last changeset the stats are based on.
+     */
+    changesetId: number;
+    /**
+     * Count of files at the requested scope.
+     */
+    fileCountTotal: number;
 }
 
 export interface TfvcVersionDescriptor {

--- a/api/interfaces/WorkInterfaces.ts
+++ b/api/interfaces/WorkInterfaces.ts
@@ -111,6 +111,10 @@ export interface BacklogLevelConfiguration {
      */
     id: string;
     /**
+     * Indicates whether the backlog level is hidden
+     */
+    isHidden: boolean;
+    /**
      * Backlog Name
      */
     name: string;
@@ -119,6 +123,10 @@ export interface BacklogLevelConfiguration {
      */
     rank: number;
     /**
+     * The type of this backlog level
+     */
+    type: BacklogType;
+    /**
      * Max number of work items to show in the given backlog
      */
     workItemCountLimit: number;
@@ -126,6 +134,34 @@ export interface BacklogLevelConfiguration {
      * Work Item types participating in this backlog as known by the project/Process, can be overridden by team settings for bugs
      */
     workItemTypes: WorkItemTrackingInterfaces.WorkItemTypeReference[];
+}
+
+/**
+ * Represents work items in a backlog level
+ */
+export interface BacklogLevelWorkItems {
+    /**
+     * A list of work items within a backlog level
+     */
+    workItems: WorkItemTrackingInterfaces.WorkItemLink[];
+}
+
+/**
+ * Definition of the type of backlog level
+ */
+export enum BacklogType {
+    /**
+     * Portfolio backlog level
+     */
+    Portfolio = 0,
+    /**
+     * Requirement backlog level
+     */
+    Requirement = 1,
+    /**
+     * Task backlog level
+     */
+    Task = 2,
 }
 
 export interface Board extends BoardReference {
@@ -363,7 +399,7 @@ export interface DeliveryViewData extends PlanViewData {
 /**
  * Collection of properties, specific to the DeliveryTimelineView
  */
-export interface DeliveryViewPropertyCollection extends PlanPropertyCollection {
+export interface DeliveryViewPropertyCollection {
     /**
      * Card settings
      */
@@ -461,6 +497,16 @@ export enum IdentityDisplayFormat {
      * Display Avatar and Full name
      */
     AvatarAndFullName = 2,
+}
+
+/**
+ * Represents work items in an iteration backlog
+ */
+export interface IterationWorkItems extends TeamSettingsDataContractBase {
+    /**
+     * Work item relations
+     */
+    workItemRelations: WorkItemTrackingInterfaces.WorkItemLink[];
 }
 
 /**
@@ -572,12 +618,6 @@ export interface PlanMetadata {
 }
 
 /**
- * Base class for properties of a scaled agile plan
- */
-export interface PlanPropertyCollection {
-}
-
-/**
  * Enum for the various types of plans
  */
 export enum PlanType {
@@ -620,6 +660,36 @@ export enum PlanUserPermissions {
 export interface PlanViewData {
     id: string;
     revision: number;
+}
+
+/**
+ * Represents a single pre-defined query.
+ */
+export interface PredefinedQuery {
+    /**
+     * Whether or not the query returned the complete set of data or if the data was truncated.
+     */
+    hasMore: boolean;
+    /**
+     * Id of the query
+     */
+    id: string;
+    /**
+     * Localized name of the query
+     */
+    name: string;
+    /**
+     * The results of the query.  This will be a set of WorkItem objects with only the 'id' set.  The client is responsible for paging in the data as needed.
+     */
+    results: WorkItemTrackingInterfaces.WorkItem[];
+    /**
+     * REST API Url to use to retrieve results for this query
+     */
+    url: string;
+    /**
+     * Url to use to display a page in the browser with the results of this query
+     */
+    webUrl: string;
 }
 
 /**
@@ -1023,6 +1093,15 @@ export interface WorkItemTypeStateInfo {
 export var TypeInfo = {
     BacklogConfiguration: <any>{
     },
+    BacklogLevelConfiguration: <any>{
+    },
+    BacklogType: {
+        enumValues: {
+            "portfolio": 0,
+            "requirement": 1,
+            "task": 2
+        }
+    },
     Board: <any>{
     },
     BoardColumn: <any>{
@@ -1158,6 +1237,22 @@ export var TypeInfo = {
 TypeInfo.BacklogConfiguration.fields = {
     bugsBehavior: {
         enumType: TypeInfo.BugsBehavior
+    },
+    portfolioBacklogs: {
+        isArray: true,
+        typeInfo: TypeInfo.BacklogLevelConfiguration
+    },
+    requirementBacklog: {
+        typeInfo: TypeInfo.BacklogLevelConfiguration
+    },
+    taskBacklog: {
+        typeInfo: TypeInfo.BacklogLevelConfiguration
+    }
+};
+
+TypeInfo.BacklogLevelConfiguration.fields = {
+    type: {
+        enumType: TypeInfo.BacklogType
     }
 };
 

--- a/api/interfaces/WorkItemTrackingProcessDefinitionsInterfaces.ts
+++ b/api/interfaces/WorkItemTrackingProcessDefinitionsInterfaces.ts
@@ -18,6 +18,10 @@ export interface BehaviorCreateModel {
      */
     color: string;
     /**
+     * Optional - Id
+     */
+    id: string;
+    /**
      * Parent behavior id
      */
     inherits: string;
@@ -474,6 +478,21 @@ export interface WorkItemTypeFieldModel {
     url: string;
 }
 
+/**
+ * New version of WorkItemTypeFieldModel supporting defaultValue as object (such as IdentityRef)
+ */
+export interface WorkItemTypeFieldModel2 {
+    allowGroups: boolean;
+    defaultValue: any;
+    name: string;
+    pickList: PickListMetadataModel;
+    readOnly: boolean;
+    referenceName: string;
+    required: boolean;
+    type: FieldType;
+    url: string;
+}
+
 export interface WorkItemTypeModel {
     /**
      * Behaviors of the work item type
@@ -594,6 +613,8 @@ export var TypeInfo = {
     },
     WorkItemTypeFieldModel: <any>{
     },
+    WorkItemTypeFieldModel2: <any>{
+    },
     WorkItemTypeModel: <any>{
     },
 };
@@ -618,6 +639,12 @@ TypeInfo.Page.fields = {
 };
 
 TypeInfo.WorkItemTypeFieldModel.fields = {
+    type: {
+        enumType: TypeInfo.FieldType
+    }
+};
+
+TypeInfo.WorkItemTypeFieldModel2.fields = {
     type: {
         enumType: TypeInfo.FieldType
     }

--- a/api/interfaces/WorkItemTrackingProcessInterfaces.ts
+++ b/api/interfaces/WorkItemTrackingProcessInterfaces.ts
@@ -13,6 +13,32 @@
 
 
 /**
+ * Class that describes a request to add a field in a work item type.
+ */
+export interface AddProcessWorkItemTypeFieldRequest {
+    /**
+     * Allow setting field value to a group identity. Only applies to identity fields.
+     */
+    allowGroups: boolean;
+    /**
+     * The default value of the field.
+     */
+    defaultValue: any;
+    /**
+     * If true the field cannot be edited.
+     */
+    readOnly: boolean;
+    /**
+     * Reference name of the field.
+     */
+    referenceName: string;
+    /**
+     * If true the field cannot be empty.
+     */
+    required: boolean;
+}
+
+/**
  * Represent a control in the form.
  */
 export interface Control {
@@ -33,7 +59,7 @@ export interface Control {
      */
     id: string;
     /**
-     * A value indicating whether this layout node has been inherited from a parent layout.  This is expected to only be only set by the combiner.
+     * A value indicating whether this layout node has been inherited. from a parent layout.  This is expected to only be only set by the combiner.
      */
     inherited: boolean;
     /**
@@ -41,16 +67,19 @@ export interface Control {
      */
     isContribution: boolean;
     /**
-     * Label for the field
+     * Label for the field.
      */
     label: string;
     /**
      * Inner text of the control.
      */
     metadata: string;
+    /**
+     * Order in which the control should appear in its group.
+     */
     order: number;
     /**
-     * A value indicating whether this layout node has been overridden by a child layout.
+     * A value indicating whether this layout node has been overridden . by a child layout.
      */
     overridden: boolean;
     /**
@@ -87,9 +116,82 @@ export interface CreateProcessModel {
 }
 
 /**
+ * Request object/class for creating a rule on a work item type.
+ */
+export interface CreateProcessRuleRequest {
+    /**
+     * List of actions to take when the rule is triggered.
+     */
+    actions: RuleAction[];
+    /**
+     * List of conditions when the rule should be triggered.
+     */
+    conditions: RuleCondition[];
+    /**
+     * Indicates if the rule is disabled.
+     */
+    isDisabled: boolean;
+    /**
+     * Name for the rule.
+     */
+    name: string;
+}
+
+/**
+ * Class for create work item type request
+ */
+export interface CreateProcessWorkItemTypeRequest {
+    /**
+     * Color hexadecimal code to represent the work item type
+     */
+    color: string;
+    /**
+     * Description of the work item type
+     */
+    description: string;
+    /**
+     * Icon to represent the work item type
+     */
+    icon: string;
+    /**
+     * Parent work item type for work item type
+     */
+    inheritsFrom: string;
+    /**
+     * True if the work item type need to be disabled
+     */
+    isDisabled: boolean;
+    /**
+     * Name of work item type
+     */
+    name: string;
+}
+
+/**
+ * Indicates the customization-type. Customization-type is System if is system generated or by default. Customization-type is Inherited if the existing workitemtype of inherited process is customized. Customization-type is Custom if the newly created workitemtype is customized.
+ */
+export enum CustomizationType {
+    /**
+     * Customization-type is System if is system generated workitemtype.
+     */
+    System = 1,
+    /**
+     * Customization-type is Inherited if the existing workitemtype of inherited process is customized.
+     */
+    Inherited = 2,
+    /**
+     * Customization-type is Custom if the newly created workitemtype is customized.
+     */
+    Custom = 3,
+}
+
+/**
  * Represents the extensions part of the layout
  */
 export interface Extension {
+    /**
+     * Id of the extension
+     */
     id: string;
 }
 
@@ -111,6 +213,9 @@ export interface FieldRuleModel {
     isSystem: boolean;
 }
 
+/**
+ * Enum for the type of a field.
+ */
 export enum FieldType {
     String = 1,
     Integer = 2,
@@ -128,9 +233,12 @@ export enum FieldType {
     PicklistDouble = 16,
 }
 
+/**
+ * Describes the layout of a work item type
+ */
 export interface FormLayout {
     /**
-     * Gets and sets extensions list
+     * Gets and sets extensions list.
      */
     extensions: Extension[];
     /**
@@ -143,9 +251,22 @@ export interface FormLayout {
     systemControls: Control[];
 }
 
+/**
+ * Expand options to fetch fields for behaviors API.
+ */
 export enum GetBehaviorsExpand {
+    /**
+     * Default none option.
+     */
     None = 0,
+    /**
+     * This option returns fields associated with a behavior.
+     */
     Fields = 1,
+    /**
+     * This option returns fields associated with this behavior and all behaviors from which it inherits.
+     */
+    CombinedFields = 2,
 }
 
 export enum GetProcessExpandLevel {
@@ -153,6 +274,9 @@ export enum GetProcessExpandLevel {
     Projects = 1,
 }
 
+/**
+ * Flag to define what properties to return in get work item type response.
+ */
 export enum GetWorkItemTypeExpand {
     None = 0,
     States = 1,
@@ -206,6 +330,13 @@ export interface Group {
     visible: boolean;
 }
 
+export interface HideStateModel {
+    hidden: boolean;
+}
+
+/**
+ * Describes a page in the work item form layout
+ */
 export interface Page {
     /**
      * Contribution for the page.
@@ -253,6 +384,9 @@ export interface Page {
     visible: boolean;
 }
 
+/**
+ * Enum for the types of pages in the work item form layout
+ */
 export enum PageType {
     Custom = 1,
     History = 2,
@@ -260,10 +394,194 @@ export enum PageType {
     Attachments = 4,
 }
 
+/**
+ * Picklist.
+ */
+export interface PickList extends PickListMetadata {
+    /**
+     * A list of PicklistItemModel.
+     */
+    items: string[];
+}
+
+/**
+ * Metadata for picklist.
+ */
+export interface PickListMetadata {
+    /**
+     * ID of the picklist
+     */
+    id: string;
+    /**
+     * Indicates whether items outside of suggested list are allowed
+     */
+    isSuggested: boolean;
+    /**
+     * Name of the picklist
+     */
+    name: string;
+    /**
+     * DataType of picklist
+     */
+    type: string;
+    /**
+     * Url of the picklist
+     */
+    url: string;
+}
+
+/**
+ * Process Behavior Model.
+ */
+export interface ProcessBehavior {
+    /**
+     * Color.
+     */
+    color: string;
+    /**
+     * Indicates the type of customization on this work item. System behaviors are inherited from parent process but not modified. Inherited behaviors are modified modified behaviors that were inherited from parent process. Custom behaviors are behaviors created by user in current process.
+     */
+    customization: CustomizationType;
+    /**
+     * . Description
+     */
+    description: string;
+    /**
+     * Process Behavior Fields.
+     */
+    fields: ProcessBehaviorField[];
+    /**
+     * Parent behavior reference.
+     */
+    inherits: ProcessBehaviorReference;
+    /**
+     * Behavior Name.
+     */
+    name: string;
+    /**
+     * Rank of the behavior
+     */
+    rank: number;
+    /**
+     * Behavior Id
+     */
+    referenceName: string;
+    /**
+     * Url of the behavior.
+     */
+    url: string;
+}
+
+/**
+ * Process Behavior Create Payload.
+ */
+export interface ProcessBehaviorCreateRequest {
+    /**
+     * Color.
+     */
+    color: string;
+    /**
+     * Parent behavior id.
+     */
+    inherits: string;
+    /**
+     * Name of the behavior.
+     */
+    name: string;
+    /**
+     * ReferenceName is optional, if not specified will be auto-generated.
+     */
+    referenceName: string;
+}
+
+/**
+ * Process Behavior Field.
+ */
+export interface ProcessBehaviorField {
+    /**
+     * Name of the field.
+     */
+    name: string;
+    /**
+     * Reference name of the field.
+     */
+    referenceName: string;
+    /**
+     * Url to field.
+     */
+    url: string;
+}
+
+/**
+ * Process behavior Reference.
+ */
+export interface ProcessBehaviorReference {
+    /**
+     * Id of a Behavior.
+     */
+    behaviorRefName: string;
+    /**
+     * Url to behavior.
+     */
+    url: string;
+}
+
+/**
+ * Process Behavior Replace Payload.
+ */
+export interface ProcessBehaviorUpdateRequest {
+    /**
+     * Color.
+     */
+    color: string;
+    /**
+     * Behavior Name.
+     */
+    name: string;
+}
+
 export enum ProcessClass {
     System = 0,
     Derived = 1,
     Custom = 2,
+}
+
+/**
+ * Process.
+ */
+export interface ProcessInfo {
+    /**
+     * Indicates the type of customization on this process. System Process is default process. Inherited Process is modified process that was System process before.
+     */
+    customizationType: CustomizationType;
+    /**
+     * Description of the process.
+     */
+    description: string;
+    /**
+     * Is the process enabled.
+     */
+    isEnabled: boolean;
+    /**
+     * Name of the process.
+     */
+    name: string;
+    /**
+     * ID of the parent process.
+     */
+    parentProcessTypeId: string;
+    /**
+     * Projects in this process to which the user is subscribed to.
+     */
+    projects: ProjectReference[];
+    /**
+     * Reference name of the process.
+     */
+    referenceName: string;
+    /**
+     * The ID of the process.
+     */
+    typeId: string;
 }
 
 export interface ProcessModel {
@@ -294,29 +612,135 @@ export interface ProcessModel {
 }
 
 /**
- * Properties of the process
+ * Properties of the process.
  */
 export interface ProcessProperties {
     /**
-     * Class of the process
+     * Class of the process.
      */
     class: ProcessClass;
     /**
-     * Is the process default process
+     * Is the process default process.
      */
     isDefault: boolean;
     /**
-     * Is the process enabled
+     * Is the process enabled.
      */
     isEnabled: boolean;
     /**
-     * ID of the parent process
+     * ID of the parent process.
      */
     parentProcessTypeId: string;
     /**
-     * Version of the process
+     * Version of the process.
      */
     version: string;
+}
+
+/**
+ * Process Rule Response.
+ */
+export interface ProcessRule extends CreateProcessRuleRequest {
+    /**
+     * Indicates if the rule is system generated or created by user.
+     */
+    customizationType: CustomizationType;
+    /**
+     * Id to uniquely identify the rule.
+     */
+    id: string;
+    /**
+     * Resource Url.
+     */
+    url: string;
+}
+
+/**
+ * Class that describes a work item type object
+ */
+export interface ProcessWorkItemType {
+    behaviors: WorkItemTypeBehavior[];
+    /**
+     * Color hexadecimal code to represent the work item type
+     */
+    color: string;
+    /**
+     * Indicates the type of customization on this work item System work item types are inherited from parent process but not modified Inherited work item types are modified work item that were inherited from parent process Custom work item types are work item types that were created in the current process
+     */
+    customization: CustomizationType;
+    /**
+     * Description of the work item type
+     */
+    description: string;
+    /**
+     * Icon to represent the work item typ
+     */
+    icon: string;
+    /**
+     * Reference name of the parent work item type
+     */
+    inherits: string;
+    /**
+     * Indicates if a work item type is disabled
+     */
+    isDisabled: boolean;
+    layout: FormLayout;
+    /**
+     * Name of the work item type
+     */
+    name: string;
+    /**
+     * Reference name of work item type
+     */
+    referenceName: string;
+    states: WorkItemStateResultModel[];
+    /**
+     * Url of the work item type
+     */
+    url: string;
+}
+
+/**
+ * Class that describes a field in a work item type and its properties.
+ */
+export interface ProcessWorkItemTypeField {
+    /**
+     * Allow setting field value to a group identity. Only applies to identity fields.
+     */
+    allowGroups: boolean;
+    customization: CustomizationType;
+    /**
+     * The default value of the field.
+     */
+    defaultValue: any;
+    /**
+     * Description of the field.
+     */
+    description: string;
+    /**
+     * Name of the field.
+     */
+    name: string;
+    /**
+     * If true the field cannot be edited.
+     */
+    readOnly: boolean;
+    /**
+     * Reference name of the field.
+     */
+    referenceName: string;
+    /**
+     * If true the field cannot be empty.
+     */
+    required: boolean;
+    /**
+     * Type of the field.
+     */
+    type: FieldType;
+    /**
+     * Resource URL of the field.
+     */
+    url: string;
 }
 
 export interface ProjectReference {
@@ -338,9 +762,100 @@ export interface ProjectReference {
     url: string;
 }
 
+export interface RuleAction {
+    /**
+     * Type of action to take when the rule is triggered.
+     */
+    actionType: RuleActionType;
+    /**
+     * Field on which the action should be taken.
+     */
+    targetField: string;
+    /**
+     * Value to apply on target field, once the action is taken.
+     */
+    value: string;
+}
+
 export interface RuleActionModel {
     actionType: string;
     targetField: string;
+    value: string;
+}
+
+/**
+ * Type of action to take when the rule is triggered.
+ */
+export enum RuleActionType {
+    /**
+     * Make the target field required. Example : {"actionType":"$makeRequired","targetField":"Microsoft.VSTS.Common.Activity","value":""}
+     */
+    MakeRequired = 1,
+    /**
+     * Make the target field read-only. Example : {"actionType":"$makeReadOnly","targetField":"Microsoft.VSTS.Common.Activity","value":""}
+     */
+    MakeReadOnly = 2,
+    /**
+     * Set a default value on the target field. This is used if the user creates a integer/string field and sets a default value of this field.
+     */
+    SetDefaultValue = 3,
+    /**
+     * Set the default value on the target field from server clock. This is used if user creates the field like Date/Time and uses default value.
+     */
+    SetDefaultFromClock = 4,
+    /**
+     * Set the default current user value on the target field. This is used if the user creates the field of type identity and uses default value.
+     */
+    SetDefaultFromCurrentUser = 5,
+    /**
+     * Set the default value on from existing field to the target field.  This used wants to set a existing field value to the current field.
+     */
+    SetDefaultFromField = 6,
+    /**
+     * Set the value of target field to given value. Example : {actionType: "$copyValue", targetField: "ScrumInherited.mypicklist", value: "samplevalue"}
+     */
+    CopyValue = 7,
+    /**
+     * Set the value from clock.
+     */
+    CopyFromClock = 8,
+    /**
+     * Set the current user to the target field. Example : {"actionType":"$copyFromCurrentUser","targetField":"System.AssignedTo","value":""}.
+     */
+    CopyFromCurrentUser = 9,
+    /**
+     * Copy the value from a specified field and set to target field. Example : {actionType: "$copyFromField", targetField: "System.AssignedTo", value:"System.ChangedBy"}. Here, value is copied from "System.ChangedBy" and set to "System.AssingedTo" field.
+     */
+    CopyFromField = 10,
+    /**
+     * Set the value of the target field to empty.
+     */
+    SetValueToEmpty = 11,
+    /**
+     * Use the current time to set the value of the target field. Example : {actionType: "$copyFromServerClock", targetField: "System.CreatedDate", value: ""}
+     */
+    CopyFromServerClock = 12,
+    /**
+     * Use the current user to set the value of the target field.
+     */
+    CopyFromServerCurrentUser = 13,
+}
+
+/**
+ * Defines a condition on a field when the rule should be triggered.
+ */
+export interface RuleCondition {
+    /**
+     * Type of condition. $When. This condition limits the execution of its children to cases when another field has a particular value, i.e. when the Is value of the referenced field is equal to the given literal value. $WhenNot.This condition limits the execution of its children to cases when another field does not have a particular value, i.e.when the Is value of the referenced field is not equal to the given literal value. $WhenChanged.This condition limits the execution of its children to cases when another field has changed, i.e.when the Is value of the referenced field is not equal to the Was value of that field. $WhenNotChanged.This condition limits the execution of its children to cases when another field has not changed, i.e.when the Is value of the referenced field is equal to the Was value of that field.
+     */
+    conditionType: RuleConditionType;
+    /**
+     * Field that defines condition.
+     */
+    field: string;
+    /**
+     * Value of field to define the condition for rule.
+     */
     value: string;
 }
 
@@ -350,7 +865,41 @@ export interface RuleConditionModel {
     value: string;
 }
 
+/**
+ * Type of rule condition.
+ */
+export enum RuleConditionType {
+    /**
+     * $When. This condition limits the execution of its children to cases when another field has a particular value, i.e. when the Is value of the referenced field is equal to the given literal value.
+     */
+    When = 1,
+    /**
+     * $WhenNot.This condition limits the execution of its children to cases when another field does not have a particular value, i.e.when the Is value of the referenced field is not equal to the given literal value.
+     */
+    WhenNot = 2,
+    /**
+     * $WhenChanged.This condition limits the execution of its children to cases when another field has changed, i.e.when the Is value of the referenced field is not equal to the Was value of that field.
+     */
+    WhenChanged = 3,
+    /**
+     * $WhenNotChanged.This condition limits the execution of its children to cases when another field has not changed, i.e.when the Is value of the referenced field is equal to the Was value of that field.
+     */
+    WhenNotChanged = 4,
+    WhenWas = 5,
+    WhenStateChangedTo = 6,
+    WhenStateChangedFromAndTo = 7,
+    WhenWorkItemIsCreated = 8,
+    WhenValueIsDefined = 9,
+    WhenValueIsNotDefined = 10,
+}
+
+/**
+ * Defines a section of the work item form layout
+ */
 export interface Section {
+    /**
+     * List of child groups in this section
+     */
     groups: Group[];
     /**
      * The id for the layout node.
@@ -362,13 +911,85 @@ export interface Section {
     overridden: boolean;
 }
 
+/**
+ * Describes a request to update a process
+ */
 export interface UpdateProcessModel {
+    /**
+     * New description of the process
+     */
     description: string;
+    /**
+     * If true new projects will use this process by default
+     */
     isDefault: boolean;
+    /**
+     * If false the process will be disabled and cannot be used to create projects
+     */
     isEnabled: boolean;
+    /**
+     * New name of the process
+     */
     name: string;
 }
 
+/**
+ * Request class/object to update the rule.
+ */
+export interface UpdateProcessRuleRequest extends CreateProcessRuleRequest {
+    /**
+     * Id to uniquely identify the rule.
+     */
+    id: string;
+}
+
+/**
+ * Class to describe a request that updates a field's properties in a work item type.
+ */
+export interface UpdateProcessWorkItemTypeFieldRequest {
+    /**
+     * Allow setting field value to a group identity. Only applies to identity fields.
+     */
+    allowGroups: boolean;
+    /**
+     * The default value of the field.
+     */
+    defaultValue: any;
+    /**
+     * If true the field cannot be edited.
+     */
+    readOnly: boolean;
+    /**
+     * The default value of the field.
+     */
+    required: boolean;
+}
+
+/**
+ * Class for update request on a work item type
+ */
+export interface UpdateProcessWorkItemTypeRequest {
+    /**
+     * Color of the work item type
+     */
+    color: string;
+    /**
+     * Description of the work item type
+     */
+    description: string;
+    /**
+     * Icon of the work item type
+     */
+    icon: string;
+    /**
+     * If set will disable the work item type
+     */
+    isDisabled: boolean;
+}
+
+/**
+ * Properties of a work item form contribution
+ */
 export interface WitContribution {
     /**
      * The id for the contribution.
@@ -412,8 +1033,28 @@ export interface WorkItemBehaviorReference {
     url: string;
 }
 
+export interface WorkItemStateInputModel {
+    /**
+     * Color of the state
+     */
+    color: string;
+    /**
+     * Name of the state
+     */
+    name: string;
+    /**
+     * Order in which state should appear
+     */
+    order: number;
+    /**
+     * Category of the state
+     */
+    stateCategory: string;
+}
+
 export interface WorkItemStateResultModel {
     color: string;
+    customizationType: CustomizationType;
     hidden: boolean;
     id: string;
     name: string;
@@ -422,9 +1063,21 @@ export interface WorkItemStateResultModel {
     url: string;
 }
 
+/**
+ * Association between a work item type and it's behavior
+ */
 export interface WorkItemTypeBehavior {
+    /**
+     * Reference to the behavior of a work item type
+     */
     behavior: WorkItemBehaviorReference;
+    /**
+     * If true the work item type is the default work item type in the behavior
+     */
     isDefault: boolean;
+    /**
+     * URL of the work item type behavior
+     */
     url: string;
 }
 
@@ -453,6 +1106,15 @@ export interface WorkItemTypeModel {
 }
 
 export var TypeInfo = {
+    CreateProcessRuleRequest: <any>{
+    },
+    CustomizationType: {
+        enumValues: {
+            "system": 1,
+            "inherited": 2,
+            "custom": 3
+        }
+    },
     FieldModel: <any>{
     },
     FieldType: {
@@ -478,7 +1140,8 @@ export var TypeInfo = {
     GetBehaviorsExpand: {
         enumValues: {
             "none": 0,
-            "fields": 1
+            "fields": 1,
+            "combinedFields": 2
         }
     },
     GetProcessExpandLevel: {
@@ -505,6 +1168,8 @@ export var TypeInfo = {
             "attachments": 4
         }
     },
+    ProcessBehavior: <any>{
+    },
     ProcessClass: {
         enumValues: {
             "system": 0,
@@ -512,9 +1177,56 @@ export var TypeInfo = {
             "custom": 2
         }
     },
+    ProcessInfo: <any>{
+    },
     ProcessModel: <any>{
     },
     ProcessProperties: <any>{
+    },
+    ProcessRule: <any>{
+    },
+    ProcessWorkItemType: <any>{
+    },
+    ProcessWorkItemTypeField: <any>{
+    },
+    RuleAction: <any>{
+    },
+    RuleActionType: {
+        enumValues: {
+            "makeRequired": 1,
+            "makeReadOnly": 2,
+            "setDefaultValue": 3,
+            "setDefaultFromClock": 4,
+            "setDefaultFromCurrentUser": 5,
+            "setDefaultFromField": 6,
+            "copyValue": 7,
+            "copyFromClock": 8,
+            "copyFromCurrentUser": 9,
+            "copyFromField": 10,
+            "setValueToEmpty": 11,
+            "copyFromServerClock": 12,
+            "copyFromServerCurrentUser": 13
+        }
+    },
+    RuleCondition: <any>{
+    },
+    RuleConditionType: {
+        enumValues: {
+            "when": 1,
+            "whenNot": 2,
+            "whenChanged": 3,
+            "whenNotChanged": 4,
+            "whenWas": 5,
+            "whenStateChangedTo": 6,
+            "whenStateChangedFromAndTo": 7,
+            "whenWorkItemIsCreated": 8,
+            "whenValueIsDefined": 9,
+            "whenValueIsNotDefined": 10
+        }
+    },
+    UpdateProcessRuleRequest: <any>{
+    },
+    WorkItemStateResultModel: <any>{
     },
     WorkItemTypeClass: {
         enumValues: {
@@ -525,6 +1237,17 @@ export var TypeInfo = {
     },
     WorkItemTypeModel: <any>{
     },
+};
+
+TypeInfo.CreateProcessRuleRequest.fields = {
+    actions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleAction
+    },
+    conditions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleCondition
+    }
 };
 
 TypeInfo.FieldModel.fields = {
@@ -546,6 +1269,18 @@ TypeInfo.Page.fields = {
     }
 };
 
+TypeInfo.ProcessBehavior.fields = {
+    customization: {
+        enumType: TypeInfo.CustomizationType
+    }
+};
+
+TypeInfo.ProcessInfo.fields = {
+    customizationType: {
+        enumType: TypeInfo.CustomizationType
+    }
+};
+
 TypeInfo.ProcessModel.fields = {
     properties: {
         typeInfo: TypeInfo.ProcessProperties
@@ -558,11 +1293,80 @@ TypeInfo.ProcessProperties.fields = {
     }
 };
 
+TypeInfo.ProcessRule.fields = {
+    actions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleAction
+    },
+    conditions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleCondition
+    },
+    customizationType: {
+        enumType: TypeInfo.CustomizationType
+    }
+};
+
+TypeInfo.ProcessWorkItemType.fields = {
+    customization: {
+        enumType: TypeInfo.CustomizationType
+    },
+    layout: {
+        typeInfo: TypeInfo.FormLayout
+    },
+    states: {
+        isArray: true,
+        typeInfo: TypeInfo.WorkItemStateResultModel
+    }
+};
+
+TypeInfo.ProcessWorkItemTypeField.fields = {
+    customization: {
+        enumType: TypeInfo.CustomizationType
+    },
+    type: {
+        enumType: TypeInfo.FieldType
+    }
+};
+
+TypeInfo.RuleAction.fields = {
+    actionType: {
+        enumType: TypeInfo.RuleActionType
+    }
+};
+
+TypeInfo.RuleCondition.fields = {
+    conditionType: {
+        enumType: TypeInfo.RuleConditionType
+    }
+};
+
+TypeInfo.UpdateProcessRuleRequest.fields = {
+    actions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleAction
+    },
+    conditions: {
+        isArray: true,
+        typeInfo: TypeInfo.RuleCondition
+    }
+};
+
+TypeInfo.WorkItemStateResultModel.fields = {
+    customizationType: {
+        enumType: TypeInfo.CustomizationType
+    }
+};
+
 TypeInfo.WorkItemTypeModel.fields = {
     class: {
         enumType: TypeInfo.WorkItemTypeClass
     },
     layout: {
         typeInfo: TypeInfo.FormLayout
+    },
+    states: {
+        isArray: true,
+        typeInfo: TypeInfo.WorkItemStateResultModel
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "6.6.0",
+    "version": "6.7.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -19,7 +19,7 @@ import { Timeline as TaskAgentTimeline } from "azure-devops-node-api/interfaces/
 import { WebApiTeam } from 'azure-devops-node-api/interfaces/CoreInterfaces';
 import { WidgetScope, WidgetTypesResponse } from 'azure-devops-node-api/interfaces/DashboardInterfaces';
 import { WorkItemField } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
-import { ProcessModel } from 'azure-devops-node-api/interfaces/WorkItemTrackingProcessInterfaces';
+import { ProcessModel, ProcessInfo } from 'azure-devops-node-api/interfaces/WorkItemTrackingProcessInterfaces';
 import { PickListMetadataModel } from 'azure-devops-node-api/interfaces/WorkItemTrackingProcessDefinitionsInterfaces';
 import { WikiV2 } from 'azure-devops-node-api/interfaces/WikiInterfaces';
 
@@ -234,7 +234,7 @@ export async function run() {
         /********** Work Item Tracking Process **********/
         printSectionStart('Work Item Tracking Process');
         const workItemTrackingProcessApi = await vstsCollectionLevel.getWorkItemTrackingProcessApi();
-        const processes: ProcessModel[] = await workItemTrackingProcessApi.getProcesses();
+        const processes: ProcessInfo[] = await workItemTrackingProcessApi.getListOfProcesses();
 
         if (processes) {
             console.log(`found ${processes.length} processes`);


### PR DESCRIPTION
There are a few issues I created after running this that need to be addressed:

- Build required modules not referenced correctly https://github.com/Microsoft/azure-devops-node-api/issues/211
- RestClient needs to expose HEAD for WorkItemTrackingApi https://github.com/Microsoft/typed-rest-client/issues/81
- 3 apis not getting generated (FileContainer, Profile, SecurityRoles) https://github.com/Microsoft/azure-devops-node-api/issues/212

TODO: Update generation to handle HEAD through http client instead of rest.