### PR TITLE
Fix invalid reference to `vsts` in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let orgUrl = "https://dev.azure.com/yourorgname";
 // ideally from config
 let token: string = "cbdeb34vzyuk5l4gxc4qfczn3lko3avfkfqyb47etahq6axpcqha"; 
 
-let authHandler = vsts.getPersonalAccessTokenHandler(token); 
+let authHandler = azdev.getPersonalAccessTokenHandler(token); 
 let connection = new azdev.WebApi(orgUrl, authHandler);    
 ```
 


### PR DESCRIPTION
Change `vsts` to `azdev` in a line in the Get started sample which hadn't been updated.