### PR TITLE
Add organization helpers

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -31,7 +31,7 @@ import bearm = require('./handlers/bearertoken');
 import ntlmm = require('./handlers/ntlm');
 import patm = require('./handlers/personalaccesstoken');
 
-import * as httpm from 'typed-rest-client//HttpClient';
+import * as httpm from 'typed-rest-client/HttpClient';
 import * as rm from 'typed-rest-client/RestClient';
 import vsom = require('./VsoClient');
 import lim = require("./interfaces/LocationsInterfaces");
@@ -95,7 +95,7 @@ export async function getOrganizationUrlByOrgId(organizationId: string): Promise
 async function getOrgLocationUrl(param: string): Promise<string> {
     const url: string = `https://dev.azure.com/_apis/resourceAreas/79134C72-4A58-4B42-976C-04E7115F32BF?${param}&api-version=5.0-preview.1`;
     const restClient: rm.RestClient = new rm.RestClient(defaultUserAgent);
-    const orgUrlResponse = await restClient.get<IOrganizationUrlResponse>(url);
+    const orgUrlResponse = await restClient.get<lim.ResourceAreaInfo>(url);
 
     if (orgUrlResponse 
         && orgUrlResponse.statusCode === httpm.HttpCodes.OK 
@@ -104,12 +104,6 @@ async function getOrgLocationUrl(param: string): Promise<string> {
     }
 
     throw new Error('Organization not found.');
-}
-
-interface IOrganizationUrlResponse {
-    id: string,
-    name: string,
-    locationUrl: string
 }
 
 export interface IWebApiRequestSettings {

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -175,10 +175,6 @@ export class WebApi {
         }
 
         let userAgent: string;
-        const nodeApiName: string = 'azure-devops-node-api';
-        const nodeApiVersion: string = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
-        const osName: string = os.platform();
-        const osVersion: string = os.release();
 
         if(requestSettings) {
             userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -31,6 +31,7 @@ import bearm = require('./handlers/bearertoken');
 import ntlmm = require('./handlers/ntlm');
 import patm = require('./handlers/personalaccesstoken');
 
+import * as httpm from 'typed-rest-client//HttpClient';
 import * as rm from 'typed-rest-client/RestClient';
 import vsom = require('./VsoClient');
 import lim = require("./interfaces/LocationsInterfaces");
@@ -70,7 +71,6 @@ export function getHandlerFromToken(token: string): VsoBaseInterfaces.IRequestHa
 
 /**
  * Given an Organization name, get the URL for that Organization.
- * @param organizationName
  */
 export async function getOrganizationUrlByOrgName(organizationName: string): Promise<string> {
     return getOrgLocationUrl(`accountName=${organizationName}`);
@@ -78,7 +78,6 @@ export async function getOrganizationUrlByOrgName(organizationName: string): Pro
 
 /**
  * Given an Organization id, get the URL for that Organization.
- * @param organizationId 
  */
 export async function getOrganizationUrlByOrgId(organizationId: string): Promise<string> {
     return getOrgLocationUrl(`hostId=${organizationId}`);
@@ -95,12 +94,11 @@ export async function getOrganizationUrlByOrgId(organizationId: string): Promise
  */
 async function getOrgLocationUrl(param: string): Promise<string> {
     const url: string = `https://dev.azure.com/_apis/resourceAreas/79134C72-4A58-4B42-976C-04E7115F32BF?${param}&api-version=5.0-preview.1`;
-
     const restClient: rm.RestClient = new rm.RestClient(defaultUserAgent);
     const orgUrlResponse = await restClient.get<IOrganizationUrlResponse>(url);
 
     if (orgUrlResponse 
-        && orgUrlResponse.statusCode === 200 
+        && orgUrlResponse.statusCode === httpm.HttpCodes.OK 
         && orgUrlResponse.result) {
         return orgUrlResponse.result.locationUrl;
     }
@@ -113,8 +111,6 @@ interface IOrganizationUrlResponse {
     name: string,
     locationUrl: string
 }
-
-// TODO: Unit tests for both using Nock.
 
 export interface IWebApiRequestSettings {
     productName: string,
@@ -444,7 +440,6 @@ export class WebApi {
 /**
  * Helpers.
  */
-
 const nodeApiName: string = 'azure-devops-node-api';
 const nodeApiVersion: string = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
 const osName: string = os.platform();

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "author": "Microsoft Corporation",
     "contributors": [
         "Bryan MacFarlane <bryanmac@microsoft.com>",
-        "Daniel McCormick<daniel.mccormick@microsoft.com>",
+        "Daniel McCormick <daniel.mccormick@microsoft.com>",
         "Scott Dallamura <scdallam@microsoft.com>",
-        "Stephen Franceschelli<stephen.franceschelli@microsoft.com>",
+        "Stephen Franceschelli <stephen.franceschelli@microsoft.com>",
         "Teddy Ward <t-edward@microsoft.com>"
     ],
     "license": "MIT",
@@ -32,10 +32,10 @@
     "devDependencies": {
         "@types/mocha": "^2.2.44",
         "@types/shelljs": "0.7.8",
+        "@types/node": "8.9.2",
         "mocha": "^3.5.3",
         "nock": "9.6.1",
         "shelljs": "0.7.8",
-        "typescript": "2.4.2",
-        "@types/node": "8.9.2"
+        "typescript": "2.4.2"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "6.6.1",
+    "version": "6.7.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -248,4 +248,42 @@ describe('WebApi Units', function () {
         assert.equal(res.apiVersion, '1');
         assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate');
     });
+
+    it ('gets organization url by organization name', async () => {
+        // Arrange
+        const orgName: string = 'myorgname';
+        nock('https://dev.azure.com/_apis/resourceAreas', 
+             { reqheaders: { "accept": "application/json", "user-agent": /\/.*/ }})
+            .get(`/79134C72-4A58-4B42-976C-04E7115F32BF?accountName=${orgName}&api-version=5.0-preview.1`)
+            .reply(200, {
+                "id": "79134c72-4a58-4b42-976c-04e7115f32bf",
+                "name": "core",
+                "locationUrl": "https://dev.azure.com/myorgname"
+            });
+
+        // Act
+        const orgLocationUrl: string = await WebApi.getOrganizationUrlByOrgName(orgName);
+
+        // Assert
+        assert.equal(orgLocationUrl, 'https://dev.azure.com/myorgname');
+    });
+
+    it ('gets organization url by organization id', async () => {
+        // Arrange
+        const orgId: string = '6c12d405-344a-4364-88c4-7623dd0ca0dc';
+        nock('https://dev.azure.com/_apis/resourceAreas', 
+             { reqheaders: { "accept": "application/json", "user-agent": /\/.*/ }})
+            .get(`/79134C72-4A58-4B42-976C-04E7115F32BF?hostId=${orgId}&api-version=5.0-preview.1`)
+            .reply(200, {
+                "id": orgId,
+                "name": "core",
+                "locationUrl": "https://dev.azure.com/myorgname"
+            });
+
+        // Act
+        const orgLocationUrl: string = await WebApi.getOrganizationUrlByOrgId(orgId);
+
+        // Assert
+        assert.equal(orgLocationUrl, 'https://dev.azure.com/myorgname');
+    });
 });


### PR DESCRIPTION
I added it as a separate function instead of having another constructor for two reasons:

1. It will work like the C# client
2. If someone want's to use the org URL for other purposes they can easily.

FYI @willsmythe