### PR TITLE
Stopping tests from automatically generating .js files

### DIFF
--- a/make.js
+++ b/make.js
@@ -7,7 +7,6 @@ var rp = function(relPath) {
 }
 
 var buildPath = path.join(__dirname, '_build');
-var testPath = path.join(__dirname, '_test');
 
 var run = function(cl) {
     console.log('> ' + cl);
@@ -20,7 +19,6 @@ var run = function(cl) {
 
 target.clean = function() {
     rm('-Rf', buildPath);
-    rm('-Rf', testPath);
 };
 
 target.build = function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -404,6 +404,19 @@
                 "semver": "5.5.1"
             }
         },
+        "node": {
+            "version": "10.10.0",
+            "resolved": "https://registry.npmjs.org/node/-/node-10.10.0.tgz",
+            "integrity": "sha512-Ezm1wQ4XzE3YXVtilNv5RWtvyC2d3307u2UmQns9w8rU0/v6ONeip4GPHBblBbz7QQwaZEVp9KzJ8aIRzeGTiw==",
+            "requires": {
+                "node-bin-setup": "1.0.6"
+            }
+        },
+        "node-bin-setup": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.0.6.tgz",
+            "integrity": "sha512-uPIxXNis1CRbv1DwqAxkgBk5NFV3s7cMN/Gf556jSw6jBvV7ca4F9lRL/8cALcZecRibeqU+5dFYqFFmzv5a0Q=="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     ],
     "license": "MIT",
     "dependencies": {
+        "node": "^10.10.0",
         "os": "0.1.1",
         "tunnel": "0.0.4",
         "typed-rest-client": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "node": "^10.10.0",
         "os": "0.1.1",
         "tunnel": "0.0.4",
         "typed-rest-client": "1.0.9",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -7,11 +7,34 @@
     "azure-devops-node-api": {
       "version": "file:../_build",
       "requires": {
+        "node": "10.10.0",
+        "os": "0.1.1",
         "tunnel": "0.0.4",
         "typed-rest-client": "1.0.9",
         "underscore": "1.8.3"
       },
       "dependencies": {
+        "node": {
+          "version": "10.10.0",
+          "bundled": true,
+          "requires": {
+            "node-bin-setup": "1.0.6"
+          },
+          "dependencies": {
+            "node-win-x64": {
+              "version": "10.10.0",
+              "bundled": true
+            }
+          }
+        },
+        "node-bin-setup": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "os": {
+          "version": "0.1.1",
+          "bundled": true
+        },
         "tunnel": {
           "version": "0.0.4",
           "bundled": true

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -7,30 +7,12 @@
     "azure-devops-node-api": {
       "version": "file:../_build",
       "requires": {
-        "node": "10.10.0",
         "os": "0.1.1",
         "tunnel": "0.0.4",
         "typed-rest-client": "1.0.9",
         "underscore": "1.8.3"
       },
       "dependencies": {
-        "node": {
-          "version": "10.10.0",
-          "bundled": true,
-          "requires": {
-            "node-bin-setup": "1.0.6"
-          },
-          "dependencies": {
-            "node-win-x64": {
-              "version": "10.10.0",
-              "bundled": true
-            }
-          }
-        },
-        "node-bin-setup": {
-          "version": "1.0.6",
-          "bundled": true
-        },
         "os": {
           "version": "0.1.1",
           "bundled": true

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -2,10 +2,10 @@ import assert = require('assert');
 import fs = require('fs');
 import nock = require('nock');
 import os = require('os');
-import vsom = require('../../api/VsoClient');
-import WebApi = require('../../api/WebApi');
-import * as rm from 'typed-rest-client/RestClient';
-import { ApiResourceLocation } from '../../api/interfaces/common/VsoBaseInterfaces';
+import vsom = require('../../_build/VsoClient');
+import WebApi = require('../../_build/WebApi');
+import * as rm from '../../_build/node_modules/typed-rest-client/RestClient';
+import { ApiResourceLocation } from '../../_build/interfaces/common/VsoBaseInterfaces';
 
 describe('VSOClient Units', function () {
     let rest: rm.RestClient;

--- a/test/units/tsconfig.json
+++ b/test/units/tsconfig.json
@@ -1,8 +1,0 @@
-{
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es6",
-        "noImplicitAny": false,
-        "sourceMap": false
-    }
-}


### PR DESCRIPTION
Changes to package-locks are just from builds, probably should have been added in some previous commit.