### PR TITLE
Correcting sample code to remove undefined 'vsts'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let orgUrl = "https://dev.azure.com/yourorgname";
 // ideally from config
 let token: string = "cbdeb34vzyuk5l4gxc4qfczn3lko3avfkfqyb47etahq6axpcqha"; 
 
-let authHandler = vsts.getPersonalAccessTokenHandler(token); 
+let authHandler = azdev.getPersonalAccessTokenHandler(token); 
 let connection = new azdev.WebApi(orgUrl, authHandler);    
 ```
 


### PR DESCRIPTION
In the sample code, one instance of `vsts` was missed to be changed to `azdev` and thus the sample code would fail. Changing the usage to `azdev`

![image](https://user-images.githubusercontent.com/31500022/46455561-3c5ecd80-c7c9-11e8-9d8f-2ea3e73450f0.png)
