### PR TITLE
Found issue when no proxy wasn't set and set up tests better

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -339,6 +339,9 @@ export class WebApi {
      * @param url: the server url
      */
     public isNoProxyHost = function(_url: string) {
+        if (!process.env.no_proxy) {
+            return false;
+        }
         const noProxyDomains = (process.env.no_proxy || '')
         .split(',')
         .map(v => v.toLowerCase());

--- a/make.js
+++ b/make.js
@@ -40,6 +40,8 @@ target.build = function() {
 
 
 target.units = function() {
+    target.build();
+
     pushd('test');
     run('npm install ../_build');
     popd();

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -213,10 +213,8 @@ describe('WebApi Units', function () {
     const nodeApiVersion: string = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
 
     it('sets the user agent correctly when request settings are specified', async () => {
-        console.log('TEST');
         const myWebApi: WebApi.WebApi = new WebApi.WebApi('microsoft.com', WebApi.getBasicHandler('user', 'password'),
                                                           undefined, {productName: 'name', productVersion: '1.2.3'});
-                                                          console.log('TEST');
         const userAgent: string = `name/1.2.3 (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
         assert.equal(userAgent, myWebApi.rest.client.userAgent, 'User agent should be: ' + userAgent);
     });

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -213,8 +213,10 @@ describe('WebApi Units', function () {
     const nodeApiVersion: string = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
 
     it('sets the user agent correctly when request settings are specified', async () => {
+        console.log('TEST');
         const myWebApi: WebApi.WebApi = new WebApi.WebApi('microsoft.com', WebApi.getBasicHandler('user', 'password'),
                                                           undefined, {productName: 'name', productVersion: '1.2.3'});
+                                                          console.log('TEST');
         const userAgent: string = `name/1.2.3 (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
         assert.equal(userAgent, myWebApi.rest.client.userAgent, 'User agent should be: ' + userAgent);
     });

--- a/test/units/tsconfig.json
+++ b/test/units/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "ES6",
+        "module": "commonjs",
+        "moduleResolution": "node"
+    },
+    "files": [
+        "tests.ts"
+    ]
+}


### PR DESCRIPTION
Cloned/ran tests and they weren't working because of a missing tsconfig file. Added that, ran tests, and realized some were failing because isNoProxyHost fails when no_proxy isn't set. Finally, updated tests to automatically build the library first.