### PR TITLE
Cleanup strings in samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install azure-devops-node-api --save
 
 ### Create a connection
 ```javascript
-import * as azdev from 'azure-devops-node-api';
+import * as azdev from "azure-devops-node-api";
 
 // your collection url
 let orgUrl = "https://dev.azure.com/yourorgname";
@@ -41,7 +41,7 @@ let connection = new azdev.WebApi(orgUrl, authHandler);
 ### Get an instance of a client
 
 ```javascript
-import * as ba from 'azure-devops-node-api/BuildApi';
+import * as ba from "azure-devops-node-api/BuildApi";
 
 let build: ba.IBuildApi = await connection.getBuildApi();
 ```
@@ -79,10 +79,10 @@ These clients are available:
 Coding is easy using linear coding with async/await in TypeScript
 
 ```javascript
-import * as bi from 'azure-devops-node-api/interfaces/BuildInterfaces';
+import * as bi from "azure-devops-node-api/interfaces/BuildInterfaces";
 
 async function run() {
-    let project: string = 'myProject';
+    let project: string = "myProject";
     let defs: bi.DefinitionReference[] = await build.getDefinitions(project);
 
     defs.forEach((defRef: bi.DefinitionReference) => {

--- a/samples/build.ts
+++ b/samples/build.ts
@@ -1,8 +1,8 @@
-import * as cm from './common';
-import * as vm from 'azure-devops-node-api';
+import * as cm from "./common";
+import * as vm from "azure-devops-node-api";
 
-import * as ba from 'azure-devops-node-api/BuildApi';
-import * as bi from 'azure-devops-node-api/interfaces/BuildInterfaces';
+import * as ba from "azure-devops-node-api/BuildApi";
+import * as bi from "azure-devops-node-api/interfaces/BuildInterfaces";
 
 export async function run() {
     try
@@ -10,15 +10,15 @@ export async function run() {
         let vsts: vm.WebApi = await cm.getWebApi();
         let vstsBuild: ba.IBuildApi = await vsts.getBuildApi();
 
-        cm.banner('Build Samples');
+        cm.banner("Build Samples");
         let project = cm.getProject();
-        console.log('project', project);
+        console.log("project", project);
 
         // list definitions
-        cm.heading('Build Definitions for ' + project);
+        cm.heading("Build Definitions for " + project);
         let defs: bi.DefinitionReference[] = await vstsBuild.getDefinitions(project);
         
-        console.log('You have ' + defs.length + ' build definition(s)');
+        console.log("You have " + defs.length + " build definition(s)");
 
         // save off last def to create a new definition below
         let lastDef: bi.BuildDefinition;
@@ -29,11 +29,11 @@ export async function run() {
             lastDef = def;
             let rep: bi.BuildRepository = def.repository;
 
-            console.log(defRef.name + ' (' + defRef.id + ') ' + 'repo ' + rep.type);
+            console.log(defRef.name + " (" + defRef.id + ") " + "repo " + rep.type);
         }
 
         // get top 10 successfully completed builds since 2016
-        cm.heading('top 10 successfully completed builds for ' + project + 'project');
+        cm.heading("top 10 successfully completed builds for " + project + "project");
         let builds: bi.Build[] = await vstsBuild.getBuilds(
                         project, 
                         null,                       // definitions: number[] 
@@ -51,9 +51,9 @@ export async function run() {
                         10                          // top: number
                         );
         
-        console.log(builds.length + ' builds returned');
+        console.log(builds.length + " builds returned");
         builds.forEach((build: bi.Build) => {
-            console.log(build.buildNumber, bi.BuildResult[build.result], 'on', build.finishTime.toDateString());
+            console.log(build.buildNumber, bi.BuildResult[build.result], "on", build.finishTime.toDateString());
         });
 
         // new definition
@@ -61,10 +61,10 @@ export async function run() {
             let process = lastDef.process as bi.DesignerProcess;
             if (process.phases && process.phases.length > 0) {
                 let phase = process.phases[0];
-                cm.heading('creating a new definition');
+                cm.heading("creating a new definition");
                 let newDef: bi.BuildDefinition = <bi.BuildDefinition>{};
                 
-                let newName: string = "api copy of " + lastDef.name;
+                let newName = "api copy of " + lastDef.name;
                 console.log("name", newName);
                 newDef.name = newName;
 
@@ -137,7 +137,7 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error('Error: ' + err.stack);
+        console.error("Error: " + err.stack);
     }
 
 }

--- a/samples/build.ts
+++ b/samples/build.ts
@@ -15,10 +15,10 @@ export async function run() {
         console.log("project", project);
 
         // list definitions
-        cm.heading("Build Definitions for " + project);
+        cm.heading(`Build Definitions for ${project}`);
         let defs: bi.DefinitionReference[] = await vstsBuild.getDefinitions(project);
         
-        console.log("You have " + defs.length + " build definition(s)");
+        console.log(`You have ${defs.length} build definition(s)`);
 
         // save off last def to create a new definition below
         let lastDef: bi.BuildDefinition;
@@ -29,11 +29,11 @@ export async function run() {
             lastDef = def;
             let rep: bi.BuildRepository = def.repository;
 
-            console.log(defRef.name + " (" + defRef.id + ") " + "repo " + rep.type);
+            console.log(`${defRef.name} (${defRef.id}) repo ${rep.type}`);
         }
 
         // get top 10 successfully completed builds since 2016
-        cm.heading("top 10 successfully completed builds for " + project + "project");
+        cm.heading(`top 10 successfully completed builds for ${project}project`);
         let builds: bi.Build[] = await vstsBuild.getBuilds(
                         project, 
                         null,                       // definitions: number[] 
@@ -51,7 +51,7 @@ export async function run() {
                         10                          // top: number
                         );
         
-        console.log(builds.length + " builds returned");
+        console.log(`${builds.length} builds returned`);
         builds.forEach((build: bi.Build) => {
             console.log(build.buildNumber, bi.BuildResult[build.result], "on", build.finishTime.toDateString());
         });
@@ -64,7 +64,7 @@ export async function run() {
                 cm.heading("creating a new definition");
                 let newDef: bi.BuildDefinition = <bi.BuildDefinition>{};
                 
-                let newName = "api copy of " + lastDef.name;
+                let newName = `api copy of ${lastDef.name}`;
                 console.log("name", newName);
                 newDef.name = newName;
 
@@ -137,7 +137,7 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error("Error: " + err.stack);
+        console.error(`Error: ${err.stack}`);
     }
 
 }

--- a/samples/buildArtifact.ts
+++ b/samples/buildArtifact.ts
@@ -1,10 +1,10 @@
 // A sample showing how to list VSTS build artifacts, and how to download a zip of a VSTS build artifact.
-import * as cm from './common';
-import * as vm from 'azure-devops-node-api';
-import * as fs from 'fs';
+import * as cm from "./common";
+import * as vm from "azure-devops-node-api";
+import * as fs from "fs";
 
-import * as ba from 'azure-devops-node-api/BuildApi';
-import * as bi from 'azure-devops-node-api/interfaces/BuildInterfaces';
+import * as ba from "azure-devops-node-api/BuildApi";
+import * as bi from "azure-devops-node-api/interfaces/BuildInterfaces";
 
 export async function run() {
     try
@@ -12,9 +12,9 @@ export async function run() {
         const vsts: vm.WebApi = await cm.getWebApi();
         const vstsBuild: ba.IBuildApi = await vsts.getBuildApi();
 
-        cm.banner('Build Artifact Samples');
+        cm.banner("Build Artifact Samples");
         const project = cm.getProject();
-        console.log('project', project);
+        console.log("project", project);
 
         // get the latest successful build.
         cm.heading(`Get latest successful build for ${project} project`);
@@ -45,11 +45,11 @@ export async function run() {
 
             let downloadableArtifact;
             for (const artifact of artifacts) {
-                let additionalInfo = '';
-                if (artifact.resource.type === 'FilePath') {
+                let additionalInfo = "";
+                if (artifact.resource.type === "FilePath") {
                     additionalInfo = `UNC Path: ${artifact.resource.data}`;
                 }
-                else if (artifact.resource.type === 'Container') {
+                else if (artifact.resource.type === "Container") {
                     // As of June 2018, only `Container` artifacts can be downloaded as a zip.
                     additionalInfo = `Downloadable: true.`;
                     downloadableArtifact = artifact;
@@ -67,19 +67,19 @@ export async function run() {
                 const fileStream = fs.createWriteStream(path);
                 artifactStream.pipe(fileStream);
 
-                fileStream.on('close', () => {
+                fileStream.on("close", () => {
                     console.log(`Artifact '${downloadableArtifact.name}' downloaded to ${path}`);
                 });
             }
             else {
-                console.log('No downloadable artifact found.');
+                console.log("No downloadable artifact found.");
             }
         }
         else {
-            console.log('No successful builds found.');
+            console.log("No successful builds found.");
         }
     }
     catch (err) {
-        console.error('Error: ' + err.stack);
+        console.error("Error: " + err.stack);
     }
 }

--- a/samples/buildArtifact.ts
+++ b/samples/buildArtifact.ts
@@ -80,6 +80,6 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error("Error: " + err.stack);
+        console.error(`Error: ${err.stack}`);
     }
 }

--- a/samples/common.d.ts
+++ b/samples/common.d.ts
@@ -1,2 +1,2 @@
-import * as vm from 'vso-node-api';
+import * as vm from "vso-node-api";
 export declare function getWebApi(): vm.WebApi;

--- a/samples/common.ts
+++ b/samples/common.ts
@@ -4,7 +4,7 @@ import * as lim from "azure-devops-node-api/interfaces/LocationsInterfaces";
 function getEnv(name: string): string {
     let val = process.env[name];
     if (!val) {
-        console.error(name + " env var not set");
+        console.error(`${name} env var not set`);
         process.exit(1);
     }
     return val;
@@ -47,7 +47,7 @@ export async function getApi(serverUrl: string): Promise<vm.WebApi> {
 
             let vsts: vm.WebApi = new vm.WebApi(serverUrl, authHandler, option);
             let connData: lim.ConnectionData = await vsts.connect();
-            console.log("Hello " + connData.authenticatedUser.providerDisplayName);
+            console.log(`Hello ${connData.authenticatedUser.providerDisplayName}`);
             resolve(vsts);
         }
         catch (err) {
@@ -62,13 +62,13 @@ export function getProject(): string {
 
 export function banner(title: string): void {
     console.log("=======================================");
-    console.log("\t" + title);
+    console.log(`\t${title}`);
     console.log("=======================================");
 }
 
 export function heading(title: string): void {
     console.log();
-    console.log("> " + title);
+    console.log(`> ${title}`);
 }
 
 

--- a/samples/common.ts
+++ b/samples/common.ts
@@ -1,24 +1,24 @@
-import * as vm from 'azure-devops-node-api';
-import * as lim from 'azure-devops-node-api/interfaces/LocationsInterfaces';
+import * as vm from "azure-devops-node-api";
+import * as lim from "azure-devops-node-api/interfaces/LocationsInterfaces";
 
 function getEnv(name: string): string {
     let val = process.env[name];
     if (!val) {
-        console.error(name + ' env var not set');
+        console.error(name + " env var not set");
         process.exit(1);
     }
     return val;
 }
 
 export async function getWebApi(): Promise<vm.WebApi> {
-    let serverUrl = getEnv('API_URL');
+    let serverUrl = getEnv("API_URL");
     return await this.getApi(serverUrl);
 }
 
 export async function getApi(serverUrl: string): Promise<vm.WebApi> {
     return new Promise<vm.WebApi>(async (resolve, reject) => {
         try {
-            let token = getEnv('API_TOKEN');
+            let token = getEnv("API_TOKEN");
             let authHandler = vm.getPersonalAccessTokenHandler(token);
             let option = undefined;
 
@@ -47,7 +47,7 @@ export async function getApi(serverUrl: string): Promise<vm.WebApi> {
 
             let vsts: vm.WebApi = new vm.WebApi(serverUrl, authHandler, option);
             let connData: lim.ConnectionData = await vsts.connect();
-            console.log('Hello ' + connData.authenticatedUser.providerDisplayName);
+            console.log("Hello " + connData.authenticatedUser.providerDisplayName);
             resolve(vsts);
         }
         catch (err) {
@@ -57,18 +57,18 @@ export async function getApi(serverUrl: string): Promise<vm.WebApi> {
 }
 
 export function getProject(): string {
-    return getEnv('API_PROJECT');
+    return getEnv("API_PROJECT");
 }
 
 export function banner(title: string): void {
-    console.log('=======================================');
-    console.log('\t' + title);
-    console.log('=======================================');
+    console.log("=======================================");
+    console.log("\t" + title);
+    console.log("=======================================");
 }
 
 export function heading(title: string): void {
     console.log();
-    console.log('> ' + title);
+    console.log("> " + title);
 }
 
 

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -1,27 +1,27 @@
-import * as common from './common';
-import * as vsoNodeApi from 'azure-devops-node-api';
+import * as common from "./common";
+import * as vsoNodeApi from "azure-devops-node-api";
 
-import { Build } from 'azure-devops-node-api/interfaces/BuildInterfaces';
-import { ContributedFeature } from 'azure-devops-node-api/interfaces/FeatureManagementInterfaces';
-import { FileContainer } from 'azure-devops-node-api/interfaces/FileContainerInterfaces';
-import { GitRepository, TfvcChangesetRef } from 'azure-devops-node-api/interfaces/TfvcInterfaces';
-import { Plan } from 'azure-devops-node-api/interfaces/WorkInterfaces';
-import { PolicyType } from 'azure-devops-node-api/interfaces/PolicyInterfaces';
-import { ProfileRegions } from 'azure-devops-node-api/interfaces/ProfileInterfaces';
-import { ProjectLanguageAnalytics } from 'azure-devops-node-api/interfaces/ProjectAnalysisInterfaces';
-import { Release } from 'azure-devops-node-api/interfaces/ReleaseInterfaces';
-import { ResourceAreaInfo } from 'azure-devops-node-api/interfaces/LocationsInterfaces';
-import { RequestedExtension } from 'azure-devops-node-api/interfaces/ExtensionManagementInterfaces';
-import { SecurityRole } from 'azure-devops-node-api/interfaces/SecurityRolesInterfaces';
-import { TaskAgentPool } from 'azure-devops-node-api/interfaces/TaskAgentInterfaces';
-import { TestPlan } from 'azure-devops-node-api/interfaces/TestInterfaces';
+import { Build } from "azure-devops-node-api/interfaces/BuildInterfaces";
+import { ContributedFeature } from "azure-devops-node-api/interfaces/FeatureManagementInterfaces";
+import { FileContainer } from "azure-devops-node-api/interfaces/FileContainerInterfaces";
+import { GitRepository, TfvcChangesetRef } from "azure-devops-node-api/interfaces/TfvcInterfaces";
+import { Plan } from "azure-devops-node-api/interfaces/WorkInterfaces";
+import { PolicyType } from "azure-devops-node-api/interfaces/PolicyInterfaces";
+import { ProfileRegions } from "azure-devops-node-api/interfaces/ProfileInterfaces";
+import { ProjectLanguageAnalytics } from "azure-devops-node-api/interfaces/ProjectAnalysisInterfaces";
+import { Release } from "azure-devops-node-api/interfaces/ReleaseInterfaces";
+import { ResourceAreaInfo } from "azure-devops-node-api/interfaces/LocationsInterfaces";
+import { RequestedExtension } from "azure-devops-node-api/interfaces/ExtensionManagementInterfaces";
+import { SecurityRole } from "azure-devops-node-api/interfaces/SecurityRolesInterfaces";
+import { TaskAgentPool } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
+import { TestPlan } from "azure-devops-node-api/interfaces/TestInterfaces";
 import { Timeline as TaskAgentTimeline } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
-import { WebApiTeam } from 'azure-devops-node-api/interfaces/CoreInterfaces';
-import { WidgetScope, WidgetTypesResponse } from 'azure-devops-node-api/interfaces/DashboardInterfaces';
-import { WorkItemField } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces';
-import { ProcessModel } from 'azure-devops-node-api/interfaces/WorkItemTrackingProcessInterfaces';
-import { PickListMetadataModel } from 'azure-devops-node-api/interfaces/WorkItemTrackingProcessDefinitionsInterfaces';
-import { WikiV2 } from 'azure-devops-node-api/interfaces/WikiInterfaces';
+import { WebApiTeam } from "azure-devops-node-api/interfaces/CoreInterfaces";
+import { WidgetScope, WidgetTypesResponse } from "azure-devops-node-api/interfaces/DashboardInterfaces";
+import { WorkItemField } from "azure-devops-node-api/interfaces/WorkItemTrackingInterfaces";
+import { ProcessModel } from "azure-devops-node-api/interfaces/WorkItemTrackingProcessInterfaces";
+import { PickListMetadataModel } from "azure-devops-node-api/interfaces/WorkItemTrackingProcessDefinitionsInterfaces";
+import { WikiV2 } from "azure-devops-node-api/interfaces/WikiInterfaces";
 
 // In order for this to run you will need to set the following environment variables:
 // 
@@ -37,7 +37,7 @@ export async function run() {
         const vstsCollectionLevel: vsoNodeApi.WebApi = await common.getWebApi();
 
         /********** Build **********/
-        printSectionStart('Build');
+        printSectionStart("Build");
         const buildApi = await vstsCollectionLevel.getBuildApi();
         const builds: Build[] = await buildApi.getBuilds(common.getProject());
 
@@ -46,7 +46,7 @@ export async function run() {
         }
 
         /********** Core **********/
-        printSectionStart('Core');
+        printSectionStart("Core");
         const coreApi = await vstsCollectionLevel.getCoreApi();
         const teams: WebApiTeam[] = await coreApi.getAllTeams();
 
@@ -55,7 +55,7 @@ export async function run() {
         }
 
         /********** Dashboard **********/
-        printSectionStart('Dashboard');
+        printSectionStart("Dashboard");
         const dashboardApi = await vstsCollectionLevel.getDashboardApi();
         const widgetTypes: WidgetTypesResponse = await dashboardApi.getWidgetTypes(WidgetScope.Collection_User);
 
@@ -64,7 +64,7 @@ export async function run() {
         }
 
         /********** Extension Management **********/
-        printSectionStart('Extension Management');
+        printSectionStart("Extension Management");
         const extensionManagementApi = await vstsCollectionLevel.getExtensionManagementApi();
         const requests:RequestedExtension[] = await extensionManagementApi.getRequests();
 
@@ -73,7 +73,7 @@ export async function run() {
         }
 
         /********** Feature Management **********/
-        printSectionStart('Feature Management');
+        printSectionStart("Feature Management");
         const featureManagementApi = await vstsCollectionLevel.getFeatureManagementApi();
         const features: ContributedFeature[] = await featureManagementApi.getFeatures();
 
@@ -82,7 +82,7 @@ export async function run() {
         }
 
         /********** File Container **********/
-        printSectionStart('File Container');
+        printSectionStart("File Container");
         const fileContainerApi = await vstsCollectionLevel.getFileContainerApi();
         const containers: FileContainer[] = await fileContainerApi.getContainers();
 
@@ -91,7 +91,7 @@ export async function run() {
         }
 
         /********** Git **********/
-        printSectionStart('Git');
+        printSectionStart("Git");
         const gitApi = await vstsCollectionLevel.getGitApi();
         const respositories: GitRepository[] = await gitApi.getRepositories();
 
@@ -100,7 +100,7 @@ export async function run() {
         }
 
         /********** Locations **********/
-        printSectionStart('Locations');
+        printSectionStart("Locations");
         const locationsApi = await vstsCollectionLevel.getLocationsApi();
         const resourceAreas: ResourceAreaInfo[] = await locationsApi.getResourceAreas();
 
@@ -109,7 +109,7 @@ export async function run() {
         }
 
         /********** Notifications **********/
-        printSectionStart('Notifications');
+        printSectionStart("Notifications");
         const notificationsApi = await vstsCollectionLevel.getNotificationApi();
         const subscriptions = await notificationsApi.listSubscriptions();
 
@@ -118,7 +118,7 @@ export async function run() {
         }
 
         /********** Policy **********/
-        printSectionStart('Policy');
+        printSectionStart("Policy");
         const policyApi = await vstsCollectionLevel.getPolicyApi();
         const policyTypes: PolicyType[] = await policyApi.getPolicyTypes(common.getProject());
 
@@ -127,7 +127,7 @@ export async function run() {
         }
 
         /********** Profile **********/
-        printSectionStart('Profile');
+        printSectionStart("Profile");
         const profileApi = await vstsCollectionLevel.getProfileApi();
         const regions: ProfileRegions = await profileApi.getRegions();
 
@@ -136,7 +136,7 @@ export async function run() {
         }
 
         /********** Project Analysis **********/
-        printSectionStart('Project Analysis');
+        printSectionStart("Project Analysis");
         const projectAnalysisApi = await vstsCollectionLevel.getProjectAnalysisApi();
         const languageAnalytics: ProjectLanguageAnalytics = await projectAnalysisApi.getProjectLanguageAnalytics(common.getProject());
 
@@ -145,7 +145,7 @@ export async function run() {
         }
 
         /********** Release **********/
-        printSectionStart('Release');
+        printSectionStart("Release");
         const releaseApi = await vstsCollectionLevel.getReleaseApi();
         const releases: Release[] = await releaseApi.getReleases();
 
@@ -154,29 +154,29 @@ export async function run() {
         }
 
         /********** Security **********/
-        printSectionStart('Security');
+        printSectionStart("Security");
         const securityApi = await vstsCollectionLevel.getSecurityRolesApi();
         const roleDefinitions: SecurityRole[] = await securityApi.getRoleDefinitions("");
 
         if (roleDefinitions) {
             console.log(`found ${roleDefinitions.length} role definitions`);
         } else {
-            console.log('role definitions is null');
+            console.log("role definitions is null");
         }
 
         /********** Task **********/
-        printSectionStart('Task');
+        printSectionStart("Task");
         const taskApi = await vstsCollectionLevel.getTaskApi();
         const timelines: TaskAgentTimeline[] = await taskApi.getTimelines("", "", "");
 
         if (timelines) {
             console.log(`found ${timelines.length} timelines`);
         } else {
-            console.log('timelines is null');
+            console.log("timelines is null");
         }
 
         /********** Task Agent **********/
-        printSectionStart('Task Agent');
+        printSectionStart("Task Agent");
         const taskAgentApi = await vstsCollectionLevel.getTaskAgentApi();
         const agentPools: TaskAgentPool[] = await taskAgentApi.getAgentPools();
 
@@ -185,7 +185,7 @@ export async function run() {
         }
 
         /********** Test **********/
-        printSectionStart('Test');
+        printSectionStart("Test");
         const testApi = await vstsCollectionLevel.getTestApi();
         const plans: TestPlan[] = await testApi.getPlans(common.getProject());
 
@@ -194,7 +194,7 @@ export async function run() {
         }
 
         /********** Tfvc **********/
-        printSectionStart('Tfvc');
+        printSectionStart("Tfvc");
         const tfvcApi = await vstsCollectionLevel.getTfvcApi();
         const changesets: TfvcChangesetRef[] = await tfvcApi.getChangesets();
 
@@ -203,7 +203,7 @@ export async function run() {
         }
 
         /********** Wiki **********/
-        printSectionStart('Wiki');
+        printSectionStart("Wiki");
         const wikiApi = await vstsCollectionLevel.getWikiApi();
         const wikis: WikiV2[] = await wikiApi.getAllWikis();
 
@@ -212,18 +212,18 @@ export async function run() {
         }
 
         /********** Work **********/
-        printSectionStart('Work');
+        printSectionStart("Work");
         const workApi = await vstsCollectionLevel.getWorkApi();
         const workPlans: Plan[] = await workApi.getPlans(common.getProject());
 
         if (workPlans) {
             console.log(`found ${workPlans.length} work plans`);
         } else {
-            console.log('work plans is null');
+            console.log("work plans is null");
         }
 
         /********** Work Item Tracking **********/
-        printSectionStart('Work Item Tracking');
+        printSectionStart("Work Item Tracking");
         const workItemTrackingApi = await vstsCollectionLevel.getWorkItemTrackingApi();
         const workItemFields: WorkItemField[] = await workItemTrackingApi.getFields();
 
@@ -232,7 +232,7 @@ export async function run() {
         }
         
         /********** Work Item Tracking Process **********/
-        printSectionStart('Work Item Tracking Process');
+        printSectionStart("Work Item Tracking Process");
         const workItemTrackingProcessApi = await vstsCollectionLevel.getWorkItemTrackingProcessApi();
         const processes: ProcessModel[] = await workItemTrackingProcessApi.getListOfProcesses();
 
@@ -241,7 +241,7 @@ export async function run() {
         }
 
         /********** Work Item Tracking Process Definitions **********/
-        printSectionStart('Work Item Tracking Process Definitions');
+        printSectionStart("Work Item Tracking Process Definitions");
         const workItemTrackingProcessDefinitionApi = await vstsCollectionLevel.getWorkItemTrackingProcessDefinitionApi();
         const listsMetadata: PickListMetadataModel[] = await workItemTrackingProcessDefinitionApi.getListsMetadata();
 
@@ -250,7 +250,7 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error('Error: ' + err.stack);
+        console.error("Error: " + err.stack);
     }
 
 }

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -250,7 +250,7 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error("Error: " + err.stack);
+        console.error(`Error: ${err.stack}`);
     }
 
 }

--- a/samples/filecontainer.ts
+++ b/samples/filecontainer.ts
@@ -11,18 +11,18 @@ export async function run() {
         let containers = await fileContainerApi.getContainers(null, null);
         if (containers.length > 0) {
             let container = containers[0];
-            console.log("found container " + container.name);
+            console.log(`found container ${container.name}`);
             let containerId = container.id;
 
             let items = await fileContainerApi.getItems(containerId, null, null, null, null, null, null, false);
-            console.log("found " + items.length + " items");
+            console.log(`found ${items.length} items`);
 
             let item = items.filter((item) => {
                 return item.itemType === ti.ContainerItemType.File;
             })[0];
 
             if (item) {
-                console.log("downloading " + item.path);
+                console.log(`downloading ${item.path}`);
                 let restResponse = await fileContainerApi.getItem(containerId, null, item.path, item.path.substring(item.path.lastIndexOf("/") + 1));
                 
                 let output = "";
@@ -34,13 +34,13 @@ export async function run() {
                         resolve(output);
                     });
                 });
-                console.log("downloaded " + item.path);
+                console.log(`downloaded ${item.path}`);
                 console.log(output);
             }
         }
     }
     catch (err) {
-        console.error("Error: " + err.stack);
+        console.error(`Error: ${err.stack}`);
     }
 
 }

--- a/samples/filecontainer.ts
+++ b/samples/filecontainer.ts
@@ -1,6 +1,6 @@
-import * as cm from './common';
-import * as vm from 'azure-devops-node-api';
-import * as ti from 'azure-devops-node-api/interfaces/FileContainerInterfaces';
+import * as cm from "./common";
+import * as vm from "azure-devops-node-api";
+import * as ti from "azure-devops-node-api/interfaces/FileContainerInterfaces";
 
 export async function run() {
     try
@@ -23,14 +23,14 @@ export async function run() {
 
             if (item) {
                 console.log("downloading " + item.path);
-                let restResponse = await fileContainerApi.getItem(containerId, null, item.path, item.path.substring(item.path.lastIndexOf('/') + 1));
+                let restResponse = await fileContainerApi.getItem(containerId, null, item.path, item.path.substring(item.path.lastIndexOf("/") + 1));
                 
                 let output = "";
                 await new Promise((resolve, reject) => {
-                    restResponse.result.on('data', (chunk) => {
+                    restResponse.result.on("data", (chunk) => {
                         output += chunk;
                     });
-                    restResponse.result.on('end', () => {
+                    restResponse.result.on("end", () => {
                         resolve(output);
                     });
                 });
@@ -40,7 +40,7 @@ export async function run() {
         }
     }
     catch (err) {
-        console.error('Error: ' + err.stack);
+        console.error("Error: " + err.stack);
     }
 
 }

--- a/samples/git.ts
+++ b/samples/git.ts
@@ -1,23 +1,23 @@
-import * as common from './common';
-import * as nodeApi from 'azure-devops-node-api';
+import * as common from "./common";
+import * as nodeApi from "azure-devops-node-api";
 
-import * as GitApi from 'azure-devops-node-api/GitApi';
-import * as GitInterfaces from 'azure-devops-node-api/interfaces/GitInterfaces';
+import * as GitApi from "azure-devops-node-api/GitApi";
+import * as GitInterfaces from "azure-devops-node-api/interfaces/GitInterfaces";
 
 export async function run() {
     let webApi: nodeApi.WebApi = await common.getWebApi();
     let gitApiObject: GitApi.IGitApi = await webApi.getGitApi();
 
-    common.banner('Git Samples');
-    let project: string = common.getProject();
-    console.log('Project:', project);
+    common.banner("Git Samples");
+    let project = common.getProject();
+    console.log("Project:", project);
 
     common.heading("Get Repositories");
     const repos: GitInterfaces.GitRepository[] = await gitApiObject.getRepositories(project);
     console.log("There are", repos.length, "repositories in this project");
 
     common.heading("Create a repository");
-    const createOptions: GitInterfaces.GitRepositoryCreateOptions = <GitInterfaces.GitRepositoryCreateOptions>{name: 'new repo'};
+    const createOptions: GitInterfaces.GitRepositoryCreateOptions = <GitInterfaces.GitRepositoryCreateOptions>{name: "new repo"};
     let newRepo: GitInterfaces.GitRepository = await gitApiObject.createRepository(createOptions, project);
     console.log("New repo:", newRepo.name);
 
@@ -52,7 +52,7 @@ export async function run() {
             threads = await gitApiObject.getThreads(firstRepo.id, pullRequests[0].pullRequestId);
         }
         if (pullRequests.length > 0 && threads.length > 0) {
-            let comment: GitInterfaces.Comment = <GitInterfaces.Comment>{content: 'Hello comment'};
+            let comment: GitInterfaces.Comment = <GitInterfaces.Comment>{content: "Hello comment"};
             comment = await gitApiObject.createComment(comment, firstRepo.id, pullRequests[0].pullRequestId, threads[0].id);
             console.log("Comment created:", comment.content);
             common.heading("Delete a comment on a pull request");

--- a/samples/policy.ts
+++ b/samples/policy.ts
@@ -1,17 +1,17 @@
-import * as common from './common';
-import * as nodeApi from 'azure-devops-node-api';
+import * as common from "./common";
+import * as nodeApi from "azure-devops-node-api";
 
-import * as PolicyApi from 'azure-devops-node-api/PolicyApi';
-import * as PolicyInterfaces from 'azure-devops-node-api/interfaces/PolicyInterfaces';
-import * as VSSInterfaces from 'azure-devops-node-api/interfaces/common/VSSInterfaces';
+import * as PolicyApi from "azure-devops-node-api/PolicyApi";
+import * as PolicyInterfaces from "azure-devops-node-api/interfaces/PolicyInterfaces";
+import * as VSSInterfaces from "azure-devops-node-api/interfaces/common/VSSInterfaces";
 
 export async function run(projectId: string) {
     const webApi: nodeApi.WebApi = await common.getWebApi();
     const policyApiObject: PolicyApi.IPolicyApi = await webApi.getPolicyApi();
 
-    common.banner('Policy Samples');
+    common.banner("Policy Samples");
 
-    common.heading('Create Policy Configuration for this Project');
+    common.heading("Create Policy Configuration for this Project");
     const newConfiguration: PolicyInterfaces.PolicyConfiguration = {isEnabled: true,
                                                                     isBlocking: false,
                                                                     type: {
@@ -51,13 +51,13 @@ export async function run(projectId: string) {
     const policies: PolicyInterfaces.PolicyType[] = await policyApiObject.getPolicyTypes(projectId);
     console.log("Policy Types:", policies);
 
-    common.heading('Delete Policy Configuration');
+    common.heading("Delete Policy Configuration");
     await policyApiObject.deletePolicyConfiguration(projectId, firstConfig.id);
     const deletedConfiguration: PolicyInterfaces.PolicyConfiguration = await policyApiObject.getPolicyConfiguration(projectId, firstConfig.id);
     if (deletedConfiguration.isDeleted) {
-        console.log('Policy configuration successfully deleted');
+        console.log("Policy configuration successfully deleted");
     }
     else {
-        console.log('Unable to delete policy');
+        console.log("Unable to delete policy");
     }
 }

--- a/samples/profile.ts
+++ b/samples/profile.ts
@@ -1,31 +1,31 @@
-import * as common from './common';
-import * as nodeApi from 'azure-devops-node-api';
+import * as common from "./common";
+import * as nodeApi from "azure-devops-node-api";
 
-import * as ProfileApi from 'azure-devops-node-api/ProfileApi';
-import * as ProfileInterfaces from 'azure-devops-node-api/interfaces/ProfileInterfaces';
+import * as ProfileApi from "azure-devops-node-api/ProfileApi";
+import * as ProfileInterfaces from "azure-devops-node-api/interfaces/ProfileInterfaces";
 
 export async function run(projectId: string) {
     const webApi: nodeApi.WebApi = await common.getWebApi();
     const profileApiObject: ProfileApi.IProfileApi = await webApi.getProfileApi();
-    common.banner('Profile Samples');
+    common.banner("Profile Samples");
 
-    common.heading('Create a profile');
+    common.heading("Create a profile");
     const createProfileContext: ProfileInterfaces.CreateProfileContext = {cIData: null,
                                                                           contactWithOffers: false,
-                                                                          countryName: 'US',
+                                                                          countryName: "US",
                                                                           displayName: null,
-                                                                          emailAddress: 'sample@microsoft.com',
+                                                                          emailAddress: "sample@microsoft.com",
                                                                           hasAccount: false,
-                                                                          language: 'english',
-                                                                          phoneNumber: '123456890'};
+                                                                          language: "english",
+                                                                          phoneNumber: "123456890"};
     let profile: ProfileInterfaces.Profile = await profileApiObject.createProfile(createProfileContext, false);
-    console.log('Profile created for', profile.coreAttributes.DisplayName.value);
+    console.log("Profile created for", profile.coreAttributes.DisplayName.value);
 
-    common.heading('Get the avatar');
+    common.heading("Get the avatar");
     const avatar: ProfileInterfaces.Avatar = await profileApiObject.getAvatar(profile.id);
     console.log("Avatar value:", avatar.value);
 
-    common.heading('Get region information');
+    common.heading("Get region information");
     const regions: ProfileInterfaces.ProfileRegions = await profileApiObject.getRegions();
     console.log(`There are ${regions.regions.length} regions found including regions like ${regions.regions[0].name}`);
 }

--- a/samples/run.ts
+++ b/samples/run.ts
@@ -3,19 +3,19 @@
 // export API_URL=https://buildcanary.visualstudio.com/DefaultCollection
 // export export API_TOKEN=<yourAllScopesApiToken>
 // export API_PROJECT=test
-import * as cm from './common';
-import * as nodeApi from 'azure-devops-node-api';
-import * as cApi from 'azure-devops-node-api/CoreApi';
-import * as coreInterfaces from 'azure-devops-node-api/interfaces/CoreInterfaces'
+import * as cm from "./common";
+import * as nodeApi from "azure-devops-node-api";
+import * as cApi from "azure-devops-node-api/CoreApi";
+import * as coreInterfaces from "azure-devops-node-api/interfaces/CoreInterfaces"
 
-let samples: string[] = require('./samples.json');
+let samples: string[] = require("./samples.json");
 let coreApi: cApi.ICoreApi;
 const maxLoops: number = 500;
 
 let selection: string = process.argv[2];
 if (selection) {
     if (samples.indexOf(selection) == -1) {
-        console.error('Not a valid sample.  See list of samples');
+        console.error("Not a valid sample.  See list of samples");
         process.exit(1);
     }
 
@@ -23,17 +23,17 @@ if (selection) {
 }
 
 async function createProject(projectId: string): Promise<boolean> {
-    console.log('Cleaning up from last run');
+    console.log("Cleaning up from last run");
     if (!(await deleteProject(projectId))) {
-        console.log('Failed to delete previous project');
+        console.log("Failed to delete previous project");
         return false;
     }
 
     const projectToCreate: coreInterfaces.TeamProject = {name: projectId,
-                                                         description: 'sample project created automatically by azure-devops-node-api.',
+                                                         description: "sample project created automatically by azure-devops-node-api.",
                                                          visibility: coreInterfaces.ProjectVisibility.Private,
-                                                         capabilities: {versioncontrol: {sourceControlType: 'Git'}, 
-                                                                        processTemplate: {templateTypeId: '6b724908-ef14-45cf-84f8-768b5384da45'}},
+                                                         capabilities: {versioncontrol: {sourceControlType: "Git"}, 
+                                                                        processTemplate: {templateTypeId: "6b724908-ef14-45cf-84f8-768b5384da45"}},
                                                          _links: null,
                                                          defaultTeam: null,
                                                          abbreviation: null,
@@ -45,7 +45,7 @@ async function createProject(projectId: string): Promise<boolean> {
 
     //Poll until project exists
     let project: coreInterfaces.TeamProject = null;
-    console.log('Waiting for project to spin up');
+    console.log("Waiting for project to spin up");
     let numLoops = 0;
     while (numLoops < maxLoops) {
         project = await coreApi.getProject(projectId);
@@ -67,7 +67,7 @@ async function deleteProject(projectId: string): Promise<boolean> {
     await coreApi.queueDeleteProject(project.id);
 
     //Poll until project no longer exists
-    console.log('Waiting for project to be deleted');
+    console.log("Waiting for project to be deleted");
     let numLoops = 0;
     while (project && numLoops < maxLoops) {
         project = await coreApi.getProject(projectId);
@@ -82,14 +82,14 @@ async function deleteProject(projectId: string): Promise<boolean> {
 async function runSamples(selected?: string) {
     const webApi: nodeApi.WebApi = await cm.getWebApi();
     coreApi = await webApi.getCoreApi();
-    const projectId: string = 'azureDevopsNodeSampleProject';
+    const projectId: string = "azureDevopsNodeSampleProject";
 
-    cm.heading('Creating example project');
+    cm.heading("Creating example project");
     if (await createProject(projectId)) {
-        console.log('Project created');
+        console.log("Project created");
     }
     else {
-        console.log('Failed to create project, exiting');
+        console.log("Failed to create project, exiting");
         return;
     }
     
@@ -100,17 +100,17 @@ async function runSamples(selected?: string) {
             continue;
         }
 
-        cm.banner('Sample ' + sample);
-        var sm = require('./' + sample + '.js');
+        cm.banner("Sample " + sample);
+        var sm = require("./" + sample + ".js");
         await sm.run(projectId);
     }
 
-    cm.heading('Cleaning up project');
+    cm.heading("Cleaning up project");
     if (await deleteProject(projectId)) {
-        console.log('Done');
+        console.log("Done");
     }
     else {
-        console.log('Failed to delete project');
+        console.log("Failed to delete project");
     }
 }
 

--- a/samples/run.ts
+++ b/samples/run.ts
@@ -100,8 +100,8 @@ async function runSamples(selected?: string) {
             continue;
         }
 
-        cm.banner("Sample " + sample);
-        var sm = require("./" + sample + ".js");
+        cm.banner(`Sample ${sample}`);
+        var sm = require(`./${sample}.js`);
         await sm.run(projectId);
     }
 

--- a/samples/task.ts
+++ b/samples/task.ts
@@ -58,7 +58,7 @@ export async function run() {
         sh.rm(sampleFilePath);
     }
     catch (err) {
-        console.error("Error: " + err.stack);
+        console.error(`Error: ${err.stack}`);
     }
 
 }

--- a/samples/task.ts
+++ b/samples/task.ts
@@ -1,15 +1,15 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as stream from 'stream';
-import * as sh from 'shelljs';
+import * as fs from "fs";
+import * as path from "path";
+import * as stream from "stream";
+import * as sh from "shelljs";
 
-import * as cm from './common';
-import * as vm from 'azure-devops-node-api';
+import * as cm from "./common";
+import * as vm from "azure-devops-node-api";
 
-import * as ta from 'azure-devops-node-api/TaskAgentApi';
-import * as ti from 'azure-devops-node-api/interfaces/TaskAgentInterfaces';
+import * as ta from "azure-devops-node-api/TaskAgentApi";
+import * as ti from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 
-let sampleFilePath: string = path.join(process.cwd(), 'taskdefinition.zip');
+let sampleFilePath: string = path.join(process.cwd(), "taskdefinition.zip");
 
 export async function run() {
     try
@@ -17,12 +17,12 @@ export async function run() {
         let vsts: vm.WebApi = await cm.getWebApi();
         let vstsTask: ta.ITaskAgentApi = await vsts.getTaskAgentApi();
 
-        cm.banner('Task Samples');
+        cm.banner("Task Samples");
         let project = cm.getProject();
-        console.log('project', project);
+        console.log("project", project);
 
         // list tasks
-        cm.heading('Task Definitions');
+        cm.heading("Task Definitions");
         let tasks: ti.TaskDefinition[] = await vstsTask.getTaskDefinitions();
         console.log(`You have ${tasks.length} task definition(s)`);
 
@@ -32,7 +32,7 @@ export async function run() {
             let file: NodeJS.WritableStream = fs.createWriteStream(sampleFilePath);
             let stream = (await vstsTask.getTaskContentZip(taskDefinition.id, `${taskDefinition.version.major}.${taskDefinition.version.minor}.${taskDefinition.version.patch}`)).pipe(file);
             let promise = new Promise((resolve, reject) => {
-                stream.on('finish', () => {
+                stream.on("finish", () => {
                     resolve();
                 });
             });
@@ -46,7 +46,7 @@ export async function run() {
         s.push("test file contents");
         s.push(null);
         let name = `vstsnodeapitest${new Date().getTime()}`;
-        console.log('uploading file');
+        console.log("uploading file");
         let secureFile = await vstsTask.uploadSecureFile(null, s, project, name);
         console.log(`uploaded secure file ${secureFile.name}`);
 
@@ -58,7 +58,7 @@ export async function run() {
         sh.rm(sampleFilePath);
     }
     catch (err) {
-        console.error('Error: ' + err.stack);
+        console.error("Error: " + err.stack);
     }
 
 }

--- a/samples/wiki.ts
+++ b/samples/wiki.ts
@@ -1,27 +1,27 @@
-import * as common from './common';
-import * as nodeApi from 'azure-devops-node-api';
+import * as common from "./common";
+import * as nodeApi from "azure-devops-node-api";
 
-import * as CoreApi from 'azure-devops-node-api/CoreApi'
-import * as CoreInterfaces from 'azure-devops-node-api/interfaces/CoreInterfaces'
-import * as WikiApi from 'azure-devops-node-api/WikiApi';
-import * as WikiInterfaces from 'azure-devops-node-api/interfaces/WikiInterfaces';
+import * as CoreApi from "azure-devops-node-api/CoreApi"
+import * as CoreInterfaces from "azure-devops-node-api/interfaces/CoreInterfaces"
+import * as WikiApi from "azure-devops-node-api/WikiApi";
+import * as WikiInterfaces from "azure-devops-node-api/interfaces/WikiInterfaces";
 
 export async function run() { 
     const webApi: nodeApi.WebApi = await common.getWebApi();
     const wikiApiObject: WikiApi.IWikiApi = await webApi.getWikiApi();
     const coreApiObject: CoreApi.ICoreApi = await webApi.getCoreApi();
 
-    common.banner('Wiki Samples');
-    const project: string = common.getProject();
+    common.banner("Wiki Samples");
+    const project = common.getProject();
     const projectObject: CoreInterfaces.TeamProject = await coreApiObject.getProject(project);
-    console.log('Project:', project);
+    console.log("Project:", project);
 
-    common.heading('Get all wikis');
+    common.heading("Get all wikis");
     const wikis: WikiInterfaces.WikiV2[] = await wikiApiObject.getAllWikis(project);
     console.log("Wikis", wikis.map((wiki) => wiki.name));
 
     let wikiId: string;
-    const createNewWiki: boolean = (wikis.length === 0);
+    const createNewWiki = (wikis.length === 0);
     if (createNewWiki) {
         common.heading("Create a wiki");
         const wikiParams: WikiInterfaces.WikiCreateParametersV2 = <WikiInterfaces.WikiCreateParametersV2>{name: "Hello Wiki", projectId: projectObject.id};


### PR DESCRIPTION
- Normalize quote types to use double quotes everywhere. (The existing code was split almost 50/50 between single and double quotes and I couldn't find a style guide, so I choose the standard the TypeScript team uses. If you prefer single quotes, I'll just change it over to that.)
- Use template strings where possible instead of concatenating strings.

@damccorm: I finally got around to this. Could you have a look?