### PR TITLE
change how useragent is formulated to support use in browser

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -42,6 +42,8 @@ import os = require('os');
 import url = require('url');
 import path = require('path');
 
+const isBrowser: boolean =(function(){return typeof window !== 'undefined' && this===window})();
+
 /**
  * Methods to return handler objects (see handlers folder)
  */
@@ -137,15 +139,23 @@ export class WebApi {
 
         let userAgent: string;
         const nodeApiName: string = 'azure-devops-node-api';
-        const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
-        const osName: string = os.platform();
-        const osVersion: string = os.release();
+        if(isBrowser) {
+            if(requestSettings) {
+                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${window.navigator.userAgent})`
+            } else {
+                userAgent = window.navigator.userAgent;
+            }
+        } else {
+            const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
+            const osName: string = os.platform();
+            const osVersion: string = os.release();
 
-        if (requestSettings) {
-            userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
-        }
-        else {
-            userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+            if (requestSettings) {
+                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
+            }
+            else {
+                userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+            }
         }
         this.rest = new rm.RestClient(userAgent, null, [this.authHandler], this.options);
         this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
@@ -401,6 +411,9 @@ export class WebApi {
     }
 
     private _readTaskLibSecrets(lookupKey: string): string {
+        if(isBrowser) {
+            throw new Error("Browsers can't securely keep secrets");
+        }
         // the lookupKey should has following format
         // base64encoded<keyFilePath>:base64encoded<encryptedContent>
         if (lookupKey && lookupKey.indexOf(':') > 0) {

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -138,7 +138,6 @@ export class WebApi {
         }
 
         let userAgent: string;
-        const nodeApiName: string = 'azure-devops-node-api';
         if(isBrowser) {
             if(requestSettings) {
                 userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${window.navigator.userAgent})`
@@ -146,6 +145,7 @@ export class WebApi {
                 userAgent = window.navigator.userAgent;
             }
         } else {
+        const nodeApiName: string = 'azure-devops-node-api';
             const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
             const osName: string = os.platform();
             const osVersion: string = os.release();

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -145,7 +145,7 @@ export class WebApi {
                 userAgent = window.navigator.userAgent;
             }
         } else {
-        const nodeApiName: string = 'azure-devops-node-api';
+            const nodeApiName: string = 'azure-devops-node-api';
             const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
             const osName: string = os.platform();
             const osVersion: string = os.release();

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -138,14 +138,14 @@ export class WebApi {
         }
 
         let userAgent: string;
+        const nodeApiName: string = 'azure-devops-node-api';
         if(isBrowser) {
             if(requestSettings) {
-                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${window.navigator.userAgent})`
+                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
             } else {
-                userAgent = window.navigator.userAgent;
+                userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
             }
         } else {
-            const nodeApiName: string = 'azure-devops-node-api';
             const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
             const osName: string = os.platform();
             const osVersion: string = os.release();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "7.1.0",
+    "version": "7.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,7 +9,7 @@
       "requires": {
         "os": "0.1.1",
         "tunnel": "0.0.4",
-        "typed-rest-client": "1.0.9",
+        "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       },
       "dependencies": {
@@ -22,7 +22,7 @@
           "bundled": true
         },
         "typed-rest-client": {
-          "version": "1.0.9",
+          "version": "1.2.0",
           "bundled": true,
           "requires": {
             "tunnel": "0.0.4",


### PR DESCRIPTION
This change makes it possible to include the library in a webpacked project. For browser calls, we use the browser's user agent, which should be fine.