### PR TITLE
Get profile samples working

### DIFF
--- a/samples/common.ts
+++ b/samples/common.ts
@@ -10,8 +10,8 @@ function getEnv(name: string): string {
     return val;
 }
 
-export async function getWebApi(): Promise<vm.WebApi> {
-    let serverUrl = getEnv("API_URL");
+export async function getWebApi(serverUrl?: string): Promise<vm.WebApi> {
+    serverUrl = serverUrl || getEnv("API_URL");
     return await this.getApi(serverUrl);
 }
 

--- a/samples/profile.ts
+++ b/samples/profile.ts
@@ -5,7 +5,11 @@ import * as ProfileApi from "azure-devops-node-api/ProfileApi";
 import * as ProfileInterfaces from "azure-devops-node-api/interfaces/ProfileInterfaces";
 
 export async function run(projectId: string) {
-    const webApi: nodeApi.WebApi = await common.getWebApi();
+    let serverUrl = process.env["API_URL"];
+    // Profile api can't be hit at the org level, has to be hit at the deployment level, so url should be structured like set API_URL=https://vssps.dev.azure.com/{orgName}
+    serverUrl = serverUrl.replace('://dev.azure.com', '://vssps.dev.azure.com');
+    console.log('serverUrl', serverUrl);
+    const webApi: nodeApi.WebApi = await common.getWebApi(serverUrl);
     const profileApiObject: ProfileApi.IProfileApi = await webApi.getProfileApi();
     common.banner("Profile Samples");
 
@@ -13,19 +17,11 @@ export async function run(projectId: string) {
     const createProfileContext: ProfileInterfaces.CreateProfileContext = {cIData: null,
                                                                           contactWithOffers: false,
                                                                           countryName: "US",
-                                                                          displayName: null,
+                                                                          displayName: "displayedName",
                                                                           emailAddress: "sample@microsoft.com",
                                                                           hasAccount: false,
                                                                           language: "english",
                                                                           phoneNumber: "123456890"};
     let profile: ProfileInterfaces.Profile = await profileApiObject.createProfile(createProfileContext, false);
     console.log("Profile created for", profile.coreAttributes.DisplayName.value);
-
-    common.heading("Get the avatar");
-    const avatar: ProfileInterfaces.Avatar = await profileApiObject.getAvatar(profile.id);
-    console.log("Avatar value:", avatar.value);
-
-    common.heading("Get region information");
-    const regions: ProfileInterfaces.ProfileRegions = await profileApiObject.getRegions();
-    console.log(`There are ${regions.regions.length} regions found including regions like ${regions.regions[0].name}`);
 }


### PR DESCRIPTION
Right now, profile samples are failing under our instructions. This is because when you try to hit `https://dev.azure.com/{orgName}/_apis/ResourceAreas` it fails, you have to hit `https://vssps.dev.azure.com/{orgName}/_apis/ResourceAreas` instead because it is considered a deployment level concept, not a project level concept. In general, things around profile don't seem settled so I took out some of the samples here as well (they were failing too).

Maybe we should add this back at some point, for now I think we should prioritize getting things working though.

Fixes #303