### PR TITLE
Fixed isBrowser check to use window.document instead

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -42,8 +42,7 @@ import os = require('os');
 import url = require('url');
 import path = require('path');
 
-const isBrowser: boolean =(function(){return typeof window !== 'undefined' && this===window})();
-
+const isBrowser: boolean =(function(){return typeof window !== 'undefined' && typeof window.document !== 'undefined'})();
 /**
  * Methods to return handler objects (see handlers folder)
  */

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -42,7 +42,7 @@ import os = require('os');
 import url = require('url');
 import path = require('path');
 
-const isBrowser: boolean =(function(){return typeof window !== 'undefined'})();
+const isBrowser: boolean = typeof window !== 'undefined';
 /**
  * Methods to return handler objects (see handlers folder)
  */

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -42,7 +42,7 @@ import os = require('os');
 import url = require('url');
 import path = require('path');
 
-const isBrowser: boolean =(function(){return typeof window !== 'undefined' && typeof window.document !== 'undefined'})();
+const isBrowser: boolean =(function(){return typeof window !== 'undefined'})();
 /**
  * Methods to return handler objects (see handlers folder)
  */


### PR DESCRIPTION
Currently, the check for isBrowser returns false in the browser due to the this===window part of the check. Instead use window.document (which is only available in the browser) to check for the browser. 