### PR TITLE
Fix tunnelling error when getting WebApi behind a proxy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -488,9 +488,9 @@
             }
         },
         "tunnel": {
-            "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
-            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+            "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "type-detect": {
             "version": "4.0.8",
@@ -505,6 +505,13 @@
             "requires": {
                 "tunnel": "0.0.4",
                 "underscore": "1.8.3"
+            },
+            "dependencies": {
+                "tunnel": {
+                    "version": "0.0.4",
+                    "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+                    "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM="
+                }
             }
         },
         "typescript": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     ],
     "license": "MIT",
     "dependencies": {
-        "tunnel": "0.0.4",
+        "tunnel": "0.0.6",
         "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
     },


### PR DESCRIPTION
fixes #331 The tunnel dependency is using an old version. The newer version includes a fix for the error.