### PR TITLE
Fix "Couldn't find a suitable Node resolution" in yarn v2

### DIFF
--- a/api/FileContainerApi.ts
+++ b/api/FileContainerApi.ts
@@ -2,7 +2,7 @@
 * ---------------------------------------------------------
 * Copyright(C) Microsoft Corporation. All rights reserved.
 * ---------------------------------------------------------
-* 
+*
 * ---------------------------------------------------------
 * Generated file, DO NOT EDIT
 * ---------------------------------------------------------
@@ -13,7 +13,7 @@
 import stream = require("stream");
 import * as zlib from "zlib";
 import * as restm from 'typed-rest-client/RestClient';
-import * as httpm from 'typed-rest-client//HttpClient';
+import * as httpm from 'typed-rest-client/HttpClient';
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import FileContainerApiBase = require("./FileContainerApiBase");
 import FileContainerInterfaces = require("./interfaces/FileContainerInterfaces");


### PR DESCRIPTION
Using this package with yarn v2 throws `Error: Couldn't find a suitable Node resolution for the specified unqualified path`.

Might be yarn v2 being too strict but the import isn't consistent with the others anyway so we might as well fix it here.