### PR TITLE
Dont fail on missing package.json

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -145,7 +145,10 @@ export class WebApi {
                 userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
             }
         } else {
-            const nodeApiVersion: string = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
+            let nodeApiVersion: string = 'unknown';
+            if (fs.existsSync(path.resolve(__dirname, 'package.json'))) {
+                nodeApiVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
+            }
             const osName: string = os.platform();
             const osVersion: string = os.release();
 

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -146,8 +146,9 @@ export class WebApi {
             }
         } else {
             let nodeApiVersion: string = 'unknown';
-            if (fs.existsSync(path.resolve(__dirname, 'package.json'))) {
-                nodeApiVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')).version;
+            const packageJsonPath: string = path.resolve(__dirname, 'package.json');
+            if (fs.existsSync(packageJsonPath)) {
+                nodeApiVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
             }
             const osName: string = os.platform();
             const osVersion: string = os.release();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "9.0.2",
+    "version": "9.0.3",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
When people use webpack, the releative location of files gets moved around - this makes sure we don't fail on that since its only used for userAgents. I think we technically have that as telemetry, but I've never seen us use it

Fixes #312