### PR TITLE
278 - fix BUG in getCommitDiffs so it works comparing start and end commit ids

### DIFF
--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -894,9 +894,11 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 diffCommonCommit: diffCommonCommit,
                 '$top': top,
                 '$skip': skip,
-                baseVersionDescriptor: baseVersionDescriptor,
-                targetVersionDescriptor: targetVersionDescriptor,
-            };
+                'baseVersion': baseVersionDescriptor.baseVersion,
+                'baseVersionType': baseVersionDescriptor.baseVersionType,
+                'targetVersion': targetVersionDescriptor.targetVersion,
+                'targetVersionType': targetVersionDescriptor.targetVersionType
+              };
             
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(


### PR DESCRIPTION
feature GitApi.getCommitDiffs does not work as the API expects baseVersion, baseVersionType, targetVersion, targetVersionType.   This resolves issue with minor change temporarily adjusting request so that it matches api expectations.

https://github.com/microsoft/azure-devops-node-api/issues/278