### PR TITLE
Fix sample project snippet parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ npm run samples
 Run a specific sample:
 
 ```bash
-$ npm run samples -- http
+$ npm run samples -- projectAnalysis
 ```
 
 ## API and TFS Mapping


### PR DESCRIPTION
This changes the sample to run from `http` (no longer an option) to
existing and working `projectAnalysis`

Thanks!