### PR TITLE
Added the support for domains in no_proxy env var

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -366,12 +366,20 @@ export class WebApi {
         if (!process.env.no_proxy) {
             return false;
         }
+
         const noProxyDomains = (process.env.no_proxy || '')
         .split(',')
         .map(v => v.toLowerCase());
         const serverUrl = url.parse(_url).host.toLowerCase();
-        // return true if the no_proxy includes the host
-        return noProxyDomains.indexOf(serverUrl) !== -1;
+
+        for (const domain of noProxyDomains) {
+            // if the domain of the server is listed, return true
+            if (serverUrl.endsWith(domain)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private async _getResourceAreaUrl(serverUrl: string, resourceId: string): Promise<string> {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -10,6 +10,33 @@
         "tunnel": "0.0.6",
         "typed-rest-client": "1.7.2",
         "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "typed-rest-client": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.2.tgz",
+          "integrity": "sha512-6ENgPdTH7s2Xcd6mBaahyMLBoXPi0LNe75E1T0RFOdhqN9ENpZmf3P5iloOlJUDaHYrucPPzMrBybr6BdS2URg==",
+          "requires": {
+            "qs": "^6.9.1",
+            "tunnel": "0.0.6",
+            "underscore": "1.8.3"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
       }
     }
   }

--- a/test/units/tests.js
+++ b/test/units/tests.js
@@ -270,7 +270,7 @@ describe('WebApi Units', function () {
         assert.equal(myWebApi.isNoProxyHost('https://dev.azure.com/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-tfs-instance.host/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-other-tfs-instance.host/myproject'), false);
-        assert.equal(myWebApi.isNoProxyHost('https://tfs.mydomain.com/mycollection'), false);
+        assert.equal(myWebApi.isNoProxyHost('https://tfs.mydomain.com/mycollection'), true);
         assert.equal(myWebApi.isNoProxyHost('https://tfs.ad.mydomain.com/mycollection'), true);
     }));
 });

--- a/test/units/tests.js
+++ b/test/units/tests.js
@@ -266,9 +266,11 @@ describe('WebApi Units', function () {
     }));
     it('supports no_proxy environment variable', () => __awaiter(this, void 0, void 0, function* () {
         const myWebApi = new WebApi.WebApi('https://dev.azure.com/', WebApi.getBasicHandler('user', 'password'), null);
-        process.env.no_proxy = 'dev.azure.com,my-tfs-instance.host';
+        process.env.no_proxy = 'dev.azure.com,my-tfs-instance.host,.mydomain.com';
         assert.equal(myWebApi.isNoProxyHost('https://dev.azure.com/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-tfs-instance.host/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-other-tfs-instance.host/myproject'), false);
+        assert.equal(myWebApi.isNoProxyHost('https://tfs.mydomain.com/mycollection'), false);
+        assert.equal(myWebApi.isNoProxyHost('https://tfs.ad.mydomain.com/mycollection'), true);
     }));
 });

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -293,9 +293,11 @@ describe('WebApi Units', function () {
 
     it('supports no_proxy environment variable', async() => {
         const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com/', WebApi.getBasicHandler('user', 'password'), null);
-        process.env.no_proxy='dev.azure.com,my-tfs-instance.host'
+        process.env.no_proxy='dev.azure.com,my-tfs-instance.host,.mydomain.com'
         assert.equal(myWebApi.isNoProxyHost('https://dev.azure.com/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-tfs-instance.host/myproject'), true);
         assert.equal(myWebApi.isNoProxyHost('https://my-other-tfs-instance.host/myproject'), false);
+        assert.equal(myWebApi.isNoProxyHost('https://tfs.mydomain.com/mycollection'), true);
+        assert.equal(myWebApi.isNoProxyHost('https://tfs.ad.mydomain.com/mycollection'), true);
     });
 });


### PR DESCRIPTION
Domains and subdomains are currently not supported in the no_proxy environment variable.
It is wildly accepted for the no_proxy variable to enlist all of the hosts in a given domain with the .domain.com notion, where . indicates all domains and subdomains for a given domain.
With this change we add the support of specifying the domains in the no_proxy variable.


Closes #382 