### PR TITLE
Remove deprecated URL API usage

### DIFF
--- a/api/TaskAgentApi.ts
+++ b/api/TaskAgentApi.ts
@@ -1,7 +1,6 @@
 import basem = require('./ClientApiBases');
 import ifm = require("./interfaces/common/VsoBaseInterfaces");
 import taskagentbasem = require('./TaskAgentApiBase');
-import url = require('url');
 import vsom = require('./VsoClient');
 import TaskAgentInterfaces = require("./interfaces/TaskAgentInterfaces");
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
@@ -226,7 +225,7 @@ export class TaskAgentApi extends taskagentbasem.TaskAgentApiBase implements ITa
     private _getAccountUrl(collectionUrl: string): string {
         // converts a collection URL to an account URL
         // returns null if the conversion can't be made
-        var purl = url.parse(collectionUrl);
+        var purl = new URL(collectionUrl);
         if (!purl.protocol || !purl.host) {
             return null;
         }
@@ -234,7 +233,7 @@ export class TaskAgentApi extends taskagentbasem.TaskAgentApiBase implements ITa
         var accountUrl = purl.protocol + '//' + purl.host;
 
         // purl.path is something like /DefaultCollection or /tfs/DefaultCollection or /DefaultCollection/
-        var splitPath: string[] = purl.path.split('/').slice(1);
+        var splitPath: string[] = purl.pathname.split('/').slice(1);
         if (splitPath.length === 0 || (splitPath.length === 1 && splitPath[0] === '')) {
             return null;
         }

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -43,12 +43,10 @@ export class VsoClient {
     private _initializationPromise: Promise<any>;
 
     restClient: restm.RestClient;
-    baseUrl: string;
-    basePath: string;
+    baseUrl: URL;
 
     constructor(baseUrl: string, restClient: restm.RestClient) {
-        this.baseUrl = baseUrl;
-        this.basePath = new URL(baseUrl).pathname;
+        this.baseUrl = new URL(baseUrl);
         this.restClient = restClient;
         this._locationsByAreaPromises = {};
         this._initializationPromise = Promise.resolve(true);
@@ -180,7 +178,7 @@ export class VsoClient {
     }
 
     public resolveUrl(relativeUrl: string): string {
-        return new URL(path.resolve(this.basePath, relativeUrl), this.baseUrl).toString();
+        return new URL(relativeUrl, this.baseUrl).toString();
     }
 
     private queryParamsToStringHelper(queryParams: any, prefix: string): string {
@@ -238,7 +236,7 @@ export class VsoClient {
 
         // Resolve the relative url with the base
         return new URL(
-          path.resolve(this.basePath, relativeUrl),
+          relativeUrl,
           this.baseUrl
         ).toString();
     }

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -3,7 +3,6 @@
 //*******************************************************************************************************
 
 /// Imports of 3rd Party ///
-import url = require("url");
 import path = require("path");
 /// Import base rest class ///
 import * as restm from 'typed-rest-client/RestClient';
@@ -49,7 +48,7 @@ export class VsoClient {
 
     constructor(baseUrl: string, restClient: restm.RestClient) {
         this.baseUrl = baseUrl;
-        this.basePath = url.parse(baseUrl).pathname;
+        this.basePath = new URL(baseUrl).pathname;
         this.restClient = restClient;
         this._locationsByAreaPromises = {};
         this._initializationPromise = Promise.resolve(true);
@@ -181,7 +180,7 @@ export class VsoClient {
     }
 
     public resolveUrl(relativeUrl: string): string {
-        return url.resolve(this.baseUrl, path.join(this.basePath, relativeUrl));
+        return new URL(path.resolve(this.basePath, relativeUrl), this.baseUrl).toString();
     }
 
     private queryParamsToStringHelper(queryParams: any, prefix: string): string {
@@ -238,7 +237,10 @@ export class VsoClient {
         }
 
         // Resolve the relative url with the base
-        return url.resolve(this.baseUrl, path.join(this.basePath, relativeUrl));
+        return new URL(
+          path.resolve(this.basePath, relativeUrl),
+          this.baseUrl
+        ).toString();
     }
 
     // helper method copied directly from VSS\WebAPI\restclient.ts

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -39,7 +39,6 @@ import lim = require("./interfaces/LocationsInterfaces");
 import crypto = require('crypto');
 import fs = require('fs');
 import os = require('os');
-import url = require('url');
 import path = require('path');
 
 const isBrowser: boolean = typeof window !== 'undefined';
@@ -369,7 +368,7 @@ export class WebApi {
         const noProxyDomains = (process.env.no_proxy || '')
         .split(',')
         .map(v => v.toLowerCase());
-        const serverUrl = url.parse(_url).host.toLowerCase();
+        const serverUrl = new URL(_url).host.toLowerCase();
         // return true if the no_proxy includes the host
         return noProxyDomains.indexOf(serverUrl) !== -1;
     }

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -7,7 +7,6 @@
 
 import Serialization = require('../../Serialization');
 import http = require("http");
-import url = require("url");
 
 /**
  * Information about the location of a REST API resource
@@ -69,7 +68,7 @@ export interface IHttpClient {
 
 export interface IRequestInfo {
     options: http.RequestOptions;
-    parsedUrl: url.Url;
+    parsedUrl: URL;
     httpModule: any;
 }
 

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -8,8 +8,35 @@
       "version": "file:../_build",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "1.7.2",
+        "typed-rest-client": "^1.7.3",
         "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "typed-rest-client": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.3.tgz",
+          "integrity": "sha512-CwTpx/TkRHGZoHkJhBcp4X8K3/WtlzSHVQR0OIFnt10j4tgy4ypgq/SrrgVpA1s6tAL49Q6J3R5C0Cgfh2ddqA==",
+          "requires": {
+            "qs": "^6.9.1",
+            "tunnel": "0.0.6",
+            "underscore": "1.8.3"
+          }
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
       }
     }
   }


### PR DESCRIPTION
The legacy URL API (provided by `require('url')`) was deprecated by NodeJS 11 released in October 2018. It is scheduled to be removed in a future release.

The main motivation for this change, is Yarn v2, which does not allow undeclared dependencies to be used. `require('url')` is ambiguous between the built-in NodeJS module, and the npm package [url](https://www.npmjs.com/package/url). I'm assuming the intent is to use the built-in module, so I've migrated to using the new URL API, for which the import is implicit.