### PR TITLE
Fix `updatePullRequestReviewer`

### DIFF
--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -4249,7 +4249,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
     }
 
     /**
-     * Edit a reviewer entry. These fields are patchable: isFlagged
+     * Edit a reviewer entry. These fields are patchable: isFlagged, vote
      * 
      * @param {GitInterfaces.IdentityRefWithVote} reviewer - Reviewer data.<br />If the reviewer's ID is included here, it must match the reviewerID parameter.
      * @param {string} repositoryId - The repository ID of the pull request’s target branch.
@@ -4285,7 +4285,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                                                                                 verData.apiVersion);
 
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote>;
-                res = await this.rest.update<GitInterfaces.IdentityRefWithVote>(url, reviewer, options);
+                res = await this.rest.replace<GitInterfaces.IdentityRefWithVote>(url, reviewer, options);
 
                 let ret = this.formatResponse(res.result,
                                               null,


### PR DESCRIPTION
The pull request reviewer vote could not be updated by calling `updatePullRequestReviewer()`. According to the AzDO REST API documentation (https://docs.microsoft.com/en-us/rest/api/azure/devops/git/pull%20request%20reviewers/create%20pull%20request%20reviewer?view=azure-devops-rest-5.1), `PUT /{organization}/{project}/_apis/git/repositories/{repositoryId}/pullRequests/{pullRequestId}/reviewers/{reviewerId}` (instead of the PATCH method) should be used to cast a reviewer vote, which also allows to update other properties of the reviewer such as `isFlagged`.

Issue #407 