### PR TITLE
Passed allowCrossOriginAuthentication to BasicCredentialHandler constructor - to fix authorization issue

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -55,20 +55,20 @@ export function getNtlmHandler(username: string, password: string, workstation?:
     return new ntlmm.NtlmCredentialHandler(username, password, workstation, domain);
 }
 
-export function getBearerHandler(token: string): VsoBaseInterfaces.IRequestHandler {
-    return new bearm.BearerCredentialHandler(token);
+export function getBearerHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new bearm.BearerCredentialHandler(token, allowCrossOriginAuthentication);
 }
 
-export function getPersonalAccessTokenHandler(token: string): VsoBaseInterfaces.IRequestHandler {
-    return new patm.PersonalAccessTokenCredentialHandler(token);
+export function getPersonalAccessTokenHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new patm.PersonalAccessTokenCredentialHandler(token, allowCrossOriginAuthentication);
 }
 
-export function getHandlerFromToken(token: string): VsoBaseInterfaces.IRequestHandler {
+export function getHandlerFromToken(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
     if (token.length === 52) {
-        return getPersonalAccessTokenHandler(token);
+        return getPersonalAccessTokenHandler(token, allowCrossOriginAuthentication);
     }
     else {
-        return getBearerHandler(token);
+        return getBearerHandler(token, allowCrossOriginAuthentication);
     }
 }
 

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -47,8 +47,8 @@ const isBrowser: boolean = typeof window !== 'undefined';
  * Methods to return handler objects (see handlers folder)
  */
 
-export function getBasicHandler(username: string, password: string): VsoBaseInterfaces.IRequestHandler {
-    return new basicm.BasicCredentialHandler(username, password);
+export function getBasicHandler(username: string, password: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new basicm.BasicCredentialHandler(username, password, allowCrossOriginAuthentication);
 }
 
 export function getNtlmHandler(username: string, password: string, workstation?: string, domain?: string): VsoBaseInterfaces.IRequestHandler {

--- a/api/handlers/basiccreds.ts
+++ b/api/handlers/basiccreds.ts
@@ -5,7 +5,7 @@ import ifm = require('../interfaces/common/VsoBaseInterfaces');
 import * as resthandlers from 'typed-rest-client/Handlers'; 
 
 export class BasicCredentialHandler extends resthandlers.BasicCredentialHandler implements ifm.IRequestHandler {
-    constructor(username: string, password: string) {
-        super(username, password);
+    constructor(username: string, password: string, allowCrossOriginAuthentication?: boolean) {
+        super(username, password, allowCrossOriginAuthentication);
     }
 }

--- a/api/handlers/bearertoken.ts
+++ b/api/handlers/bearertoken.ts
@@ -5,7 +5,7 @@ import ifm = require('../interfaces/common/VsoBaseInterfaces');
 import * as resthandlers from 'typed-rest-client/Handlers'; 
 
 export class BearerCredentialHandler extends resthandlers.BearerCredentialHandler implements ifm.IRequestHandler {
-    constructor(token: string) {
-        super(token);
+    constructor(token: string, allowCrossOriginAuthentication?: boolean) {
+        super(token, allowCrossOriginAuthentication);
     }
 }

--- a/api/handlers/personalaccesstoken.ts
+++ b/api/handlers/personalaccesstoken.ts
@@ -5,7 +5,7 @@ import ifm = require('../interfaces/common/VsoBaseInterfaces');
 import * as resthandlers from 'typed-rest-client/Handlers'; 
 
 export class PersonalAccessTokenCredentialHandler extends resthandlers.PersonalAccessTokenCredentialHandler implements ifm.IRequestHandler {
-    constructor(token: string) {
-        super(token);
+    constructor(token: string, allowCrossOriginAuthentication?: boolean) {
+        super(token, allowCrossOriginAuthentication);
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "10.1.1",
+    "version": "10.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -499,9 +499,9 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.7.3.tgz",
-            "integrity": "sha512-CwTpx/TkRHGZoHkJhBcp4X8K3/WtlzSHVQR0OIFnt10j4tgy4ypgq/SrrgVpA1s6tAL49Q6J3R5C0Cgfh2ddqA==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
+            "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
             "requires": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
@@ -509,9 +509,9 @@
             },
             "dependencies": {
                 "qs": {
-                    "version": "6.9.3",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
-                    "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+                    "version": "6.9.4",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
+                    "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "10.1.1",
+    "version": "10.1.2",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.7.3",
+        "typed-rest-client": "^1.8.0",
         "underscore": "1.8.3"
     },
     "devDependencies": {


### PR DESCRIPTION
Passed allowCrossOriginAuthentication to BasicCredentialHandler constructor of typed-rest-client.

Related issue: https://github.com/microsoft/azure-devops-node-api/issues/419