### PR TITLE
Added retry logic to the downloadSecureFile method

### DIFF
--- a/api/TaskAgentApiBase.ts
+++ b/api/TaskAgentApiBase.ts
@@ -5047,11 +5047,11 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                         queryValues);
     
                     let url: string = verData.requestUrl!;
-                    
                     let apiVersion: string = verData.apiVersion!;
                     let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
-                    resolve((await this.http.get(url, { "Accept": accept })).message);
+                    const result = await this.http.get(url, { "Accept": accept });
                     isDownloadSuccessful = true;
+                    resolve(result.message);
                 }
                 catch (err) {
                     if (numberOfAttemps == maxRetryCount) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "10.1.2",
+    "version": "10.1.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "10.1.2",
+    "version": "10.1.3",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
Added logic that allow to retry downloading of secure file in case any error returned from HttpClient module.
This pr is related to this [issue](https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1795923?src=WorkItemMention&src-action=artifact_link)