### PR TITLE
Update actions/stale to v3

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has had no activity in 90 days. Please comment if it is not actually stale'


### PR DESCRIPTION
v1 of the stale bot is malfunctioning, e.g. see how #411 was closed despite people commenting. Hopefully it's fixed in v3