### PR TITLE
Bump dependencies to fix security alerts [CVE-2021-23358]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -233,9 +233,9 @@
             "dev": true
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "lodash._baseassign": {
@@ -322,12 +322,20 @@
             "dev": true
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                }
             }
         },
         "mocha": {
@@ -371,6 +379,15 @@
                         "minimatch": "^3.0.2",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
                     }
                 },
                 "ms": {
@@ -512,6 +529,11 @@
                     "version": "6.9.4",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
                     "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 }
             }
         },
@@ -522,9 +544,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.0",
-        "underscore": "1.8.3"
+        "underscore": "1.12.1"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.44",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -8,8 +8,97 @@
       "version": "file:../_build",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "1.7.2",
-        "underscore": "1.8.3"
+        "typed-rest-client": "^1.8.0",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "typed-rest-client": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.3.tgz",
+          "integrity": "sha512-gJoH7RE3trY77Bf5MNezVV+21O/WMmt9ps7w1bjFyLxrQqDymDWJSDacem1eM6R86zFM0FlE07F8dOupLmKLmQ==",
+          "requires": {
+            "qs": "^6.9.1",
+            "tunnel": "0.0.6",
+            "underscore": "1.8.3"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+              "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+        }
       }
     }
   }


### PR DESCRIPTION
Hello, our team was hit by a security alert from this package due to the `underscore` dependency. This PR manually updates `underscore` and runs `npm run audit fix`. I did not manually bump other semver-major dependencies though

npm run audit output: 
```
found 6 vulnerabilities (4 low, 1 high, 1 critical) in 70 scanned packages
  run `npm audit fix` to fix 2 of them.
  4 vulnerabilities require semver-major dependency updates.

``` 


Partially fixes https://nvd.nist.gov/vuln/detail/CVE-2021-23358 since this CVE against this package also depends on https://github.com/microsoft/typed-rest-client/pull/258 being merged.