### PR TITLE
Bump dependencies (typed-rest-client)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,15 @@
             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
             "dev": true
         },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
         "chai": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
@@ -154,11 +163,26 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
         },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
         "get-func-name": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
         },
         "glob": {
             "version": "7.1.2",
@@ -186,11 +210,24 @@
             "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
             "dev": true
         },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
         "has-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
             "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
             "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
         },
         "he": {
             "version": "1.1.1",
@@ -421,6 +458,11 @@
                 "semver": "^5.5.0"
             }
         },
+        "object-inspect": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -495,6 +537,16 @@
                 "rechoir": "^0.6.2"
             }
         },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
         "supports-color": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
@@ -516,24 +568,22 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.0.tgz",
-            "integrity": "sha512-Nu1MrdH6ECrRW5gHoRAdubgCs4oH6q5/J76jsEC8bVDfvVoVPkigukPalhMHPwb7ZvpsZqPptd5zpt/QdtrdBw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+            "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
             "requires": {
                 "qs": "^6.9.1",
                 "tunnel": "0.0.6",
-                "underscore": "1.8.3"
+                "underscore": "^1.12.1"
             },
             "dependencies": {
                 "qs": {
-                    "version": "6.9.4",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-                    "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
-                },
-                "underscore": {
-                    "version": "1.8.3",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+                    "version": "6.10.1",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+                    "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+                    "requires": {
+                        "side-channel": "^1.0.4"
+                    }
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "10.2.1",
+    "version": "10.2.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -233,9 +233,9 @@
             "dev": true
         },
         "lodash": {
-            "version": "4.17.15",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "dev": true
         },
         "lodash._baseassign": {
@@ -322,12 +322,20 @@
             "dev": true
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "1.2.5",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+                    "dev": true
+                }
             }
         },
         "mocha": {
@@ -371,6 +379,15 @@
                         "minimatch": "^3.0.2",
                         "once": "^1.3.0",
                         "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                    "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "0.0.8"
                     }
                 },
                 "ms": {
@@ -512,6 +529,11 @@
                     "version": "6.9.4",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
                     "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+                },
+                "underscore": {
+                    "version": "1.8.3",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+                    "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
                 }
             }
         },
@@ -522,9 +544,9 @@
             "dev": true
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+            "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
         },
         "wrappy": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.4",
-        "underscore": "1.12.1"
+        "typed-rest-client": "^1.8.4"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.44",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "license": "MIT",
     "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
+        "typed-rest-client": "^1.8.4",
         "underscore": "1.12.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "tunnel": "0.0.6",
         "typed-rest-client": "^1.8.0",
-        "underscore": "1.8.3"
+        "underscore": "1.12.1"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.44",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "10.2.1",
+    "version": "10.2.2",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -8,8 +8,7 @@
       "version": "file:../_build",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^1.8.0",
-        "underscore": "1.12.1"
+        "typed-rest-client": "^1.8.4"
       },
       "dependencies": {
         "call-bind": {
@@ -78,26 +77,19 @@
           "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
         },
         "typed-rest-client": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.3.tgz",
-          "integrity": "sha512-gJoH7RE3trY77Bf5MNezVV+21O/WMmt9ps7w1bjFyLxrQqDymDWJSDacem1eM6R86zFM0FlE07F8dOupLmKLmQ==",
+          "version": "1.8.4",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
+          "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
           "requires": {
             "qs": "^6.9.1",
             "tunnel": "0.0.6",
-            "underscore": "1.8.3"
-          },
-          "dependencies": {
-            "underscore": {
-              "version": "1.8.3",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-              "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-            }
+            "underscore": "^1.12.1"
           }
         },
         "underscore": {
-          "version": "1.12.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+          "version": "1.13.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.0.tgz",
+          "integrity": "sha512-sCs4H3pCytsb5K7i072FAEC9YlSYFIbosvM0tAKAlpSSUgD7yC1iXSEGdl5XrDKQ1YUB+p/HDzYrSG2H2Vl36g=="
         }
       }
     }

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -8,8 +8,97 @@
       "version": "file:../_build",
       "requires": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "1.7.2",
-        "underscore": "1.8.3"
+        "typed-rest-client": "^1.8.0",
+        "underscore": "1.12.1"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "object-inspect": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+          "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "qs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
+          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "side-channel": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+          "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+          "requires": {
+            "call-bind": "^1.0.0",
+            "get-intrinsic": "^1.0.2",
+            "object-inspect": "^1.9.0"
+          }
+        },
+        "tunnel": {
+          "version": "0.0.6",
+          "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+          "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
+        },
+        "typed-rest-client": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.3.tgz",
+          "integrity": "sha512-gJoH7RE3trY77Bf5MNezVV+21O/WMmt9ps7w1bjFyLxrQqDymDWJSDacem1eM6R86zFM0FlE07F8dOupLmKLmQ==",
+          "requires": {
+            "qs": "^6.9.1",
+            "tunnel": "0.0.6",
+            "underscore": "1.8.3"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+              "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
+          "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+        }
       }
     }
   }


### PR DESCRIPTION
Fix CVE-2021-23358
Remove unused underscore dependency