### PR TITLE
Remove fake credentials from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import * as azdev from "azure-devops-node-api";
 // your collection url
 let orgUrl = "https://dev.azure.com/yourorgname";
 
-let token: string = process.env.AZURE_PERSONAL_ACCESS_TOKEN; // e.g "cbdeb34vzyuk5l4gxc4qfczn3lko3avfkfqyb47etahq6axpcqha"; 
+let token: string = process.env.AZURE_PERSONAL_ACCESS_TOKEN;
 
 let authHandler = azdev.getPersonalAccessTokenHandler(token); 
 let connection = new azdev.WebApi(orgUrl, authHandler);    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "11.0.0",
+    "version": "11.0.1",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
This is causing some people's cred scanner to go off, we should just remove it since its just an example and doesn't serve too much purpose