### PR TITLE
Add correct RESOURCE_AREA_ID for each API

### DIFF
--- a/api/FeatureManagementApi.ts
+++ b/api/FeatureManagementApi.ts
@@ -33,14 +33,16 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
         super(baseUrl, handlers, 'node-FeatureManagement-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "";
+
     /**
      * Get a specific feature by its id
-     * 
+     *
      * @param {string} featureId - The contribution id of the feature
      */
     public async getFeature(
         featureId: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeature> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeature> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeature>(async (resolve, reject) => {
             let routeValues: any = {
@@ -55,18 +57,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeature>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeature>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -76,12 +78,12 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get a list of all defined features
-     * 
+     *
      * @param {string} targetContributionId - Optional target contribution. If null/empty, return all features. If specified include the features that target the specified contribution.
      */
     public async getFeatures(
         targetContributionId?: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeature[]> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeature[]> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeature[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -90,7 +92,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
             let queryValues: any = {
                 targetContributionId: targetContributionId,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -100,18 +102,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeature[]>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeature[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              true);
+                    null,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -121,14 +123,14 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get the state of the specified feature for the given user/all-users scope
-     * 
+     *
      * @param {string} featureId - Contribution id of the feature
      * @param {string} userScope - User-Scope at which to get the value. Should be "me" for the current user or "host" for all users.
      */
     public async getFeatureState(
         featureId: string,
         userScope: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureState>(async (resolve, reject) => {
             let routeValues: any = {
@@ -144,18 +146,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeatureState>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -165,7 +167,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Set the state of a feature
-     * 
+     *
      * @param {FeatureManagementInterfaces.ContributedFeatureState} feature - Posted feature state object. Should specify the effective value.
      * @param {string} featureId - Contribution id of the feature
      * @param {string} userScope - User-Scope at which to set the value. Should be "me" for the current user or "host" for all users.
@@ -178,7 +180,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
         userScope: string,
         reason?: string,
         reasonCode?: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureState>(async (resolve, reject) => {
             let routeValues: any = {
@@ -190,7 +192,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 reason: reason,
                 reasonCode: reasonCode,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -200,18 +202,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.update<FeatureManagementInterfaces.ContributedFeatureState>(url, feature, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -221,7 +223,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get the state of the specified feature for the given named scope
-     * 
+     *
      * @param {string} featureId - Contribution id of the feature
      * @param {string} userScope - User-Scope at which to get the value. Should be "me" for the current user or "host" for all users.
      * @param {string} scopeName - Scope at which to get the feature setting for (e.g. "project" or "team")
@@ -232,7 +234,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
         userScope: string,
         scopeName: string,
         scopeValue: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureState>(async (resolve, reject) => {
             let routeValues: any = {
@@ -250,18 +252,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeatureState>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -271,7 +273,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Set the state of a feature at a specific scope
-     * 
+     *
      * @param {FeatureManagementInterfaces.ContributedFeatureState} feature - Posted feature state object. Should specify the effective value.
      * @param {string} featureId - Contribution id of the feature
      * @param {string} userScope - User-Scope at which to set the value. Should be "me" for the current user or "host" for all users.
@@ -288,7 +290,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
         scopeValue: string,
         reason?: string,
         reasonCode?: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureState> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureState>(async (resolve, reject) => {
             let routeValues: any = {
@@ -302,7 +304,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 reason: reason,
                 reasonCode: reasonCode,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -312,18 +314,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.update<FeatureManagementInterfaces.ContributedFeatureState>(url, feature, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -333,12 +335,12 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get the effective state for a list of feature ids
-     * 
+     *
      * @param {FeatureManagementInterfaces.ContributedFeatureStateQuery} query - Features to query along with current scope values
      */
     public async queryFeatureStates(
         query: FeatureManagementInterfaces.ContributedFeatureStateQuery
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery>(async (resolve, reject) => {
             let routeValues: any = {
@@ -352,18 +354,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -373,14 +375,14 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get the states of the specified features for the default scope
-     * 
+     *
      * @param {FeatureManagementInterfaces.ContributedFeatureStateQuery} query - Query describing the features to query.
      * @param {string} userScope
      */
     public async queryFeatureStatesForDefaultScope(
         query: FeatureManagementInterfaces.ContributedFeatureStateQuery,
         userScope: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery>(async (resolve, reject) => {
             let routeValues: any = {
@@ -395,18 +397,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -416,7 +418,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
 
     /**
      * Get the states of the specified features for the specific named scope
-     * 
+     *
      * @param {FeatureManagementInterfaces.ContributedFeatureStateQuery} query - Query describing the features to query.
      * @param {string} userScope
      * @param {string} scopeName
@@ -427,7 +429,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
         userScope: string,
         scopeName: string,
         scopeValue: string
-        ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
+    ): Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery> {
 
         return new Promise<FeatureManagementInterfaces.ContributedFeatureStateQuery>(async (resolve, reject) => {
             let routeValues: any = {
@@ -444,18 +446,18 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
                 let ret = this.formatResponse(res.result,
-                                              FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
-                                              false);
+                    FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);

--- a/api/FileContainerApi.ts
+++ b/api/FileContainerApi.ts
@@ -29,6 +29,8 @@ export class FileContainerApi extends FileContainerApiBase.FileContainerApiBase 
         super(baseUrl, handlers, options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "";
+
     /**
      * @param {number} containerId
      * @param {string} scope

--- a/api/NotificationApi.ts
+++ b/api/NotificationApi.ts
@@ -48,12 +48,14 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
         super(baseUrl, handlers, 'node-Notification-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "";
+
     /**
      * @param {NotificationInterfaces.BatchNotificationOperation} operation
      */
     public async performBatchNotificationOperations(
         operation: NotificationInterfaces.BatchNotificationOperation
-        ): Promise<void> {
+    ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -67,18 +69,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, operation, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -88,7 +90,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get a list of diagnostic logs for this service.
-     * 
+     *
      * @param {string} source - ID specifying which type of logs to check diagnostics for.
      * @param {string} entryId - The ID of the specific log to query for.
      * @param {Date} startTime - Start time for the time range to query in.
@@ -99,7 +101,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
         entryId?: string,
         startTime?: Date,
         endTime?: Date
-        ): Promise<NotificationInterfaces.INotificationDiagnosticLog[]> {
+    ): Promise<NotificationInterfaces.INotificationDiagnosticLog[]> {
 
         return new Promise<NotificationInterfaces.INotificationDiagnosticLog[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -111,7 +113,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 startTime: startTime,
                 endTime: endTime,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -121,18 +123,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.INotificationDiagnosticLog[]>;
                 res = await this.rest.get<NotificationInterfaces.INotificationDiagnosticLog[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.INotificationDiagnosticLog,
-                                              true);
+                    NotificationInterfaces.TypeInfo.INotificationDiagnosticLog,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -142,12 +144,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get the diagnostics settings for a subscription.
-     * 
+     *
      * @param {string} subscriptionId - The id of the notifications subscription.
      */
     public async getSubscriptionDiagnostics(
         subscriptionId: string
-        ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
+    ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
 
         return new Promise<NotificationInterfaces.SubscriptionDiagnostics>(async (resolve, reject) => {
             let routeValues: any = {
@@ -162,18 +164,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
                 res = await this.rest.get<NotificationInterfaces.SubscriptionDiagnostics>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
-                                              false);
+                    NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -183,14 +185,14 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Update the diagnostics settings for a subscription.
-     * 
+     *
      * @param {NotificationInterfaces.UpdateSubscripitonDiagnosticsParameters} updateParameters
      * @param {string} subscriptionId - The id of the notifications subscription.
      */
     public async updateSubscriptionDiagnostics(
         updateParameters: NotificationInterfaces.UpdateSubscripitonDiagnosticsParameters,
         subscriptionId: string
-        ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
+    ): Promise<NotificationInterfaces.SubscriptionDiagnostics> {
 
         return new Promise<NotificationInterfaces.SubscriptionDiagnostics>(async (resolve, reject) => {
             let routeValues: any = {
@@ -205,18 +207,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
                 res = await this.rest.replace<NotificationInterfaces.SubscriptionDiagnostics>(url, updateParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
-                                              false);
+                    NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -226,12 +228,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Publish an event. This request must be directed to the service "extmgmt".
-     * 
+     *
      * @param {VSSInterfaces.VssNotificationEvent} notificationEvent
      */
     public async publishEvent(
         notificationEvent: VSSInterfaces.VssNotificationEvent
-        ): Promise<VSSInterfaces.VssNotificationEvent> {
+    ): Promise<VSSInterfaces.VssNotificationEvent> {
 
         return new Promise<VSSInterfaces.VssNotificationEvent>(async (resolve, reject) => {
             let routeValues: any = {
@@ -245,18 +247,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<VSSInterfaces.VssNotificationEvent>;
                 res = await this.rest.create<VSSInterfaces.VssNotificationEvent>(url, notificationEvent, options);
 
                 let ret = this.formatResponse(res.result,
-                                              VSSInterfaces.TypeInfo.VssNotificationEvent,
-                                              false);
+                    VSSInterfaces.TypeInfo.VssNotificationEvent,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -266,12 +268,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Tranform a notification event.
-     * 
+     *
      * @param {NotificationInterfaces.EventTransformRequest} transformRequest - Object to be transformed.
      */
     public async transformEvent(
         transformRequest: NotificationInterfaces.EventTransformRequest
-        ): Promise<NotificationInterfaces.EventTransformResult> {
+    ): Promise<NotificationInterfaces.EventTransformResult> {
 
         return new Promise<NotificationInterfaces.EventTransformResult>(async (resolve, reject) => {
             let routeValues: any = {
@@ -285,18 +287,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.EventTransformResult>;
                 res = await this.rest.create<NotificationInterfaces.EventTransformResult>(url, transformRequest, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -311,7 +313,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
     public async queryEventTypes(
         inputValuesQuery: NotificationInterfaces.FieldValuesQuery,
         eventType: string
-        ): Promise<NotificationInterfaces.NotificationEventField[]> {
+    ): Promise<NotificationInterfaces.NotificationEventField[]> {
 
         return new Promise<NotificationInterfaces.NotificationEventField[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -326,18 +328,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventField[]>;
                 res = await this.rest.create<NotificationInterfaces.NotificationEventField[]>(url, inputValuesQuery, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationEventField,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationEventField,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -347,12 +349,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get a specific event type.
-     * 
+     *
      * @param {string} eventType - The ID of the event type.
      */
     public async getEventType(
         eventType: string
-        ): Promise<NotificationInterfaces.NotificationEventType> {
+    ): Promise<NotificationInterfaces.NotificationEventType> {
 
         return new Promise<NotificationInterfaces.NotificationEventType>(async (resolve, reject) => {
             let routeValues: any = {
@@ -367,18 +369,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventType>;
                 res = await this.rest.get<NotificationInterfaces.NotificationEventType>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationEventType,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationEventType,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -388,12 +390,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * List available event types for this service. Optionally filter by only event types for the specified publisher.
-     * 
+     *
      * @param {string} publisherId - Limit to event types for this publisher
      */
     public async listEventTypes(
         publisherId?: string
-        ): Promise<NotificationInterfaces.NotificationEventType[]> {
+    ): Promise<NotificationInterfaces.NotificationEventType[]> {
 
         return new Promise<NotificationInterfaces.NotificationEventType[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -402,7 +404,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             let queryValues: any = {
                 publisherId: publisherId,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -412,18 +414,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventType[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationEventType[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationEventType,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationEventType,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -436,7 +438,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
      */
     public async getNotificationReasons(
         notificationId: number
-        ): Promise<NotificationInterfaces.NotificationReason> {
+    ): Promise<NotificationInterfaces.NotificationReason> {
 
         return new Promise<NotificationInterfaces.NotificationReason>(async (resolve, reject) => {
             let routeValues: any = {
@@ -451,18 +453,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationReason>;
                 res = await this.rest.get<NotificationInterfaces.NotificationReason>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationReason,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationReason,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -475,7 +477,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
      */
     public async listNotificationReasons(
         notificationIds?: number
-        ): Promise<NotificationInterfaces.NotificationReason[]> {
+    ): Promise<NotificationInterfaces.NotificationReason[]> {
 
         return new Promise<NotificationInterfaces.NotificationReason[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -484,7 +486,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             let queryValues: any = {
                 notificationIds: notificationIds,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -494,18 +496,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationReason[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationReason[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationReason,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationReason,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -516,7 +518,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
     /**
      */
     public async getSettings(
-        ): Promise<NotificationInterfaces.NotificationAdminSettings> {
+    ): Promise<NotificationInterfaces.NotificationAdminSettings> {
 
         return new Promise<NotificationInterfaces.NotificationAdminSettings>(async (resolve, reject) => {
             let routeValues: any = {
@@ -530,18 +532,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
                 res = await this.rest.get<NotificationInterfaces.NotificationAdminSettings>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationAdminSettings,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationAdminSettings,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -554,7 +556,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
      */
     public async updateSettings(
         updateParameters: NotificationInterfaces.NotificationAdminSettingsUpdateParameters
-        ): Promise<NotificationInterfaces.NotificationAdminSettings> {
+    ): Promise<NotificationInterfaces.NotificationAdminSettings> {
 
         return new Promise<NotificationInterfaces.NotificationAdminSettings>(async (resolve, reject) => {
             let routeValues: any = {
@@ -568,18 +570,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
                 res = await this.rest.update<NotificationInterfaces.NotificationAdminSettings>(url, updateParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationAdminSettings,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationAdminSettings,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -589,12 +591,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get delivery preferences of a notifications subscriber.
-     * 
+     *
      * @param {string} subscriberId - ID of the user or group.
      */
     public async getSubscriber(
         subscriberId: string
-        ): Promise<NotificationInterfaces.NotificationSubscriber> {
+    ): Promise<NotificationInterfaces.NotificationSubscriber> {
 
         return new Promise<NotificationInterfaces.NotificationSubscriber>(async (resolve, reject) => {
             let routeValues: any = {
@@ -609,18 +611,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriber>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscriber>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscriber,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationSubscriber,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -630,14 +632,14 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Update delivery preferences of a notifications subscriber.
-     * 
+     *
      * @param {NotificationInterfaces.NotificationSubscriberUpdateParameters} updateParameters
      * @param {string} subscriberId - ID of the user or group.
      */
     public async updateSubscriber(
         updateParameters: NotificationInterfaces.NotificationSubscriberUpdateParameters,
         subscriberId: string
-        ): Promise<NotificationInterfaces.NotificationSubscriber> {
+    ): Promise<NotificationInterfaces.NotificationSubscriber> {
 
         return new Promise<NotificationInterfaces.NotificationSubscriber>(async (resolve, reject) => {
             let routeValues: any = {
@@ -652,18 +654,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriber>;
                 res = await this.rest.update<NotificationInterfaces.NotificationSubscriber>(url, updateParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscriber,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationSubscriber,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -673,12 +675,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Query for subscriptions. A subscription is returned if it matches one or more of the specified conditions.
-     * 
+     *
      * @param {NotificationInterfaces.SubscriptionQuery} subscriptionQuery
      */
     public async querySubscriptions(
         subscriptionQuery: NotificationInterfaces.SubscriptionQuery
-        ): Promise<NotificationInterfaces.NotificationSubscription[]> {
+    ): Promise<NotificationInterfaces.NotificationSubscription[]> {
 
         return new Promise<NotificationInterfaces.NotificationSubscription[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -692,18 +694,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription[]>;
                 res = await this.rest.create<NotificationInterfaces.NotificationSubscription[]>(url, subscriptionQuery, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscription,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationSubscription,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -713,12 +715,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Create a new subscription.
-     * 
+     *
      * @param {NotificationInterfaces.NotificationSubscriptionCreateParameters} createParameters
      */
     public async createSubscription(
         createParameters: NotificationInterfaces.NotificationSubscriptionCreateParameters
-        ): Promise<NotificationInterfaces.NotificationSubscription> {
+    ): Promise<NotificationInterfaces.NotificationSubscription> {
 
         return new Promise<NotificationInterfaces.NotificationSubscription>(async (resolve, reject) => {
             let routeValues: any = {
@@ -732,18 +734,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.create<NotificationInterfaces.NotificationSubscription>(url, createParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscription,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationSubscription,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -753,12 +755,12 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Delete a subscription.
-     * 
+     *
      * @param {string} subscriptionId
      */
     public async deleteSubscription(
         subscriptionId: string
-        ): Promise<void> {
+    ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -773,18 +775,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -794,14 +796,14 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get a notification subscription by its ID.
-     * 
+     *
      * @param {string} subscriptionId
      * @param {NotificationInterfaces.SubscriptionQueryFlags} queryFlags
      */
     public async getSubscription(
         subscriptionId: string,
         queryFlags?: NotificationInterfaces.SubscriptionQueryFlags
-        ): Promise<NotificationInterfaces.NotificationSubscription> {
+    ): Promise<NotificationInterfaces.NotificationSubscription> {
 
         return new Promise<NotificationInterfaces.NotificationSubscription>(async (resolve, reject) => {
             let routeValues: any = {
@@ -811,7 +813,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
             let queryValues: any = {
                 queryFlags: queryFlags,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -821,18 +823,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscription>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscription,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationSubscription,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -842,7 +844,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get a list of notification subscriptions, either by subscription IDs or by all subscriptions for a given user or group.
-     * 
+     *
      * @param {string} targetId - User or Group ID
      * @param {string[]} ids - List of subscription IDs
      * @param {NotificationInterfaces.SubscriptionQueryFlags} queryFlags
@@ -851,7 +853,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
         targetId?: string,
         ids?: string[],
         queryFlags?: NotificationInterfaces.SubscriptionQueryFlags
-        ): Promise<NotificationInterfaces.NotificationSubscription[]> {
+    ): Promise<NotificationInterfaces.NotificationSubscription[]> {
 
         return new Promise<NotificationInterfaces.NotificationSubscription[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -862,7 +864,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 ids: ids && ids.join(","),
                 queryFlags: queryFlags,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -872,18 +874,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscription[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscription,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationSubscription,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -893,14 +895,14 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Update an existing subscription. Depending on the type of subscription and permissions, the caller can update the description, filter settings, channel (delivery) settings and more.
-     * 
+     *
      * @param {NotificationInterfaces.NotificationSubscriptionUpdateParameters} updateParameters
      * @param {string} subscriptionId
      */
     public async updateSubscription(
         updateParameters: NotificationInterfaces.NotificationSubscriptionUpdateParameters,
         subscriptionId: string
-        ): Promise<NotificationInterfaces.NotificationSubscription> {
+    ): Promise<NotificationInterfaces.NotificationSubscription> {
 
         return new Promise<NotificationInterfaces.NotificationSubscription>(async (resolve, reject) => {
             let routeValues: any = {
@@ -915,18 +917,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.update<NotificationInterfaces.NotificationSubscription>(url, updateParameters, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscription,
-                                              false);
+                    NotificationInterfaces.TypeInfo.NotificationSubscription,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -936,10 +938,10 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Get available subscription templates.
-     * 
+     *
      */
     public async getSubscriptionTemplates(
-        ): Promise<NotificationInterfaces.NotificationSubscriptionTemplate[]> {
+    ): Promise<NotificationInterfaces.NotificationSubscriptionTemplate[]> {
 
         return new Promise<NotificationInterfaces.NotificationSubscriptionTemplate[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -953,18 +955,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriptionTemplate[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscriptionTemplate[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              NotificationInterfaces.TypeInfo.NotificationSubscriptionTemplate,
-                                              true);
+                    NotificationInterfaces.TypeInfo.NotificationSubscriptionTemplate,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -974,7 +976,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
 
     /**
      * Update the specified user's settings for the specified subscription. This API is typically used to opt in or out of a shared subscription. User settings can only be applied to shared subscriptions, like team subscriptions or default subscriptions.
-     * 
+     *
      * @param {NotificationInterfaces.SubscriptionUserSettings} userSettings
      * @param {string} subscriptionId
      * @param {string} userId - ID of the user
@@ -983,7 +985,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
         userSettings: NotificationInterfaces.SubscriptionUserSettings,
         subscriptionId: string,
         userId: string
-        ): Promise<NotificationInterfaces.SubscriptionUserSettings> {
+    ): Promise<NotificationInterfaces.SubscriptionUserSettings> {
 
         return new Promise<NotificationInterfaces.SubscriptionUserSettings>(async (resolve, reject) => {
             let routeValues: any = {
@@ -999,18 +1001,18 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionUserSettings>;
                 res = await this.rest.replace<NotificationInterfaces.SubscriptionUserSettings>(url, userSettings, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);

--- a/api/ProfileApi.ts
+++ b/api/ProfileApi.ts
@@ -2,7 +2,7 @@
 * ---------------------------------------------------------
 * Copyright(C) Microsoft Corporation. All rights reserved.
 * ---------------------------------------------------------
-* 
+*
 * ---------------------------------------------------------
 * Generated file, DO NOT EDIT
 * ---------------------------------------------------------
@@ -43,6 +43,8 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-Profile-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "";
 
     /**
     * @param {string} id
@@ -459,7 +461,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
 
     /**
     * Lookup up country/region based on provided IPv4, null if using the remote IPv4 address.
-    * 
+    *
     * @param {string} ipaddress - IPv4 address to be used for reverse lookup, null if using RemoteIPAddress in request context
     */
     public async getGeoRegion(
@@ -503,7 +505,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
 
     /**
     * Create profile
-    * 
+    *
     * @param {ProfileInterfaces.CreateProfileContext} createProfileContext - Context for profile creation
     * @param {boolean} autoCreate - Create profile automatically
     */
@@ -606,7 +608,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
 
     /**
     * Update profile
-    * 
+    *
     * @param {ProfileInterfaces.Profile} profile - Update profile
     * @param {string} id - Profile ID
     */

--- a/api/SecurityRolesApi.ts
+++ b/api/SecurityRolesApi.ts
@@ -2,7 +2,7 @@
  * ---------------------------------------------------------
  * Copyright(C) Microsoft Corporation. All rights reserved.
  * ---------------------------------------------------------
- * 
+ *
  * ---------------------------------------------------------
  * Generated file, DO NOT EDIT
  * ---------------------------------------------------------
@@ -31,6 +31,8 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
         super(baseUrl, handlers, 'node-SecurityRoles-api', options);
     }
+
+    public static readonly RESOURCE_AREA_ID = "";
 
     /**
      * @param {string} scopeId

--- a/api/TaskApi.ts
+++ b/api/TaskApi.ts
@@ -49,6 +49,8 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         super(baseUrl, handlers, 'node-Task-api', options);
     }
 
+    public static readonly RESOURCE_AREA_ID = "";
+
     /**
      * @param {string} scopeIdentifier - The project GUID to scope the request
      * @param {string} hubName - The name of the server hub: "build" for the Build server or "rm" for the Release Management server
@@ -60,7 +62,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         type: string
-        ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
+    ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -78,18 +80,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -117,7 +119,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-        ): Promise<TaskAgentInterfaces.TaskAttachment> {
+    ): Promise<TaskAgentInterfaces.TaskAttachment> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment>(async (resolve, reject) => {
             let routeValues: any = {
@@ -141,17 +143,17 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                
+
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                                                                                verData.apiVersion);
+                    verData.apiVersion);
                 options.additionalHeaders = customHeaders;
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskAttachment>("PUT", url, contentStream, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                    false);
 
                 resolve(ret);
             }
@@ -182,7 +184,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         name: string,
         artifactHash: string,
         length: number
-        ): Promise<TaskAgentInterfaces.TaskAttachment> {
+    ): Promise<TaskAgentInterfaces.TaskAttachment> {
         if (artifactHash == null) {
             throw new TypeError('artifactHash can not be null or undefined');
         }
@@ -205,7 +207,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 artifactHash: artifactHash,
                 length: length,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -215,18 +217,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAttachment>(url, null, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -251,7 +253,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-        ): Promise<TaskAgentInterfaces.TaskAttachment> {
+    ): Promise<TaskAgentInterfaces.TaskAttachment> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment>(async (resolve, reject) => {
             let routeValues: any = {
@@ -272,18 +274,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -308,7 +310,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         recordId: string,
         type: string,
         name: string
-        ): Promise<NodeJS.ReadableStream> {
+    ): Promise<NodeJS.ReadableStream> {
 
         return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
             let routeValues: any = {
@@ -329,7 +331,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                
+
                 let apiVersion: string = verData.apiVersion!;
                 let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
                 resolve((await this.http.get(url, { "Accept": accept })).message);
@@ -355,7 +357,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         timelineId: string,
         recordId: string,
         type: string
-        ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
+    ): Promise<TaskAgentInterfaces.TaskAttachment[]> {
 
         return new Promise<TaskAgentInterfaces.TaskAttachment[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -375,18 +377,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAttachment,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TaskAttachment,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -409,7 +411,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         planId: string,
         timelineId: string,
         recordId: string
-        ): Promise<void> {
+    ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -428,18 +430,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, lines, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -468,7 +470,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         endLine?: number,
         takeCount?: number,
         continuationToken?: string
-        ): Promise<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper> {
+    ): Promise<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper> {
         if (stepId == null) {
             throw new TypeError('stepId can not be null or undefined');
         }
@@ -488,7 +490,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 takeCount: takeCount,
                 continuationToken: continuationToken,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -498,18 +500,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper>;
                 res = await this.rest.get<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -526,7 +528,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         orchestrationId: string
-        ): Promise<TaskAgentInterfaces.TaskAgentJob> {
+    ): Promise<TaskAgentInterfaces.TaskAgentJob> {
 
         return new Promise<TaskAgentInterfaces.TaskAgentJob>(async (resolve, reject) => {
             let routeValues: any = {
@@ -543,18 +545,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJob>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJob>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskAgentJob,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskAgentJob,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -576,7 +578,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         logId: number
-        ): Promise<TaskAgentInterfaces.TaskLog> {
+    ): Promise<TaskAgentInterfaces.TaskLog> {
 
         return new Promise<TaskAgentInterfaces.TaskLog>(async (resolve, reject) => {
             let routeValues: any = {
@@ -597,17 +599,17 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                
+
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json',
-                                                                                verData.apiVersion);
+                    verData.apiVersion);
                 options.additionalHeaders = customHeaders;
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskLog>("POST", url, contentStream, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskLog,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskLog,
+                    false);
 
                 resolve(ret);
             }
@@ -632,7 +634,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         logId: number,
         serializedBlobId: string,
         lineCount: number
-        ): Promise<TaskAgentInterfaces.TaskLog> {
+    ): Promise<TaskAgentInterfaces.TaskLog> {
         if (serializedBlobId == null) {
             throw new TypeError('serializedBlobId can not be null or undefined');
         }
@@ -652,7 +654,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 serializedBlobId: serializedBlobId,
                 lineCount: lineCount,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -662,18 +664,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskLog>(url, null, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskLog,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskLog,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -692,7 +694,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-        ): Promise<TaskAgentInterfaces.TaskLog> {
+    ): Promise<TaskAgentInterfaces.TaskLog> {
 
         return new Promise<TaskAgentInterfaces.TaskLog>(async (resolve, reject) => {
             let routeValues: any = {
@@ -709,18 +711,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskLog>(url, log, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskLog,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskLog,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -743,7 +745,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         logId: number,
         startLine?: number,
         endLine?: number
-        ): Promise<string[]> {
+    ): Promise<string[]> {
 
         return new Promise<string[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -757,7 +759,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 startLine: startLine,
                 endLine: endLine,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -767,18 +769,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              true);
+                    null,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -795,7 +797,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-        ): Promise<TaskAgentInterfaces.TaskLog[]> {
+    ): Promise<TaskAgentInterfaces.TaskLog[]> {
 
         return new Promise<TaskAgentInterfaces.TaskLog[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -812,18 +814,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskLog[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskLog,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TaskLog,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -838,7 +840,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
     public async getPlanGroupsQueueMetrics(
         scopeIdentifier: string,
         hubName: string
-        ): Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]> {
+    ): Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -854,18 +856,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlanGroupsQueueMetrics,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlanGroupsQueueMetrics,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -884,7 +886,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         statusFilter?: TaskAgentInterfaces.PlanGroupStatus,
         count?: number
-        ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]> {
+    ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -896,7 +898,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 statusFilter: statusFilter,
                 count: count,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -906,18 +908,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -934,7 +936,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planGroup: string
-        ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup> {
+    ): Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>(async (resolve, reject) => {
             let routeValues: any = {
@@ -951,18 +953,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -979,7 +981,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-        ): Promise<TaskAgentInterfaces.TaskOrchestrationPlan> {
+    ): Promise<TaskAgentInterfaces.TaskOrchestrationPlan> {
 
         return new Promise<TaskAgentInterfaces.TaskOrchestrationPlan>(async (resolve, reject) => {
             let routeValues: any = {
@@ -996,18 +998,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlan>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlan>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlan,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlan,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1028,7 +1030,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         planId: string,
         timelineId: string,
         changeId?: number
-        ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
+    ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
 
         return new Promise<TaskAgentInterfaces.TimelineRecord[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1041,7 +1043,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
             let queryValues: any = {
                 changeId: changeId,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -1051,18 +1053,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TimelineRecord[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TimelineRecord,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TimelineRecord,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1083,7 +1085,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         timelineId: string
-        ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
+    ): Promise<TaskAgentInterfaces.TimelineRecord[]> {
 
         return new Promise<TaskAgentInterfaces.TimelineRecord[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1101,18 +1103,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.update<TaskAgentInterfaces.TimelineRecord[]>(url, records, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.TimelineRecord,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.TimelineRecord,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1131,7 +1133,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-        ): Promise<TaskAgentInterfaces.Timeline> {
+    ): Promise<TaskAgentInterfaces.Timeline> {
 
         return new Promise<TaskAgentInterfaces.Timeline>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1148,18 +1150,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.create<TaskAgentInterfaces.Timeline>(url, timeline, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.Timeline,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.Timeline,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1178,7 +1180,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         hubName: string,
         planId: string,
         timelineId: string
-        ): Promise<void> {
+    ): Promise<void> {
 
         return new Promise<void>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1196,18 +1198,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
-                                              false);
+                    null,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1230,7 +1232,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         timelineId: string,
         changeId?: number,
         includeRecords?: boolean
-        ): Promise<TaskAgentInterfaces.Timeline> {
+    ): Promise<TaskAgentInterfaces.Timeline> {
 
         return new Promise<TaskAgentInterfaces.Timeline>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1244,7 +1246,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 changeId: changeId,
                 includeRecords: includeRecords,
             };
-            
+
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
                     "6.1-preview.1",
@@ -1254,18 +1256,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     queryValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.Timeline,
-                                              false);
+                    TaskAgentInterfaces.TypeInfo.Timeline,
+                    false);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);
@@ -1282,7 +1284,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
         scopeIdentifier: string,
         hubName: string,
         planId: string
-        ): Promise<TaskAgentInterfaces.Timeline[]> {
+    ): Promise<TaskAgentInterfaces.Timeline[]> {
 
         return new Promise<TaskAgentInterfaces.Timeline[]>(async (resolve, reject) => {
             let routeValues: any = {
@@ -1299,18 +1301,18 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                     routeValues);
 
                 let url: string = verData.requestUrl!;
-                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
-                                                                                verData.apiVersion);
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
 
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline[]>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline[]>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              TaskAgentInterfaces.TypeInfo.Timeline,
-                                              true);
+                    TaskAgentInterfaces.TypeInfo.Timeline,
+                    true);
 
                 resolve(ret);
-                
+
             }
             catch (err) {
                 reject(err);

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -198,36 +198,31 @@ export class WebApi {
     }
 
     public async getCoreApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<corem.ICoreApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "79134c72-4a58-4b42-976c-04e7115f32bf");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, corem.CoreApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new corem.CoreApi(serverUrl, handlers, this.options);
     }
 
     public async getDashboardApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<dashboardm.IDashboardApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "31c84e0a-3ece-48fd-a29d-100849af99ba");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, dashboardm.DashboardApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new dashboardm.DashboardApi(serverUrl, handlers, this.options);
     }
 
     public async getExtensionManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<extmgmtm.IExtensionManagementApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "6c2b0933-3600-42ae-bf8b-93d4f7e83594");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, extmgmtm.ExtensionManagementApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new extmgmtm.ExtensionManagementApi(serverUrl, handlers, this.options);
     }
 
     public async getFeatureManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<featuremgmtm.IFeatureManagementApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, featuremgmtm.FeatureManagementApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new featuremgmtm.FeatureManagementApi(serverUrl, handlers, this.options);
     }
 
     public async getFileContainerApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<filecontainerm.IFileContainerApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, filecontainerm.FileContainerApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new filecontainerm.FileContainerApi(serverUrl, handlers, this.options);
     }
@@ -255,85 +250,73 @@ export class WebApi {
     }
 
     public async getNotificationApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<notificationm.INotificationApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, notificationm.NotificationApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new notificationm.NotificationApi(serverUrl, handlers, this.options);
     }
 
     public async getPolicyApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<policym.IPolicyApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "fb13a388-40dd-4a04-b530-013a739c72ef");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, policym.PolicyApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new policym.PolicyApi(serverUrl, handlers, this.options);
     }
 
     public async getProfileApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<profilem.IProfileApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8ccfef3d-2b87-4e99-8ccb-66e343d2daa8");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, profilem.ProfileApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new profilem.ProfileApi(serverUrl, handlers, this.options);
     }
 
     public async getProjectAnalysisApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<projectm.IProjectAnalysisApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "7658fa33-b1bf-4580-990f-fac5896773d3");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, projectm.ProjectAnalysisApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new projectm.ProjectAnalysisApi(serverUrl, handlers, this.options);
     }
 
     public async getSecurityRolesApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<securityrolesm.ISecurityRolesApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, securityrolesm.SecurityRolesApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new securityrolesm.SecurityRolesApi(serverUrl, handlers, this.options);
     }
 
     public async getReleaseApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<releasem.IReleaseApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "efc2f575-36ef-48e9-b672-0c6fb4a48ac5");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, releasem.ReleaseApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new releasem.ReleaseApi(serverUrl, handlers, this.options);
     }
 
     public async getTaskApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskm.ITaskApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, taskm.TaskApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new taskm.TaskApi(serverUrl, handlers, this.options);
     }
 
     public async getTaskAgentApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskagentm.ITaskAgentApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, taskagentm.TaskAgentApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new taskagentm.TaskAgentApi(serverUrl, handlers, this.options);
     }
 
     public async getTestApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testm.ITestApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, testm.TestApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new testm.TestApi(serverUrl, handlers, this.options);
     }
 
     public async getTfvcApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<tfvcm.ITfvcApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8aa40520-446d-40e6-89f6-9c9f9ce44c48");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, tfvcm.TfvcApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new tfvcm.TfvcApi(serverUrl, handlers, this.options);
     }
 
     public async getWikiApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<wikim.IWikiApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, wikim.WikiApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new wikim.WikiApi(serverUrl, handlers, this.options);
     }
 
     public async getWorkApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workm.IWorkApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workm.WorkApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new workm.WorkApi(serverUrl, handlers, this.options);
     }
@@ -345,15 +328,13 @@ export class WebApi {
     }
 
     public async getWorkItemTrackingProcessApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessm.IWorkItemTrackingProcessApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workitemtrackingprocessm.WorkItemTrackingProcessApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new workitemtrackingprocessm.WorkItemTrackingProcessApi(serverUrl, handlers, this.options);
     }
 
     public async getWorkItemTrackingProcessDefinitionApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessdefinitionm.IWorkItemTrackingProcessDefinitionsApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
         return new workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi(serverUrl, handlers, this.options);
     }


### PR DESCRIPTION
Partially fixes #411 (still needed to pass the URL like `https://{your_org_name}.vssps.visualstudio.com`)

Added the correct `RESOURCE_AREA_ID` for:
- BuildApi
- CoreApi
- DashboardApi
- FeatureManagementApi
- FileContainerApi
- GalleryApi
- NotificationApi
- PolicyApi
- ProfileApi
- ProjectAnalysisApi
- SecurityRolesApi
- ReleaseApi
- TaskApi
- TaskAgentApi
- TestApi
- TfvcApi
- WikiApi
- WorkApi
- WorkItemTrackingApi
- WorkItemTrackingProcessApi
- WorkItemTrackingProcessDefinitionsApi