### PR TITLE
Fix samples

### DIFF
--- a/samples/task.ts
+++ b/samples/task.ts
@@ -42,12 +42,14 @@ export async function run() {
 
         // upload a secure file
         let s = new stream.Readable();
+        let testString: string = 'test file contents';
         s._read = function noop() {};
-        s.push("test file contents");
+        s.push(testString);
         s.push(null);
         let name = `vstsnodeapitest${new Date().getTime()}`;
         console.log("uploading file");
-        let secureFile = await vstsTask.uploadSecureFile(null, s, project, name);
+        const headers = { 'Content-Length': testString.length };
+        let secureFile = await vstsTask.uploadSecureFile(headers, s, project, name);
         console.log(`uploaded secure file ${secureFile.name}`);
 
         // delete it

--- a/samples/workItemTracking.ts
+++ b/samples/workItemTracking.ts
@@ -67,6 +67,6 @@ export async function run() {
     if (workItemTypes.length > 0) {
         const type: WorkItemTrackingInterfaces.WorkItemType = workItemTypes[0];
         common.heading('Info for type' + type.name);
-        console.log(type.name, 'has', (await witApi.getWorkItemTypeColors([project.id])).length, 'colors');
+        console.log(type.name, 'has', (await witApi.getWorkItemTypeColors([project.name])).length, 'colors');
     }
 }


### PR DESCRIPTION
Fix task and workItemTracking samples which are failing now.
`uploadSecureFile `requires Content-Length to be specified in the headers.
`getWorkItemTypeColors` requires projectNames instead of ids 
