### PR TITLE
Remove unnecessary async for getLocationsApi

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -245,11 +245,11 @@ export class WebApi {
     }
 
     // TODO: Don't call resource area here? Will cause infinite loop?
-    public async getLocationsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<locationsm.ILocationsApi> {
+    public getLocationsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): locationsm.ILocationsApi {
         let optionsClone: VsoBaseInterfaces.IRequestOptions = Object.assign({}, this.options);
         optionsClone.allowRetries = true;
         optionsClone.maxRetries = 5;
-        serverUrl = await serverUrl || this.serverUrl;
+        serverUrl = serverUrl || this.serverUrl;
         handlers = handlers || [this.authHandler];
         return new locationsm.LocationsApi(serverUrl, handlers, optionsClone);
     }
@@ -406,7 +406,7 @@ export class WebApi {
 
     private async _getResourceAreas(): Promise<lim.ResourceAreaInfo[]> {
         if (!this._resourceAreas) {
-            const locationClient: locationsm.ILocationsApi = await this.getLocationsApi();
+            const locationClient: locationsm.ILocationsApi = this.getLocationsApi();
             this._resourceAreas = await locationClient.getResourceAreas();
         }
 

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -110,7 +110,7 @@ export async function run() {
 
         /********** Locations **********/
         printSectionStart("Locations");
-        const locationsApi = await vstsCollectionLevel.getLocationsApi();
+        const locationsApi = vstsCollectionLevel.getLocationsApi();
         const resourceAreas: ResourceAreaInfo[] = await locationsApi.getResourceAreas();
 
         if (resourceAreas) {


### PR DESCRIPTION
I have noticed while digging into the source code of the library this function that is unnecessarily async. I have modified the code to remote that.


There is also a bunch of other functions that are async and probably should not. If we can get in touch and chat, we might be able to plan these changes together and give a better developer experience.
