### PR TITLE
Add array check to queryParamsToStringHelper

### DIFF
--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -190,7 +190,7 @@ export class VsoClient {
         }
         let queryString: string = '';
 
-        if (typeof(queryParams) !== 'string') {
+        if (typeof(queryParams) !== 'string' && !Array.isArray(queryParams)) {
             for (let property in queryParams) {
                 if (queryParams.hasOwnProperty(property)) {
                     const prop = queryParams[property];


### PR DESCRIPTION
Added an array check to `queryParamsToStringHelper` so it does not loop all of the element in the array and create separate query parameter for each.
Instead the `toString` will be called on the array creating a comma separated string for the query parameter value