### PR TITLE
Update the Ubuntu image from `18.04` to `20.04`

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: ubuntu-20.04
 
 strategy:
   matrix:


### PR DESCRIPTION
We have to update the Ubuntu image used in the CI since `18.04`  is removed from the pools