### PR TITLE
Adding testplan api in node sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ These clients are available:
 * TaskAgent
 * Task
 * Test
+* TestPlan
 * TestResults
 * Tfvc
 * Wiki

--- a/api/TestPlanApi.ts
+++ b/api/TestPlanApi.ts
@@ -1,0 +1,2169 @@
+/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+// Licensed under the MIT license.  See LICENSE file in the project root for full license information.
+
+import * as restm from 'typed-rest-client/RestClient';
+import vsom = require('./VsoClient');
+import basem = require('./ClientApiBases');
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+import TestPlanInterfaces = require("./interfaces/TestPlanInterfaces");
+import VSSInterfaces = require("./interfaces/common/VSSInterfaces");
+
+export interface ITestPlanApi extends basem.ClientApiBase {
+    createTestConfiguration(testConfigurationCreateUpdateParameters: TestPlanInterfaces.TestConfigurationCreateUpdateParameters, project: string): Promise<TestPlanInterfaces.TestConfiguration>;
+    deleteTestConfguration(project: string, testConfiguartionId: number): Promise<void>;
+    getTestConfigurationById(project: string, testConfigurationId: number): Promise<TestPlanInterfaces.TestConfiguration>;
+    getTestConfigurations(project: string, continuationToken?: string): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>;
+    updateTestConfiguration(testConfigurationCreateUpdateParameters: TestPlanInterfaces.TestConfigurationCreateUpdateParameters, project: string, testConfiguartionId: number): Promise<TestPlanInterfaces.TestConfiguration>;
+    getTestEntityCountByPlanId(project: string, planId: number, states?: string, outcome?: TestPlanInterfaces.UserFriendlyTestOutcome, configurations?: string, testers?: string, assignedTo?: string, entity?: TestPlanInterfaces.TestEntityTypes): Promise<TestPlanInterfaces.TestEntityCount[]>;
+    createTestPlan(testPlanCreateParams: TestPlanInterfaces.TestPlanCreateParams, project: string): Promise<TestPlanInterfaces.TestPlan>;
+    deleteTestPlan(project: string, planId: number): Promise<void>;
+    getTestPlanById(project: string, planId: number): Promise<TestPlanInterfaces.TestPlan>;
+    getTestPlans(project: string, owner?: string, continuationToken?: string, includePlanDetails?: boolean, filterActivePlans?: boolean): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>;
+    updateTestPlan(testPlanUpdateParams: TestPlanInterfaces.TestPlanUpdateParams, project: string, planId: number): Promise<TestPlanInterfaces.TestPlan>;
+    getSuiteEntries(project: string, suiteId: number, suiteEntryType?: TestPlanInterfaces.SuiteEntryTypes): Promise<TestPlanInterfaces.SuiteEntry[]>;
+    reorderSuiteEntries(suiteEntries: TestPlanInterfaces.SuiteEntryUpdateParams[], project: string, suiteId: number): Promise<TestPlanInterfaces.SuiteEntry[]>;
+    createBulkTestSuites(testSuiteCreateParams: TestPlanInterfaces.TestSuiteCreateParams[], project: string, planId: number, parentSuiteId: number): Promise<TestPlanInterfaces.TestSuite[]>;
+    createTestSuite(testSuiteCreateParams: TestPlanInterfaces.TestSuiteCreateParams, project: string, planId: number): Promise<TestPlanInterfaces.TestSuite>;
+    deleteTestSuite(project: string, planId: number, suiteId: number): Promise<void>;
+    getTestSuiteById(project: string, planId: number, suiteId: number, expand?: TestPlanInterfaces.SuiteExpand): Promise<TestPlanInterfaces.TestSuite>;
+    getTestSuitesForPlan(project: string, planId: number, expand?: TestPlanInterfaces.SuiteExpand, continuationToken?: string, asTreeView?: boolean): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>;
+    updateTestSuite(testSuiteUpdateParams: TestPlanInterfaces.TestSuiteUpdateParams, project: string, planId: number, suiteId: number): Promise<TestPlanInterfaces.TestSuite>;
+    getSuitesByTestCaseId(testCaseId: number): Promise<TestPlanInterfaces.TestSuite[]>;
+    addTestCasesToSuite(suiteTestCaseCreateUpdateParameters: TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[], project: string, planId: number, suiteId: number): Promise<TestPlanInterfaces.TestCase[]>;
+    getTestCase(project: string, planId: number, suiteId: number, testCaseId: string, witFields?: string, returnIdentityRef?: boolean): Promise<TestPlanInterfaces.TestCase[]>;
+    getTestCaseList(project: string, planId: number, suiteId: number, testIds?: string, configurationIds?: string, witFields?: string, continuationToken?: string, returnIdentityRef?: boolean, expand?: boolean, excludeFlags?: TestPlanInterfaces.ExcludeFlags, isRecursive?: boolean): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>;
+    removeTestCasesFromSuite(project: string, planId: number, suiteId: number, testCaseIds: string): Promise<void>;
+    removeTestCasesListFromSuite(project: string, planId: number, suiteId: number, testIds: string): Promise<void>;
+    updateSuiteTestCases(suiteTestCaseCreateUpdateParameters: TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[], project: string, planId: number, suiteId: number): Promise<TestPlanInterfaces.TestCase[]>;
+    cloneTestCase(cloneRequestBody: TestPlanInterfaces.CloneTestCaseParams, project: string): Promise<TestPlanInterfaces.CloneTestCaseOperationInformation>;
+    getTestCaseCloneInformation(project: string, cloneOperationId: number): Promise<TestPlanInterfaces.CloneTestCaseOperationInformation>;
+    exportTestCases(exportTestCaseRequestBody: TestPlanInterfaces.ExportTestCaseParams, project: string): Promise<NodeJS.ReadableStream>;
+    deleteTestCase(project: string, testCaseId: number): Promise<void>;
+    cloneTestPlan(cloneRequestBody: TestPlanInterfaces.CloneTestPlanParams, project: string, deepClone?: boolean): Promise<TestPlanInterfaces.CloneTestPlanOperationInformation>;
+    getCloneInformation(project: string, cloneOperationId: number): Promise<TestPlanInterfaces.CloneTestPlanOperationInformation>;
+    getPoints(project: string, planId: number, suiteId: number, pointId: string, returnIdentityRef?: boolean, includePointDetails?: boolean): Promise<TestPlanInterfaces.TestPoint[]>;
+    getPointsList(project: string, planId: number, suiteId: number, testPointIds?: string, testCaseId?: string, continuationToken?: string, returnIdentityRef?: boolean, includePointDetails?: boolean, isRecursive?: boolean): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>;
+    updateTestPoints(testPointUpdateParams: TestPlanInterfaces.TestPointUpdateParams[], project: string, planId: number, suiteId: number, includePointDetails?: boolean, returnIdentityRef?: boolean): Promise<TestPlanInterfaces.TestPoint[]>;
+    cloneTestSuite(cloneRequestBody: TestPlanInterfaces.CloneTestSuiteParams, project: string, deepClone?: boolean): Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
+    getSuiteCloneInformation(project: string, cloneOperationId: number): Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
+    createTestVariable(testVariableCreateUpdateParameters: TestPlanInterfaces.TestVariableCreateUpdateParameters, project: string): Promise<TestPlanInterfaces.TestVariable>;
+    deleteTestVariable(project: string, testVariableId: number): Promise<void>;
+    getTestVariableById(project: string, testVariableId: number): Promise<TestPlanInterfaces.TestVariable>;
+    getTestVariables(project: string, continuationToken?: string): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>;
+    updateTestVariable(testVariableCreateUpdateParameters: TestPlanInterfaces.TestVariableCreateUpdateParameters, project: string, testVariableId: number): Promise<TestPlanInterfaces.TestVariable>;
+}
+
+export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
+        super(baseUrl, handlers, 'node-TestPlan-api', options);
+    }
+
+    /**
+     * Create a test configuration.
+     * 
+     * @param {TestPlanInterfaces.TestConfigurationCreateUpdateParameters} testConfigurationCreateUpdateParameters - TestConfigurationCreateUpdateParameters
+     * @param {string} project - Project ID or project name
+     */
+    public async createTestConfiguration(
+        testConfigurationCreateUpdateParameters: TestPlanInterfaces.TestConfigurationCreateUpdateParameters,
+        project: string
+    ): Promise<TestPlanInterfaces.TestConfiguration> {
+
+        return new Promise<TestPlanInterfaces.TestConfiguration>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "8369318e-38fa-4e84-9043-4b2a75d2c256",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
+                res = await this.rest.create<TestPlanInterfaces.TestConfiguration>(url, testConfigurationCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestConfiguration,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete a test configuration by its ID.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} testConfiguartionId - ID of the test configuration to delete.
+     */
+    public async deleteTestConfguration(
+        project: string,
+        testConfiguartionId: number
+    ): Promise<void> {
+        if (testConfiguartionId == null) {
+            throw new TypeError('testConfiguartionId can not be null or undefined');
+        }
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                testConfiguartionId: testConfiguartionId,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "8369318e-38fa-4e84-9043-4b2a75d2c256",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a test configuration
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} testConfigurationId - ID of the test configuration to get.
+     */
+    public async getTestConfigurationById(
+        project: string,
+        testConfigurationId: number
+    ): Promise<TestPlanInterfaces.TestConfiguration> {
+
+        return new Promise<TestPlanInterfaces.TestConfiguration>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                testConfigurationId: testConfigurationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "8369318e-38fa-4e84-9043-4b2a75d2c256",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
+                res = await this.rest.get<TestPlanInterfaces.TestConfiguration>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestConfiguration,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of test configurations.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} continuationToken - If the list of configurations returned is not complete, a continuation token to query next batch of configurations is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test configurations.
+     */
+    public async getTestConfigurations(
+        project: string,
+        continuationToken?: string
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                continuationToken: continuationToken,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "8369318e-38fa-4e84-9043-4b2a75d2c256",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestConfiguration,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update a test configuration by its ID.
+     * 
+     * @param {TestPlanInterfaces.TestConfigurationCreateUpdateParameters} testConfigurationCreateUpdateParameters - TestConfigurationCreateUpdateParameters
+     * @param {string} project - Project ID or project name
+     * @param {number} testConfiguartionId - ID of the test configuration to update.
+     */
+    public async updateTestConfiguration(
+        testConfigurationCreateUpdateParameters: TestPlanInterfaces.TestConfigurationCreateUpdateParameters,
+        project: string,
+        testConfiguartionId: number
+    ): Promise<TestPlanInterfaces.TestConfiguration> {
+        if (testConfiguartionId == null) {
+            throw new TypeError('testConfiguartionId can not be null or undefined');
+        }
+
+        return new Promise<TestPlanInterfaces.TestConfiguration>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                testConfiguartionId: testConfiguartionId,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "8369318e-38fa-4e84-9043-4b2a75d2c256",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
+                res = await this.rest.update<TestPlanInterfaces.TestConfiguration>(url, testConfigurationCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestConfiguration,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} planId
+     * @param {string} states
+     * @param {TestPlanInterfaces.UserFriendlyTestOutcome} outcome
+     * @param {string} configurations
+     * @param {string} testers
+     * @param {string} assignedTo
+     * @param {TestPlanInterfaces.TestEntityTypes} entity
+     */
+    public async getTestEntityCountByPlanId(
+        project: string,
+        planId: number,
+        states?: string,
+        outcome?: TestPlanInterfaces.UserFriendlyTestOutcome,
+        configurations?: string,
+        testers?: string,
+        assignedTo?: string,
+        entity?: TestPlanInterfaces.TestEntityTypes
+    ): Promise<TestPlanInterfaces.TestEntityCount[]> {
+
+        return new Promise<TestPlanInterfaces.TestEntityCount[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            let queryValues: any = {
+                states: states,
+                outcome: outcome,
+                configurations: configurations,
+                testers: testers,
+                assignedTo: assignedTo,
+                entity: entity,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "300578da-7b40-4c1e-9542-7aed6029e504",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestEntityCount[]>;
+                res = await this.rest.get<TestPlanInterfaces.TestEntityCount[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create a test plan.
+     * 
+     * @param {TestPlanInterfaces.TestPlanCreateParams} testPlanCreateParams - A testPlanCreateParams object.TestPlanCreateParams
+     * @param {string} project - Project ID or project name
+     */
+    public async createTestPlan(
+        testPlanCreateParams: TestPlanInterfaces.TestPlanCreateParams,
+        project: string
+    ): Promise<TestPlanInterfaces.TestPlan> {
+
+        return new Promise<TestPlanInterfaces.TestPlan>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "0e292477-a0c2-47f3-a9b6-34f153d627f4",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
+                res = await this.rest.create<TestPlanInterfaces.TestPlan>(url, testPlanCreateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPlan,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete a test plan.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan to be deleted.
+     */
+    public async deleteTestPlan(
+        project: string,
+        planId: number
+    ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "0e292477-a0c2-47f3-a9b6-34f153d627f4",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a test plan by Id.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan to get.
+     */
+    public async getTestPlanById(
+        project: string,
+        planId: number
+    ): Promise<TestPlanInterfaces.TestPlan> {
+
+        return new Promise<TestPlanInterfaces.TestPlan>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "0e292477-a0c2-47f3-a9b6-34f153d627f4",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
+                res = await this.rest.get<TestPlanInterfaces.TestPlan>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPlan,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of test plans
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} owner - Filter for test plan by owner ID or name
+     * @param {string} continuationToken - If the list of plans returned is not complete, a continuation token to query next batch of plans is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test plans.
+     * @param {boolean} includePlanDetails - Get all properties of the test plan
+     * @param {boolean} filterActivePlans - Get just the active plans
+     */
+    public async getTestPlans(
+        project: string,
+        owner?: string,
+        continuationToken?: string,
+        includePlanDetails?: boolean,
+        filterActivePlans?: boolean
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                owner: owner,
+                continuationToken: continuationToken,
+                includePlanDetails: includePlanDetails,
+                filterActivePlans: filterActivePlans,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "0e292477-a0c2-47f3-a9b6-34f153d627f4",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPlan,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update a test plan.
+     * 
+     * @param {TestPlanInterfaces.TestPlanUpdateParams} testPlanUpdateParams - A testPlanUpdateParams object.TestPlanUpdateParams
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan to be updated.
+     */
+    public async updateTestPlan(
+        testPlanUpdateParams: TestPlanInterfaces.TestPlanUpdateParams,
+        project: string,
+        planId: number
+    ): Promise<TestPlanInterfaces.TestPlan> {
+
+        return new Promise<TestPlanInterfaces.TestPlan>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "0e292477-a0c2-47f3-a9b6-34f153d627f4",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
+                res = await this.rest.update<TestPlanInterfaces.TestPlan>(url, testPlanUpdateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPlan,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of test suite entries in the test suite.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} suiteId - Id of the parent suite.
+     * @param {TestPlanInterfaces.SuiteEntryTypes} suiteEntryType
+     */
+    public async getSuiteEntries(
+        project: string,
+        suiteId: number,
+        suiteEntryType?: TestPlanInterfaces.SuiteEntryTypes
+    ): Promise<TestPlanInterfaces.SuiteEntry[]> {
+
+        return new Promise<TestPlanInterfaces.SuiteEntry[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                suiteEntryType: suiteEntryType,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "d6733edf-72f1-4252-925b-c560dfe9b75a",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.SuiteEntry[]>;
+                res = await this.rest.get<TestPlanInterfaces.SuiteEntry[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.SuiteEntry,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Reorder test suite entries in the test suite.
+     * 
+     * @param {TestPlanInterfaces.SuiteEntryUpdateParams[]} suiteEntries - List of SuiteEntry to reorder.
+     * @param {string} project - Project ID or project name
+     * @param {number} suiteId - Id of the parent test suite.
+     */
+    public async reorderSuiteEntries(
+        suiteEntries: TestPlanInterfaces.SuiteEntryUpdateParams[],
+        project: string,
+        suiteId: number
+    ): Promise<TestPlanInterfaces.SuiteEntry[]> {
+
+        return new Promise<TestPlanInterfaces.SuiteEntry[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                suiteId: suiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "d6733edf-72f1-4252-925b-c560dfe9b75a",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.SuiteEntry[]>;
+                res = await this.rest.update<TestPlanInterfaces.SuiteEntry[]>(url, suiteEntries, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.SuiteEntry,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create bulk requirement based test suites.
+     * 
+     * @param {TestPlanInterfaces.TestSuiteCreateParams[]} testSuiteCreateParams - Parameters for suite creation
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan where requirement based suites need to be created.
+     * @param {number} parentSuiteId - ID of the parent suite under which requirement based suites will be created
+     */
+    public async createBulkTestSuites(
+        testSuiteCreateParams: TestPlanInterfaces.TestSuiteCreateParams[],
+        project: string,
+        planId: number,
+        parentSuiteId: number
+    ): Promise<TestPlanInterfaces.TestSuite[]> {
+
+        return new Promise<TestPlanInterfaces.TestSuite[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                parentSuiteId: parentSuiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1e58fbe6-1761-43ce-97f6-5492ec9d438e",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestSuite[]>;
+                res = await this.rest.create<TestPlanInterfaces.TestSuite[]>(url, testSuiteCreateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create test suite.
+     * 
+     * @param {TestPlanInterfaces.TestSuiteCreateParams} testSuiteCreateParams - Parameters for suite creation
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan that contains the suites.
+     */
+    public async createTestSuite(
+        testSuiteCreateParams: TestPlanInterfaces.TestSuiteCreateParams,
+        project: string,
+        planId: number
+    ): Promise<TestPlanInterfaces.TestSuite> {
+
+        return new Promise<TestPlanInterfaces.TestSuite>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1046d5d3-ab61-4ca7-a65a-36118a978256",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
+                res = await this.rest.create<TestPlanInterfaces.TestSuite>(url, testSuiteCreateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete test suite.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan that contains the suite.
+     * @param {number} suiteId - ID of the test suite to delete.
+     */
+    public async deleteTestSuite(
+        project: string,
+        planId: number,
+        suiteId: number
+    ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1046d5d3-ab61-4ca7-a65a-36118a978256",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get test suite by suite id.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the suite to get.
+     * @param {TestPlanInterfaces.SuiteExpand} expand - Include the children suites and testers details
+     */
+    public async getTestSuiteById(
+        project: string,
+        planId: number,
+        suiteId: number,
+        expand?: TestPlanInterfaces.SuiteExpand
+    ): Promise<TestPlanInterfaces.TestSuite> {
+
+        return new Promise<TestPlanInterfaces.TestSuite>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                expand: expand,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1046d5d3-ab61-4ca7-a65a-36118a978256",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
+                res = await this.rest.get<TestPlanInterfaces.TestSuite>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get test suites for plan.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which suites are requested.
+     * @param {TestPlanInterfaces.SuiteExpand} expand - Include the children suites and testers details.
+     * @param {string} continuationToken - If the list of suites returned is not complete, a continuation token to query next batch of suites is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test suites.
+     * @param {boolean} asTreeView - If the suites returned should be in a tree structure.
+     */
+    public async getTestSuitesForPlan(
+        project: string,
+        planId: number,
+        expand?: TestPlanInterfaces.SuiteExpand,
+        continuationToken?: string,
+        asTreeView?: boolean
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId
+            };
+
+            let queryValues: any = {
+                expand: expand,
+                continuationToken: continuationToken,
+                asTreeView: asTreeView,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1046d5d3-ab61-4ca7-a65a-36118a978256",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update test suite.
+     * 
+     * @param {TestPlanInterfaces.TestSuiteUpdateParams} testSuiteUpdateParams - Parameters for suite updation
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan that contains the suites.
+     * @param {number} suiteId - ID of the parent suite.
+     */
+    public async updateTestSuite(
+        testSuiteUpdateParams: TestPlanInterfaces.TestSuiteUpdateParams,
+        project: string,
+        planId: number,
+        suiteId: number
+    ): Promise<TestPlanInterfaces.TestSuite> {
+
+        return new Promise<TestPlanInterfaces.TestSuite>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "1046d5d3-ab61-4ca7-a65a-36118a978256",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
+                res = await this.rest.update<TestPlanInterfaces.TestSuite>(url, testSuiteUpdateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Find the list of all test suites in which a given test case is present. This is helpful if you need to find out which test suites are using a test case, when you need to make changes to a test case.
+     * 
+     * @param {number} testCaseId - ID of the test case for which suites need to be fetched.
+     */
+    public async getSuitesByTestCaseId(
+        testCaseId: number
+    ): Promise<TestPlanInterfaces.TestSuite[]> {
+        if (testCaseId == null) {
+            throw new TypeError('testCaseId can not be null or undefined');
+        }
+
+        return new Promise<TestPlanInterfaces.TestSuite[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            let queryValues: any = {
+                testCaseId: testCaseId,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "a4080e84-f17b-4fad-84f1-7960b6525bf2",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestSuite[]>;
+                res = await this.rest.get<TestPlanInterfaces.TestSuite[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestSuite,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Add test cases to a suite with specified configurations
+     * 
+     * @param {TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[]} suiteTestCaseCreateUpdateParameters - SuiteTestCaseCreateUpdateParameters object.
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan to which test cases are to be added.
+     * @param {number} suiteId - ID of the test suite to which test cases are to be added.
+     */
+    public async addTestCasesToSuite(
+        suiteTestCaseCreateUpdateParameters: TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[],
+        project: string,
+        planId: number,
+        suiteId: number
+    ): Promise<TestPlanInterfaces.TestCase[]> {
+
+        return new Promise<TestPlanInterfaces.TestCase[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
+                res = await this.rest.create<TestPlanInterfaces.TestCase[]>(url, suiteTestCaseCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestCase,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a particular Test Case from a Suite.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which test cases are requested.
+     * @param {number} suiteId - ID of the test suite for which test cases are requested.
+     * @param {string} testCaseId - Test Case Id to be fetched.
+     * @param {string} witFields - Get the list of witFields.
+     * @param {boolean} returnIdentityRef - If set to true, returns all identity fields, like AssignedTo, ActivatedBy etc., as IdentityRef objects. If set to false, these fields are returned as unique names in string format. This is false by default.
+     */
+    public async getTestCase(
+        project: string,
+        planId: number,
+        suiteId: number,
+        testCaseId: string,
+        witFields?: string,
+        returnIdentityRef?: boolean
+    ): Promise<TestPlanInterfaces.TestCase[]> {
+
+        return new Promise<TestPlanInterfaces.TestCase[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId,
+                testCaseId: testCaseId
+            };
+
+            let queryValues: any = {
+                witFields: witFields,
+                returnIdentityRef: returnIdentityRef,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
+                res = await this.rest.get<TestPlanInterfaces.TestCase[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestCase,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get Test Case List return those test cases which have all the configuration Ids as mentioned in the optional parameter. If configuration Ids is null, it return all the test cases
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which test cases are requested.
+     * @param {number} suiteId - ID of the test suite for which test cases are requested.
+     * @param {string} testIds - Test Case Ids to be fetched.
+     * @param {string} configurationIds - Fetch Test Cases which contains all the configuration Ids specified.
+     * @param {string} witFields - Get the list of witFields.
+     * @param {string} continuationToken - If the list of test cases returned is not complete, a continuation token to query next batch of test cases is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test cases.
+     * @param {boolean} returnIdentityRef - If set to true, returns all identity fields, like AssignedTo, ActivatedBy etc., as IdentityRef objects. If set to false, these fields are returned as unique names in string format. This is false by default.
+     * @param {boolean} expand - If set to false, will get a smaller payload containing only basic details about the suite test case object
+     * @param {TestPlanInterfaces.ExcludeFlags} excludeFlags - Flag to exclude various values from payload. For example to remove point assignments pass exclude = 1. To remove extra information (links, test plan , test suite) pass exclude = 2. To remove both extra information and point assignments pass exclude = 3 (1 + 2).
+     * @param {boolean} isRecursive
+     */
+    public async getTestCaseList(
+        project: string,
+        planId: number,
+        suiteId: number,
+        testIds?: string,
+        configurationIds?: string,
+        witFields?: string,
+        continuationToken?: string,
+        returnIdentityRef?: boolean,
+        expand?: boolean,
+        excludeFlags?: TestPlanInterfaces.ExcludeFlags,
+        isRecursive?: boolean
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                testIds: testIds,
+                configurationIds: configurationIds,
+                witFields: witFields,
+                continuationToken: continuationToken,
+                returnIdentityRef: returnIdentityRef,
+                expand: expand,
+                excludeFlags: excludeFlags,
+                isRecursive: isRecursive,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestCase,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes test cases from a suite based on the list of test case Ids provided.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan from which test cases are to be removed.
+     * @param {number} suiteId - ID of the test suite from which test cases are to be removed.
+     * @param {string} testCaseIds - Test Case Ids to be removed.
+     */
+    public async removeTestCasesFromSuite(
+        project: string,
+        planId: number,
+        suiteId: number,
+        testCaseIds: string
+    ): Promise<void> {
+        if (testCaseIds == null) {
+            throw new TypeError('testCaseIds can not be null or undefined');
+        }
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                testCaseIds: testCaseIds,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Removes test cases from a suite based on the list of test case Ids provided. This API can be used to remove a larger number of test cases.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan from which test cases are to be removed.
+     * @param {number} suiteId - ID of the test suite from which test cases are to be removed.
+     * @param {string} testIds - Comma separated string of Test Case Ids to be removed.
+     */
+    public async removeTestCasesListFromSuite(
+        project: string,
+        planId: number,
+        suiteId: number,
+        testIds: string
+    ): Promise<void> {
+        if (testIds == null) {
+            throw new TypeError('testIds can not be null or undefined');
+        }
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                testIds: testIds,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update the configurations for test cases
+     * 
+     * @param {TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[]} suiteTestCaseCreateUpdateParameters - A SuiteTestCaseCreateUpdateParameters object.
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan to which test cases are to be updated.
+     * @param {number} suiteId - ID of the test suite to which test cases are to be updated.
+     */
+    public async updateSuiteTestCases(
+        suiteTestCaseCreateUpdateParameters: TestPlanInterfaces.SuiteTestCaseCreateUpdateParameters[],
+        project: string,
+        planId: number,
+        suiteId: number
+    ): Promise<TestPlanInterfaces.TestCase[]> {
+
+        return new Promise<TestPlanInterfaces.TestCase[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.3",
+                    "testplan",
+                    "a9bd61ac-45cf-4d13-9441-43dcd01edf8d",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
+                res = await this.rest.update<TestPlanInterfaces.TestCase[]>(url, suiteTestCaseCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestCase,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {TestPlanInterfaces.CloneTestCaseParams} cloneRequestBody
+     * @param {string} project - Project ID or project name
+     */
+    public async cloneTestCase(
+        cloneRequestBody: TestPlanInterfaces.CloneTestCaseParams,
+        project: string
+    ): Promise<TestPlanInterfaces.CloneTestCaseOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestCaseOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "529b2b8d-82f4-4893-b1e4-1e74ea534673",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestCaseOperationInformation>;
+                res = await this.rest.create<TestPlanInterfaces.CloneTestCaseOperationInformation>(url, cloneRequestBody, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestCaseOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get clone information.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} cloneOperationId - Operation ID returned when we queue a clone operation
+     */
+    public async getTestCaseCloneInformation(
+        project: string,
+        cloneOperationId: number
+    ): Promise<TestPlanInterfaces.CloneTestCaseOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestCaseOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                cloneOperationId: cloneOperationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "529b2b8d-82f4-4893-b1e4-1e74ea534673",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestCaseOperationInformation>;
+                res = await this.rest.get<TestPlanInterfaces.CloneTestCaseOperationInformation>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestCaseOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Exports a set of test cases from a suite to a file. Currently supported  formats: xlsx
+     * 
+     * @param {TestPlanInterfaces.ExportTestCaseParams} exportTestCaseRequestBody - A ExportTestCaseParams object.ExportTestCaseParams
+     * @param {string} project - Project ID or project name
+     */
+    public async exportTestCases(
+        exportTestCaseRequestBody: TestPlanInterfaces.ExportTestCaseParams,
+        project: string
+    ): Promise<NodeJS.ReadableStream> {
+
+        return new Promise<NodeJS.ReadableStream>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "3b9d1c87-6b1a-4e7d-9e7d-1a8e543112bb",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+
+                let apiVersion: string = verData.apiVersion!;
+                let accept: string = this.createAcceptHeader("application/octet-stream", apiVersion);
+                resolve((await this.http.get(url, { "Accept": accept })).message);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete a test case.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} testCaseId - Id of test case to be deleted.
+     */
+    public async deleteTestCase(
+        project: string,
+        testCaseId: number
+    ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                testCaseId: testCaseId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "29006fb5-816b-4ff7-a329-599943569229",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Clone test plan
+     * 
+     * @param {TestPlanInterfaces.CloneTestPlanParams} cloneRequestBody - Plan Clone Request Body detail TestPlanCloneRequest
+     * @param {string} project - Project ID or project name
+     * @param {boolean} deepClone - Clones all the associated test cases as well
+     */
+    public async cloneTestPlan(
+        cloneRequestBody: TestPlanInterfaces.CloneTestPlanParams,
+        project: string,
+        deepClone?: boolean
+    ): Promise<TestPlanInterfaces.CloneTestPlanOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestPlanOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                deepClone: deepClone,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "e65df662-d8a3-46c7-ae1c-14e2d4df57e1",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestPlanOperationInformation>;
+                res = await this.rest.create<TestPlanInterfaces.CloneTestPlanOperationInformation>(url, cloneRequestBody, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestPlanOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get clone information.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} cloneOperationId - Operation ID returned when we queue a clone operation
+     */
+    public async getCloneInformation(
+        project: string,
+        cloneOperationId: number
+    ): Promise<TestPlanInterfaces.CloneTestPlanOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestPlanOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                cloneOperationId: cloneOperationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "e65df662-d8a3-46c7-ae1c-14e2d4df57e1",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestPlanOperationInformation>;
+                res = await this.rest.get<TestPlanInterfaces.CloneTestPlanOperationInformation>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestPlanOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a particular Test Point from a suite.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which test points are requested.
+     * @param {number} suiteId - ID of the test suite for which test points are requested.
+     * @param {string} pointId - ID of test point to be fetched.
+     * @param {boolean} returnIdentityRef - If set to true, returns the AssignedTo field in TestCaseReference as IdentityRef object.
+     * @param {boolean} includePointDetails - If set to false, will get a smaller payload containing only basic details about the test point object
+     */
+    public async getPoints(
+        project: string,
+        planId: number,
+        suiteId: number,
+        pointId: string,
+        returnIdentityRef?: boolean,
+        includePointDetails?: boolean
+    ): Promise<TestPlanInterfaces.TestPoint[]> {
+        if (pointId == null) {
+            throw new TypeError('pointId can not be null or undefined');
+        }
+
+        return new Promise<TestPlanInterfaces.TestPoint[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                pointId: pointId,
+                returnIdentityRef: returnIdentityRef,
+                includePointDetails: includePointDetails,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "52df686e-bae4-4334-b0ee-b6cf4e6f6b73",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestPoint[]>;
+                res = await this.rest.get<TestPlanInterfaces.TestPoint[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPoint,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get all the points inside a suite based on some filters
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which test points are requested.
+     * @param {number} suiteId - ID of the test suite for which test points are requested
+     * @param {string} testPointIds - ID of test points to fetch.
+     * @param {string} testCaseId - Get Test Points for specific test case Ids.
+     * @param {string} continuationToken - If the list of test point returned is not complete, a continuation token to query next batch of test points is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test points.
+     * @param {boolean} returnIdentityRef - If set to true, returns the AssignedTo field in TestCaseReference as IdentityRef object.
+     * @param {boolean} includePointDetails - If set to false, will get a smaller payload containing only basic details about the test point object
+     * @param {boolean} isRecursive - If set to true, will also fetch test points belonging to child suites recursively.
+     */
+    public async getPointsList(
+        project: string,
+        planId: number,
+        suiteId: number,
+        testPointIds?: string,
+        testCaseId?: string,
+        continuationToken?: string,
+        returnIdentityRef?: boolean,
+        includePointDetails?: boolean,
+        isRecursive?: boolean
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                testPointIds: testPointIds,
+                testCaseId: testCaseId,
+                continuationToken: continuationToken,
+                returnIdentityRef: returnIdentityRef,
+                includePointDetails: includePointDetails,
+                isRecursive: isRecursive,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "52df686e-bae4-4334-b0ee-b6cf4e6f6b73",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPoint,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update Test Points. This is used to Reset test point to active, update the outcome of a test point or update the tester of a test point
+     * 
+     * @param {TestPlanInterfaces.TestPointUpdateParams[]} testPointUpdateParams - A TestPointUpdateParams Object.
+     * @param {string} project - Project ID or project name
+     * @param {number} planId - ID of the test plan for which test points are requested.
+     * @param {number} suiteId - ID of the test suite for which test points are requested.
+     * @param {boolean} includePointDetails - If set to false, will get a smaller payload containing only basic details about the test point object
+     * @param {boolean} returnIdentityRef - If set to true, returns the AssignedTo field in TestCaseReference as IdentityRef object.
+     */
+    public async updateTestPoints(
+        testPointUpdateParams: TestPlanInterfaces.TestPointUpdateParams[],
+        project: string,
+        planId: number,
+        suiteId: number,
+        includePointDetails?: boolean,
+        returnIdentityRef?: boolean
+    ): Promise<TestPlanInterfaces.TestPoint[]> {
+
+        return new Promise<TestPlanInterfaces.TestPoint[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                planId: planId,
+                suiteId: suiteId
+            };
+
+            let queryValues: any = {
+                includePointDetails: includePointDetails,
+                returnIdentityRef: returnIdentityRef,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "52df686e-bae4-4334-b0ee-b6cf4e6f6b73",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestPoint[]>;
+                res = await this.rest.update<TestPlanInterfaces.TestPoint[]>(url, testPointUpdateParams, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestPoint,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Clone test suite
+     * 
+     * @param {TestPlanInterfaces.CloneTestSuiteParams} cloneRequestBody - Suite Clone Request Body detail TestSuiteCloneRequest
+     * @param {string} project - Project ID or project name
+     * @param {boolean} deepClone - Clones all the associated test cases as well
+     */
+    public async cloneTestSuite(
+        cloneRequestBody: TestPlanInterfaces.CloneTestSuiteParams,
+        project: string,
+        deepClone?: boolean
+    ): Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                deepClone: deepClone,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "181d4c97-0e98-4ee2-ad6a-4cada675e555",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
+                res = await this.rest.create<TestPlanInterfaces.CloneTestSuiteOperationInformation>(url, cloneRequestBody, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestSuiteOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get clone information.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} cloneOperationId - Operation ID returned when we queue a clone operation
+     */
+    public async getSuiteCloneInformation(
+        project: string,
+        cloneOperationId: number
+    ): Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation> {
+
+        return new Promise<TestPlanInterfaces.CloneTestSuiteOperationInformation>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                cloneOperationId: cloneOperationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.2",
+                    "testplan",
+                    "181d4c97-0e98-4ee2-ad6a-4cada675e555",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
+                res = await this.rest.get<TestPlanInterfaces.CloneTestSuiteOperationInformation>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.CloneTestSuiteOperationInformation,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Create a test variable.
+     * 
+     * @param {TestPlanInterfaces.TestVariableCreateUpdateParameters} testVariableCreateUpdateParameters - TestVariableCreateUpdateParameters
+     * @param {string} project - Project ID or project name
+     */
+    public async createTestVariable(
+        testVariableCreateUpdateParameters: TestPlanInterfaces.TestVariableCreateUpdateParameters,
+        project: string
+    ): Promise<TestPlanInterfaces.TestVariable> {
+
+        return new Promise<TestPlanInterfaces.TestVariable>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "2c61fac6-ac4e-45a5-8c38-1c2b8fd8ea6c",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
+                res = await this.rest.create<TestPlanInterfaces.TestVariable>(url, testVariableCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestVariable,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Delete a test variable by its ID.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} testVariableId - ID of the test variable to delete.
+     */
+    public async deleteTestVariable(
+        project: string,
+        testVariableId: number
+    ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                testVariableId: testVariableId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "2c61fac6-ac4e-45a5-8c38-1c2b8fd8ea6c",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    null,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a test variable by its ID.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} testVariableId - ID of the test variable to get.
+     */
+    public async getTestVariableById(
+        project: string,
+        testVariableId: number
+    ): Promise<TestPlanInterfaces.TestVariable> {
+
+        return new Promise<TestPlanInterfaces.TestVariable>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                testVariableId: testVariableId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "2c61fac6-ac4e-45a5-8c38-1c2b8fd8ea6c",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
+                res = await this.rest.get<TestPlanInterfaces.TestVariable>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestVariable,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get a list of test variables.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} continuationToken - If the list of variables returned is not complete, a continuation token to query next batch of variables is included in the response header as "x-ms-continuationtoken". Omit this parameter to get the first batch of test variables.
+     */
+    public async getTestVariables(
+        project: string,
+        continuationToken?: string
+    ): Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>> {
+
+        return new Promise<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                continuationToken: continuationToken,
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "2c61fac6-ac4e-45a5-8c38-1c2b8fd8ea6c",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestVariable,
+                    true);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update a test variable by its ID.
+     * 
+     * @param {TestPlanInterfaces.TestVariableCreateUpdateParameters} testVariableCreateUpdateParameters - TestVariableCreateUpdateParameters
+     * @param {string} project - Project ID or project name
+     * @param {number} testVariableId - ID of the test variable to update.
+     */
+    public async updateTestVariable(
+        testVariableCreateUpdateParameters: TestPlanInterfaces.TestVariableCreateUpdateParameters,
+        project: string,
+        testVariableId: number
+    ): Promise<TestPlanInterfaces.TestVariable> {
+
+        return new Promise<TestPlanInterfaces.TestVariable>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                testVariableId: testVariableId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "testplan",
+                    "2c61fac6-ac4e-45a5-8c38-1c2b8fd8ea6c",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                    verData.apiVersion);
+
+                let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
+                res = await this.rest.update<TestPlanInterfaces.TestVariable>(url, testVariableCreateUpdateParameters, options);
+
+                let ret = this.formatResponse(res.result,
+                    TestPlanInterfaces.TypeInfo.TestVariable,
+                    false);
+
+                resolve(ret);
+
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+}

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -319,7 +319,7 @@ export class WebApi {
         return new testm.TestApi(serverUrl, handlers, this.options);
     }
 
-    public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestPlanApi> {
+    public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testplanm.ITestPlanApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "e4c27205-9d23-4c98-b958-d798bc3f9cd4");
         handlers = handlers || [this.authHandler];

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -21,6 +21,7 @@ import securityrolesm = require('./SecurityRolesApi');
 import taskagentm = require('./TaskAgentApi');
 import taskm = require('./TaskApi');
 import testm = require('./TestApi');
+import testplanm = require('./TestPlanApi')
 import testresultsm = require('./TestResultsApi');
 import tfvcm = require('./TfvcApi');
 import wikim = require('./WikiApi');
@@ -139,8 +140,8 @@ export class WebApi {
 
         let userAgent: string;
         const nodeApiName: string = 'azure-devops-node-api';
-        if(isBrowser) {
-            if(requestSettings) {
+        if (isBrowser) {
+            if (requestSettings) {
                 userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
             } else {
                 userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
@@ -318,7 +319,14 @@ export class WebApi {
         return new testm.TestApi(serverUrl, handlers, this.options);
     }
 
-	public async getTestResultsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestResultsApi> {
+    public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestPlanApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "e4c27205-9d23-4c98-b958-d798bc3f9cd4");
+        handlers = handlers || [this.authHandler];
+        return new testplanm.TestPlanApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTestResultsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestResultsApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c83eaf52-edf3-4034-ae11-17d38f25404c");
         handlers = handlers || [this.authHandler];
@@ -370,13 +378,13 @@ export class WebApi {
      * Determines if the domain is exluded for proxy via the no_proxy env var
      * @param url: the server url
      */
-    public isNoProxyHost = function(_url: string) {
+    public isNoProxyHost = function (_url: string) {
         if (!process.env.no_proxy) {
             return false;
         }
         const noProxyDomains = (process.env.no_proxy || '')
-        .split(',')
-        .map(v => v.toLowerCase());
+            .split(',')
+            .map(v => v.toLowerCase());
         const serverUrl = url.parse(_url).host.toLowerCase();
         // return true if the no_proxy includes the host
         return noProxyDomains.indexOf(serverUrl) !== -1;
@@ -422,7 +430,7 @@ export class WebApi {
     }
 
     private _readTaskLibSecrets(lookupKey: string): string {
-        if(isBrowser) {
+        if (isBrowser) {
             throw new Error("Browsers can't securely keep secrets");
         }
         // the lookupKey should has following format

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -140,8 +140,8 @@ export class WebApi {
 
         let userAgent: string;
         const nodeApiName: string = 'azure-devops-node-api';
-        if (isBrowser) {
-            if (requestSettings) {
+        if(isBrowser) {
+            if(requestSettings) {
                 userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
             } else {
                 userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
@@ -378,13 +378,13 @@ export class WebApi {
      * Determines if the domain is exluded for proxy via the no_proxy env var
      * @param url: the server url
      */
-    public isNoProxyHost = function (_url: string) {
+    public isNoProxyHost = function(_url: string) {
         if (!process.env.no_proxy) {
             return false;
         }
         const noProxyDomains = (process.env.no_proxy || '')
-            .split(',')
-            .map(v => v.toLowerCase());
+        .split(',')
+        .map(v => v.toLowerCase());
         const serverUrl = url.parse(_url).host.toLowerCase();
         // return true if the no_proxy includes the host
         return noProxyDomains.indexOf(serverUrl) !== -1;

--- a/api/interfaces/TestPlanInterfaces.ts
+++ b/api/interfaces/TestPlanInterfaces.ts
@@ -1,1855 +1,454 @@
-﻿/*
- * ---------------------------------------------------------
- * Copyright(C) Microsoft Corporation. All rights reserved.
- * ---------------------------------------------------------
- *
- * ---------------------------------------------------------
- * Generated file, DO NOT EDIT
- * ---------------------------------------------------------
- */
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-"use strict";
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+import basem = require('./ClientApiBases');
+import buildm = require('./BuildApi');
+import corem = require('./CoreApi');
+import dashboardm = require('./DashboardApi');
+import extmgmtm = require("./ExtensionManagementApi");
+import featuremgmtm = require("./FeatureManagementApi");
+import filecontainerm = require('./FileContainerApi');
+import gallerym = require('./GalleryApi');
+import gitm = require('./GitApi');
+import locationsm = require('./LocationsApi');
+import notificationm = require('./NotificationApi');
+import policym = require('./PolicyApi');
+import profilem = require('./ProfileApi');
+import projectm = require('./ProjectAnalysisApi');
+import releasem = require('./ReleaseApi');
+import securityrolesm = require('./SecurityRolesApi');
+import taskagentm = require('./TaskAgentApi');
+import taskm = require('./TaskApi');
+import testm = require('./TestApi');
+import testplanm = require('./TestPlanApi')
+import testresultsm = require('./TestResultsApi');
+import tfvcm = require('./TfvcApi');
+import wikim = require('./WikiApi');
+import workm = require('./WorkApi');
+import workitemtrackingm = require('./WorkItemTrackingApi');
+import workitemtrackingprocessm = require('./WorkItemTrackingProcessApi');
+import workitemtrackingprocessdefinitionm = require('./WorkItemTrackingProcessDefinitionsApi');
+import basicm = require('./handlers/basiccreds');
+import bearm = require('./handlers/bearertoken');
+import ntlmm = require('./handlers/ntlm');
+import patm = require('./handlers/personalaccesstoken');
 
-import TFS_TestManagement_Contracts = require("../TFS/TestManagement/Contracts");
-import TfsCoreInterfaces = require("../interfaces/CoreInterfaces");
-import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
+import * as rm from 'typed-rest-client/RestClient';
+import vsom = require('./VsoClient');
+import lim = require("./interfaces/LocationsInterfaces");
 
+import crypto = require('crypto');
+import fs = require('fs');
+import os = require('os');
+import url = require('url');
+import path = require('path');
 
+const isBrowser: boolean = typeof window !== 'undefined';
 /**
- * The build definition reference resource
+ * Methods to return handler objects (see handlers folder)
  */
-export interface BuildDefinitionReference {
-    /**
-     * ID of the build definition
-     */
-    id?: number;
-    /**
-     * Name of the build definition
-     */
-    name?: string;
-}
-
-/**
- * Common Response for clone operation
- */
-export interface CloneOperationCommonResponse {
-    /**
-     * Various statistics related to the clone operation
-     */
-    cloneStatistics?: TFS_TestManagement_Contracts.CloneStatistics;
-    /**
-     * Completion data of the operation
-     */
-    completionDate?: Date;
-    /**
-     * Creation data of the operation
-     */
-    creationDate?: Date;
-    /**
-     * Reference links
-     */
-    links?: any;
-    /**
-     * Message related to the job
-     */
-    message?: string;
-    /**
-     * Clone operation Id
-     */
-    opId: number;
-    /**
-     * Clone operation state
-     */
-    state?: TFS_TestManagement_Contracts.CloneOperationState;
-}
-
-export interface CloneTestCaseOperationInformation {
-    /**
-     * Various information related to the clone
-     */
-    cloneOperationResponse: CloneOperationCommonResponse;
-    /**
-     * Test Plan Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneTestCaseOptions;
-    /**
-     * Information of destination Test Suite
-     */
-    destinationTestSuite: TestSuiteReferenceWithProject;
-    /**
-     * Information of source Test Suite
-     */
-    sourceTestSuite: SourceTestSuiteResponse;
-}
-
-/**
- * Parameters for Test Suite clone operation
- */
-export interface CloneTestCaseParams {
-    /**
-     * Test Case Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneTestCaseOptions;
-    /**
-     * Information about destination Test Plan
-     */
-    destinationTestPlan: TestPlanReference;
-    /**
-     * Information about destination Test Suite
-     */
-    destinationTestSuite: DestinationTestSuiteInfo;
-    /**
-     * Information about source Test Plan
-     */
-    sourceTestPlan: TestPlanReference;
-    /**
-     * Information about source Test Suite
-     */
-    sourceTestSuite: SourceTestSuiteInfo;
-    /**
-     * Test Case IDs
-     */
-    testCaseIds?: number[];
-}
-
-/**
- * Response for Test Plan clone operation
- */
-export interface CloneTestPlanOperationInformation {
-    /**
-     * Various information related to the clone
-     */
-    cloneOperationResponse: CloneOperationCommonResponse;
-    /**
-     * Test Plan Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
-    /**
-     * Information of destination Test Plan
-     */
-    destinationTestPlan: TestPlan;
-    /**
-     * Information of source Test Plan
-     */
-    sourceTestPlan: SourceTestplanResponse;
-}
-
-/**
- * Parameters for Test Plan clone operation
- */
-export interface CloneTestPlanParams {
-    /**
-     * Test Plan Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
-    /**
-     * Information about destination Test Plan
-     */
-    destinationTestPlan: DestinationTestPlanCloneParams;
-    /**
-     * Information about source Test Plan
-     */
-    sourceTestPlan: SourceTestPlanInfo;
-}
-
-/**
- * Response for Test Suite clone operation
- */
-export interface CloneTestSuiteOperationInformation {
-    /**
-     * Information of newly cloned Test Suite
-     */
-    clonedTestSuite?: TestSuiteReferenceWithProject;
-    /**
-     * Various information related to the clone
-     */
-    cloneOperationResponse: CloneOperationCommonResponse;
-    /**
-     * Test Plan Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
-    /**
-     * Information of destination Test Suite
-     */
-    destinationTestSuite: TestSuiteReferenceWithProject;
-    /**
-     * Information of source Test Suite
-     */
-    sourceTestSuite: TestSuiteReferenceWithProject;
-}
-
-/**
- * Parameters for Test Suite clone operation
- */
-export interface CloneTestSuiteParams {
-    /**
-     * Test Plan Clone create parameters
-     */
-    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
-    /**
-     * Information about destination Test Suite
-     */
-    destinationTestSuite: DestinationTestSuiteInfo;
-    /**
-     * Information about source Test Suite
-     */
-    sourceTestSuite: SourceTestSuiteInfo;
-}
-
-/**
- * Configuration of the Test Point
- */
-export interface Configuration {
-    /**
-     * Id of the Configuration Assigned to the Test Point
-     */
-    configurationId?: number;
-}
-
-/**
- * Destination Test Plan create parameters
- */
-export interface DestinationTestPlanCloneParams extends TestPlanCreateParams {
-    /**
-     * Destination Project Name
-     */
-    project?: string;
-}
-
-/**
- * Destination Test Suite information for Test Suite clone operation
- */
-export interface DestinationTestSuiteInfo {
-    /**
-     * Destination Suite Id
-     */
-    id: number;
-    /**
-     * Destination Project Name
-     */
-    project?: string;
-}
-
-/**
- * Exclude Flags for suite test case object. Exclude Flags exclude various objects from payload depending on the value passed
- */
-export enum ExcludeFlags {
-    /**
-     * To exclude nothing
-     */
-    None = 0,
-    /**
-     * To exclude point assignments, pass exclude = 1
-     */
-    PointAssignments = 1,
-    /**
-     * To exclude extra information (links, test plan, test suite), pass exclude = 2
-     */
-    ExtraInformation = 2,
-}
-
-export enum FailureType {
-    None = 0,
-    Regression = 1,
-    New_Issue = 2,
-    Known_Issue = 3,
-    Unknown = 4,
-    Null_Value = 5,
-    MaxValue = 5,
-}
-
-export enum LastResolutionState {
-    None = 0,
-    NeedsInvestigation = 1,
-    TestIssue = 2,
-    ProductIssue = 3,
-    ConfigurationIssue = 4,
-    NullValue = 5,
-    MaxValue = 5,
-}
-
-/**
- * Enum representing the return code of data provider.
- */
-export enum LibraryTestCasesDataReturnCode {
-    Success = 0,
-    Error = 1,
-}
-
-/**
- * This data model is used in Work item-based tabs of Test Plans Library.
- */
-export interface LibraryWorkItemsData {
-    /**
-     * Specifies the column option field names
-     */
-    columnOptions?: string[];
-    /**
-     * Continuation token to fetch next set of elements. Present only when HasMoreElements is true.
-     */
-    continuationToken?: string;
-    /**
-     * Boolean indicating if the WIQL query has exceeded the limit of items returned.
-     */
-    exceededWorkItemQueryLimit: boolean;
-    /**
-     * Boolean indicating if there are more elements present than what are being sent.
-     */
-    hasMoreElements: boolean;
-    /**
-     * Specifies if there was an error while execution of data provider.
-     */
-    returnCode: LibraryTestCasesDataReturnCode;
-    /**
-     * List of work items returned when OrderByField is sent something other than Id.
-     */
-    workItemIds?: number[];
-    /**
-     * List of work items to be returned.
-     */
-    workItems: WorkItemDetails[];
-}
-
-/**
- * This is the request data contract for LibraryTestCaseDataProvider.
- */
-export interface LibraryWorkItemsDataProviderRequest {
-    /**
-     * Specifies the list of column options to show in test cases table.
-     */
-    columnOptions?: string[];
-    /**
-     * The continuation token required for paging of work items. This is required when getting subsequent sets of work items when OrderByField is Id.
-     */
-    continuationToken?: string;
-    /**
-     * List of filter values to be supplied. Currently supported filters are Title, State, AssignedTo, Priority, AreaPath.
-     */
-    filterValues?: TestPlansLibraryWorkItemFilter[];
-    /**
-     * Whether the data is to be sorted in ascending or descending order. When not supplied, defaults to descending.
-     */
-    isAscending?: boolean;
-    /**
-     * The type of query to run.
-     */
-    libraryQueryType?: TestPlansLibraryQuery;
-    /**
-     * Work item field on which to order the results. When not supplied, defaults to work item IDs.
-     */
-    orderByField?: string;
-    /**
-     * List of work items to query for field details. This is required when getting subsequent sets of work item fields when OrderByField is other than Id.
-     */
-    workItemIds?: number[];
-}
-
-export enum Outcome {
-    /**
-     * Only used during an update to preserve the existing value.
-     */
-    Unspecified = 0,
-    /**
-     * Test has not been completed, or the test type does not report pass/failure.
-     */
-    None = 1,
-    /**
-     * Test was executed w/o any issues.
-     */
-    Passed = 2,
-    /**
-     * Test was executed, but there were issues. Issues may involve exceptions or failed assertions.
-     */
-    Failed = 3,
-    /**
-     * Test has completed, but we can't say if it passed or failed. May be used for aborted tests...
-     */
-    Inconclusive = 4,
-    /**
-     * The test timed out
-     */
-    Timeout = 5,
-    /**
-     * Test was aborted. This was not caused by a user gesture, but rather by a framework decision.
-     */
-    Aborted = 6,
-    /**
-     * Test had it chance for been executed but was not, as ITestElement.IsRunnable == false.
-     */
-    Blocked = 7,
-    /**
-     * Test was not executed. This was caused by a user gesture - e.g. user hit stop button.
-     */
-    NotExecuted = 8,
-    /**
-     * To be used by Run level results. This is not a failure.
-     */
-    Warning = 9,
-    /**
-     * There was a system error while we were trying to execute a test.
-     */
-    Error = 10,
-    /**
-     * Test is Not Applicable for execution.
-     */
-    NotApplicable = 11,
-    /**
-     * Test is paused.
-     */
-    Paused = 12,
-    /**
-     * Test is currently executing. Added this for TCM charts
-     */
-    InProgress = 13,
-    /**
-     * Test is not impacted. Added fot TIA.
-     */
-    NotImpacted = 14,
-    MaxValue = 14,
-}
-
-/**
- * Assignments for the Test Point
- */
-export interface PointAssignment extends Configuration {
-    /**
-     * Name of the Configuration Assigned to the Test Point
-     */
-    configurationName?: string;
-    /**
-     * Id of the Test Point
-     */
-    id?: number;
-    /**
-     * Tester Assigned to the Test Point
-     */
-    tester?: VSSInterfaces.IdentityRef;
-}
-
-export enum PointState {
-    /**
-     * Default
-     */
-    None = 0,
-    /**
-     * The test point needs to be executed in order for the test pass to be considered complete.  Either the test has not been run before or the previous run failed.
-     */
-    Ready = 1,
-    /**
-     * The test has passed successfully and does not need to be re-run for the test pass to be considered complete.
-     */
-    Completed = 2,
-    /**
-     * The test point needs to be executed but is not able to.
-     */
-    NotReady = 3,
-    /**
-     * The test is being executed.
-     */
-    InProgress = 4,
-    MaxValue = 4,
-}
-
-/**
- * Results class for Test Point
- */
-export interface Results {
-    /**
-     * Outcome of the Test Point
-     */
-    outcome?: Outcome;
-}
-
-export enum ResultState {
-    /**
-     * Only used during an update to preserve the existing value.
-     */
-    Unspecified = 0,
-    /**
-     * Test is in the execution queue, was not started yet.
-     */
-    Pending = 1,
-    /**
-     * Test has been queued. This is applicable when a test case is queued for execution
-     */
-    Queued = 2,
-    /**
-     * Test is currently executing.
-     */
-    InProgress = 3,
-    /**
-     * Test has been paused. This is applicable when a test case is paused by the user (For e.g. Manual Tester can pause the execution of the manual test case)
-     */
-    Paused = 4,
-    /**
-     * Test has completed, but there is no quantitative measure of completeness. This may apply to load tests.
-     */
-    Completed = 5,
-    MaxValue = 5,
-}
-
-/**
- * Source Test Plan information for Test Plan clone operation
- */
-export interface SourceTestPlanInfo {
-    /**
-     * ID of the source Test Plan
-     */
-    id: number;
-    /**
-     * Id of suites to be cloned inside source Test Plan
-     */
-    suiteIds?: number[];
-}
-
-/**
- * Source Test Plan Response for Test Plan clone operation
- */
-export interface SourceTestplanResponse extends TestPlanReference {
-    /**
-     * project reference
-     */
-    project: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Id of suites to be cloned inside source Test Plan
-     */
-    suiteIds?: number[];
-}
-
-/**
- * Source Test Suite information for Test Suite clone operation
- */
-export interface SourceTestSuiteInfo {
-    /**
-     * Id of the Source Test Suite
-     */
-    id: number;
-}
-
-/**
- * Source Test Suite Response for Test Case clone operation
- */
-export interface SourceTestSuiteResponse extends TestSuiteReference {
-    /**
-     * project reference
-     */
-    project: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Id of suites to be cloned inside source Test Plan
-     */
-    testCaseIds?: number[];
-}
-
-/**
- * A suite entry defines properties for a test suite.
- */
-export interface SuiteEntry extends SuiteEntryUpdateParams {
-    /**
-     * Id for the test suite.
-     */
-    suiteId?: number;
-}
-
-export enum SuiteEntryTypes {
-    /**
-     * Test Case
-     */
-    TestCase = 0,
-    /**
-     * Child Suite
-     */
-    Suite = 1,
-}
-
-/**
- * A suite entry defines properties for a test suite.
- */
-export interface SuiteEntryUpdateParams {
-    /**
-     * Id of the suite entry in the test suite: either a test case id or child suite id.
-     */
-    id?: number;
-    /**
-     * Sequence number for the suite entry object in the test suite.
-     */
-    sequenceNumber?: number;
-    /**
-     * Defines whether the entry is of type test case or suite.
-     */
-    suiteEntryType?: SuiteEntryTypes;
-}
-
-/**
- * Option to get details in response
- */
-export enum SuiteExpand {
-    /**
-     * Dont include any of the expansions in output.
-     */
-    None = 0,
-    /**
-     * Include children in response.
-     */
-    Children = 1,
-    /**
-     * Include default testers in response.
-     */
-    DefaultTesters = 2,
-}
-
-/**
- * Create and Update Suite Test Case Parameters
- */
-export interface SuiteTestCaseCreateUpdateParameters {
-    /**
-     * Configurations Ids
-     */
-    pointAssignments?: Configuration[];
-    /**
-     * Id of Test Case to be updated or created
-     */
-    workItem?: WorkItem;
-}
-
-/**
- * Test Case Class
- */
-export interface TestCase {
-    /**
-     * Reference links
-     */
-    links: any;
-    /**
-     * Order of the TestCase in the Suite
-     */
-    order?: number;
-    /**
-     * List of Points associated with the Test Case
-     */
-    pointAssignments?: PointAssignment[];
-    /**
-     * Project under which the Test Case is
-     */
-    project?: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Test Plan under which the Test Case is
-     */
-    testPlan?: TestPlanReference;
-    /**
-     * Test Suite under which the Test Case is
-     */
-    testSuite?: TestSuiteReference;
-    /**
-     * Work Item details of the TestCase
-     */
-    workItem?: WorkItemDetails;
-}
-
-export interface TestCaseAssociatedResult {
-    completedDate: Date;
-    configuration: TestConfigurationReference;
-    outcome: UserFriendlyTestOutcome;
-    plan: TestPlanReference;
-    pointId?: number;
-    resultId: number;
-    runBy: VSSInterfaces.IdentityRef;
-    runId: number;
-    suite: TestSuiteReference;
-    tester: VSSInterfaces.IdentityRef;
-}
-
-/**
- * Test Case Reference
- */
-export interface TestCaseReference {
-    /**
-     * Identity to whom the test case is assigned
-     */
-    assignedTo?: VSSInterfaces.IdentityRef;
-    /**
-     * Test Case Id
-     */
-    id: number;
-    /**
-     * Test Case Name
-     */
-    name: string;
-    /**
-     * State of the test case work item
-     */
-    state?: string;
-}
-
-/**
- * This data model is used in TestCaseResultsDataProvider and populates the data required for initial page load
- */
-export interface TestCaseResultsData {
-    /**
-     * Point information from where the execution history was viewed. Used to set initial filters.
-     */
-    contextPoint?: TestPointDetailedReference;
-    /**
-     * Use to store the results displayed in the table
-     */
-    results: TestCaseAssociatedResult[];
-    /**
-     * Test Case Name to be displayed in the table header
-     */
-    testCaseName: string;
-}
-
-/**
- * Test configuration
- */
-export interface TestConfiguration extends TestConfigurationCreateUpdateParameters {
-    /**
-     * Id of the configuration
-     */
-    id: number;
-    /**
-     * Id of the test configuration variable
-     */
-    project?: TfsCoreInterfaces.TeamProjectReference;
-}
-
-/**
- * Test Configuration Create or Update Parameters
- */
-export interface TestConfigurationCreateUpdateParameters {
-    /**
-     * Description of the configuration
-     */
-    description?: string;
-    /**
-     * Is the configuration a default for the test plans
-     */
-    isDefault?: boolean;
-    /**
-     * Name of the configuration
-     */
-    name: string;
-    /**
-     * State of the configuration
-     */
-    state?: TFS_TestManagement_Contracts.TestConfigurationState;
-    /**
-     * Dictionary of Test Variable, Selected Value
-     */
-    values?: TFS_TestManagement_Contracts.NameValuePair[];
-}
-
-/**
- * Test Configuration Reference
- */
-export interface TestConfigurationReference {
-    /**
-     * Id of the configuration
-     */
-    id: number;
-    /**
-     * Name of the configuration
-     */
-    name: string;
-}
-
-/**
- * Test Entity Count Used to store test cases count (define tab) and test point count (execute tab) Used to store test cases count (define tab) and test point count (execute tab)
- */
-export interface TestEntityCount {
-    /**
-     * Test Entity Count
-     */
-    count?: number;
-    /**
-     * Test Plan under which the Test Entities are
-     */
-    testPlanId?: number;
-    /**
-     * Test Suite under which the Test Entities are
-     */
-    testSuiteId?: number;
-    /**
-     * Total test entities in the suite without the applied filters
-     */
-    totalCount?: number;
-}
-
-export enum TestEntityTypes {
-    TestCase = 0,
-    TestPoint = 1,
-}
-
-/**
- * The test plan resource.
- */
-export interface TestPlan extends TestPlanUpdateParams {
-    /**
-     * Relevant links
-     */
-    _links: any;
-    /**
-     * ID of the test plan.
-     */
-    id: number;
-    /**
-     * Previous build Id associated with the test plan
-     */
-    previousBuildId?: number;
-    /**
-     * Project which contains the test plan.
-     */
-    project?: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Root test suite of the test plan.
-     */
-    rootSuite: TestSuiteReference;
-    /**
-     * Identity Reference for the last update of the test plan
-     */
-    updatedBy?: VSSInterfaces.IdentityRef;
-    /**
-     * Updated date of the test plan
-     */
-    updatedDate?: Date;
-}
-
-/**
- * The test plan create parameters.
- */
-export interface TestPlanCreateParams {
-    /**
-     * Area of the test plan.
-     */
-    areaPath?: string;
-    automatedTestEnvironment?: TFS_TestManagement_Contracts.TestEnvironment;
-    automatedTestSettings?: TFS_TestManagement_Contracts.TestSettings;
-    /**
-     * The Build Definition that generates a build associated with this test plan.
-     */
-    buildDefinition?: BuildDefinitionReference;
-    /**
-     * Build to be tested.
-     */
-    buildId?: number;
-    /**
-     * Description of the test plan.
-     */
-    description?: string;
-    /**
-     * End date for the test plan.
-     */
-    endDate?: Date;
-    /**
-     * Iteration path of the test plan.
-     */
-    iteration: string;
-    manualTestEnvironment?: TFS_TestManagement_Contracts.TestEnvironment;
-    manualTestSettings?: TFS_TestManagement_Contracts.TestSettings;
-    /**
-     * Name of the test plan.
-     */
-    name: string;
-    /**
-     * Owner of the test plan.
-     */
-    owner?: VSSInterfaces.IdentityRef;
-    /**
-     * Release Environment to be used to deploy the build and run automated tests from this test plan.
-     */
-    releaseEnvironmentDefinition?: TFS_TestManagement_Contracts.ReleaseEnvironmentDefinitionReference;
-    /**
-     * Start date for the test plan.
-     */
-    startDate?: Date;
-    /**
-     * State of the test plan.
-     */
-    state?: string;
-    /**
-     * Value to configure how same tests across test suites under a test plan need to behave
-     */
-    testOutcomeSettings?: TFS_TestManagement_Contracts.TestOutcomeSettings;
-}
-
-/**
- * The test plan detailed reference resource. Contains additional workitem realted information
- */
-export interface TestPlanDetailedReference extends TestPlanReference {
-    /**
-     * Area of the test plan.
-     */
-    areaPath?: string;
-    /**
-     * End date for the test plan.
-     */
-    endDate?: Date;
-    /**
-     * Iteration path of the test plan.
-     */
-    iteration?: string;
-    /**
-     * Root Suite Id
-     */
-    rootSuiteId: number;
-    /**
-     * Start date for the test plan.
-     */
-    startDate?: Date;
-}
-
-/**
- * The test plan reference resource.
- */
-export interface TestPlanReference {
-    /**
-     * ID of the test plan.
-     */
-    id: number;
-    /**
-     * Name of the test plan.
-     */
-    name: string;
-}
-
-/**
- * This data model is used in TestPlansHubRefreshDataProvider and populates the data required for initial page load
- */
-export interface TestPlansHubRefreshData {
-    defineColumnOptionFields?: string[];
-    defineTabCustomColumnFieldMap?: { [key: string] : string; };
-    errorMessage?: string;
-    executeColumnOptionFields?: string[];
-    executeTabCustomColumnFieldMap?: { [key: string] : string; };
-    isAdvancedExtensionEnabled?: boolean;
-    selectedPivotId?: string;
-    selectedSuiteId?: number;
-    testCasePageSize: number;
-    testCases?: TestCase[];
-    testCasesContinuationToken?: string;
-    testPlan: TestPlanDetailedReference;
-    testPointPageSize: number;
-    testPoints?: TestPoint[];
-    testPointsContinuationToken?: string;
-    testSuites: TestSuite[];
-    testSuitesContinuationToken?: string;
-}
-
-/**
- * Enum used to define the queries used in Test Plans Library.
- */
-export enum TestPlansLibraryQuery {
-    None = 0,
-    AllTestCases = 1,
-    TestCasesWithActiveBugs = 2,
-    TestCasesNotLinkedToRequirements = 3,
-    TestCasesLinkedToRequirements = 4,
-    AllSharedSteps = 11,
-    SharedStepsNotLinkedToRequirement = 12,
-}
-
-/**
- * Container to hold information about a filter being applied in Test Plans Library.
- */
-export interface TestPlansLibraryWorkItemFilter {
-    /**
-     * Work item field name on which the items are to be filtered.
-     */
-    fieldName: string;
-    /**
-     * Work item field values corresponding to the field name.
-     */
-    fieldValues: string[];
-    /**
-     * Mode of the filter.
-     */
-    filterMode?: TestPlansLibraryWorkItemFilterMode;
-}
-
-export enum TestPlansLibraryWorkItemFilterMode {
-    /**
-     * Default. Have the field values separated by an OR clause.
-     */
-    Or = 0,
-    /**
-     * Have the field values separated by an AND clause.
-     */
-    And = 1,
-}
-
-/**
- * The test plan update parameters.
- */
-export interface TestPlanUpdateParams extends TestPlanCreateParams {
-    /**
-     * Revision of the test plan.
-     */
-    revision?: number;
-}
-
-/**
- * Test Point Class
- */
-export interface TestPoint {
-    /**
-     * Comment associated to the Test Point
-     */
-    comment?: string;
-    /**
-     * Configuration associated with the Test Point
-     */
-    configuration: TestConfigurationReference;
-    /**
-     * Id of the Test Point
-     */
-    id: number;
-    /**
-     * Variable to decide whether the test case is Active or not
-     */
-    isActive: boolean;
-    /**
-     * Is the Test Point for Automated Test Case or Manual
-     */
-    isAutomated?: boolean;
-    /**
-     * Last Reset to Active Time Stamp for the Test Point
-     */
-    lastResetToActive?: Date;
-    /**
-     * Last Updated details for the Test Point
-     */
-    lastUpdatedBy: VSSInterfaces.IdentityRef;
-    /**
-     * Last Update Time Stamp for the Test Point
-     */
-    lastUpdatedDate: Date;
-    /**
-     * Reference links
-     */
-    links: any;
-    /**
-     * Project under which the Test Point is
-     */
-    project: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Results associated to the Test Point
-     */
-    results: TestPointResults;
-    /**
-     * Test Case Reference
-     */
-    testCaseReference: TestCaseReference;
-    /**
-     * Tester associated with the Test Point
-     */
-    tester?: VSSInterfaces.IdentityRef;
-    /**
-     * Test Plan under which the Test Point is
-     */
-    testPlan: TestPlanReference;
-    /**
-     * Test Suite under which the Test Point is
-     */
-    testSuite: TestSuiteReference;
-}
-
-export interface TestPointDetailedReference {
-    configuration: TestConfigurationReference;
-    plan: TestPlanReference;
-    pointId?: number;
-    suite: TestSuiteReference;
-    tester: VSSInterfaces.IdentityRef;
-}
-
-/**
- * Test Point Results
- */
-export interface TestPointResults {
-    /**
-     * Failure Type for the Test Point
-     */
-    failureType?: FailureType;
-    /**
-     * Last Resolution State Id for the Test Point
-     */
-    lastResolutionState?: LastResolutionState;
-    /**
-     * Last Result Details for the Test Point
-     */
-    lastResultDetails?: TFS_TestManagement_Contracts.LastResultDetails;
-    /**
-     * Last Result Id
-     */
-    lastResultId?: number;
-    /**
-     * Last Result State of the Test Point
-     */
-    lastResultState?: ResultState;
-    /**
-     * Last RUn Build Number for the Test Point
-     */
-    lastRunBuildNumber?: string;
-    /**
-     * Last Test Run Id for the Test Point
-     */
-    lastTestRunId?: number;
-    /**
-     * Outcome of the Test Point
-     */
-    outcome: Outcome;
-    /**
-     * State of the Test Point
-     */
-    state?: PointState;
-}
-
-/**
- * Test Point Update Parameters
- */
-export interface TestPointUpdateParams {
-    /**
-     * Id of Test Point to be updated
-     */
-    id?: number;
-    /**
-     * Reset the Test Point to Active
-     */
-    isActive?: boolean;
-    /**
-     * Results of the test point
-     */
-    results?: Results;
-    /**
-     * Tester of the Test Point
-     */
-    tester?: VSSInterfaces.IdentityRef;
-}
 
-/**
- * Test suite
- */
-export interface TestSuite extends TestSuiteCreateParams {
-    /**
-     * Links: self, testPoints, testCases, parent
-     */
-    _links: any;
-    /**
-     * Child test suites of current test suite.
-     */
-    children?: TestSuite[];
-    /**
-     * Boolean value dictating if Child test suites are present
-     */
-    hasChildren?: boolean;
-    /**
-     * Id of test suite.
-     */
-    id: number;
-    /**
-     * Last error for test suite.
-     */
-    lastError?: string;
-    /**
-     * Last populated date.
-     */
-    lastPopulatedDate?: Date;
-    /**
-     * IdentityRef of user who has updated test suite recently.
-     */
-    lastUpdatedBy?: VSSInterfaces.IdentityRef;
-    /**
-     * Last update date.
-     */
-    lastUpdatedDate?: Date;
-    /**
-     * Test plan to which the test suite belongs.
-     */
-    plan: TestPlanReference;
-    /**
-     * Test suite project shallow reference.
-     */
-    project?: TfsCoreInterfaces.TeamProjectReference;
-    /**
-     * Test suite revision.
-     */
-    revision?: number;
-}
-
-/**
- * Test suite Create Parameters
- */
-export interface TestSuiteCreateParams extends TestSuiteCreateUpdateCommonParams {
-    /**
-     * Test suite requirement id.
-     */
-    requirementId?: number;
-    /**
-     * Test suite type.
-     */
-    suiteType?: TestSuiteType;
+export function getBasicHandler(username: string, password: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new basicm.BasicCredentialHandler(username, password, allowCrossOriginAuthentication);
 }
 
-/**
- * Test Suite Create/Update Common Parameters
- */
-export interface TestSuiteCreateUpdateCommonParams {
-    /**
-     * Test suite default configurations.
-     */
-    defaultConfigurations?: TestConfigurationReference[];
-    /**
-     * Test suite default testers.
-     */
-    defaultTesters?: VSSInterfaces.IdentityRef[];
-    /**
-     * Default configuration was inherited or not.
-     */
-    inheritDefaultConfigurations?: boolean;
-    /**
-     * Name of test suite.
-     */
-    name: string;
-    /**
-     * Test suite parent shallow reference.
-     */
-    parentSuite?: TestSuiteReference;
-    /**
-     * Test suite query string, for dynamic suites.
-     */
-    queryString?: string;
+export function getNtlmHandler(username: string, password: string, workstation?: string, domain?: string): VsoBaseInterfaces.IRequestHandler {
+    return new ntlmm.NtlmCredentialHandler(username, password, workstation, domain);
 }
 
-/**
- * The test suite reference resource.
- */
-export interface TestSuiteReference {
-    /**
-     * ID of the test suite.
-     */
-    id: number;
-    /**
-     * Name of the test suite.
-     */
-    name: string;
+export function getBearerHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new bearm.BearerCredentialHandler(token, allowCrossOriginAuthentication);
 }
 
-/**
- * Test Suite Reference with Project
- */
-export interface TestSuiteReferenceWithProject extends TestSuiteReference {
-    /**
-     * Reference of destination Project
-     */
-    project: TfsCoreInterfaces.TeamProjectReference;
+export function getPersonalAccessTokenHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    return new patm.PersonalAccessTokenCredentialHandler(token, allowCrossOriginAuthentication);
 }
 
-/**
- * Type of TestSuite
- */
-export enum TestSuiteType {
-    /**
-     * Default suite type
-     */
-    None = 0,
-    /**
-     * Query Based test Suite
-     */
-    DynamicTestSuite = 1,
-    /**
-     * Static Test Suite
-     */
-    StaticTestSuite = 2,
-    /**
-     * Requirement based Test Suite
-     */
-    RequirementTestSuite = 3,
+export function getHandlerFromToken(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
+    if (token.length === 52) {
+        return getPersonalAccessTokenHandler(token, allowCrossOriginAuthentication);
+    }
+    else {
+        return getBearerHandler(token, allowCrossOriginAuthentication);
+    }
 }
 
-/**
- * Test Suite Update Parameters
- */
-export interface TestSuiteUpdateParams extends TestSuiteCreateUpdateCommonParams {
-    /**
-     * Test suite revision.
-     */
-    revision?: number;
-}
+export interface IWebApiRequestSettings {
+    productName: string,
+    productVersion: string
+};
 
-/**
- * Test Variable
- */
-export interface TestVariable extends TestVariableCreateUpdateParameters {
-    /**
-     * Id of the test variable
-     */
-    id: number;
-    /**
-     * Id of the test variable
-     */
-    project?: TfsCoreInterfaces.TeamProjectReference;
-}
+// ---------------------------------------------------------------------------
+// Factory to return client apis
+// When new APIs are added, a method must be added here to instantiate the API
+//----------------------------------------------------------------------------
+export class WebApi {
 
-/**
- * Test Variable Create or Update Parameters
- */
-export interface TestVariableCreateUpdateParameters {
-    /**
-     * Description of the test variable
-     */
-    description?: string;
-    /**
-     * Name of the test variable
-     */
-    name: string;
-    /**
-     * List of allowed values
-     */
-    values?: string[];
-}
+    public serverUrl: string;
+    public authHandler: VsoBaseInterfaces.IRequestHandler;
+    public rest: rm.RestClient;
+    public vsoClient: vsom.VsoClient;
+    public options: VsoBaseInterfaces.IRequestOptions;
 
-export enum UserFriendlyTestOutcome {
-    InProgress = 0,
-    Blocked = 1,
-    Failed = 2,
-    Passed = 3,
-    Ready = 4,
-    NotApplicable = 5,
-    Paused = 6,
-    Timeout = 7,
-    Warning = 8,
-    Error = 9,
-    NotExecuted = 10,
-    Inconclusive = 11,
-    Aborted = 12,
-    None = 13,
-    NotImpacted = 14,
-    Unspecified = 15,
-    MaxValue = 15,
-}
+    private _resourceAreas: lim.ResourceAreaInfo[];
 
-/**
- * Work Item
- */
-export interface WorkItem {
-    /**
-     * Id of the Work Item
+    /*
+     * Factory to return client apis and handlers
+     * @param defaultUrl default server url to use when creating new apis from factory methods
+     * @param authHandler default authentication credentials to use when creating new apis from factory methods
      */
-    id?: number;
-}
+    constructor(defaultUrl: string, authHandler: VsoBaseInterfaces.IRequestHandler, options?: VsoBaseInterfaces.IRequestOptions, requestSettings?: IWebApiRequestSettings) {
+        this.serverUrl = defaultUrl;
+        this.authHandler = authHandler;
+        this.options = options || {};
 
-/**
- * Work Item Class
- */
-export interface WorkItemDetails {
-    /**
-     * Work Item Id
-     */
-    id: number;
-    /**
-     * Work Item Name
-     */
-    name: string;
-    /**
-     * Work Item Fields
-     */
-    workItemFields?: any[];
-}
+        if (!this.isNoProxyHost(this.serverUrl)) {
+            // try to get proxy setting from environment variable set by VSTS-Task-Lib if there is no proxy setting in the options
+            if (!this.options.proxy || !this.options.proxy.proxyUrl) {
+                if (global['_vsts_task_lib_proxy']) {
+                    let proxyFromEnv: VsoBaseInterfaces.IProxyConfiguration = {
+                        proxyUrl: global['_vsts_task_lib_proxy_url'],
+                        proxyUsername: global['_vsts_task_lib_proxy_username'],
+                        proxyPassword: this._readTaskLibSecrets(global['_vsts_task_lib_proxy_password']),
+                        proxyBypassHosts: JSON.parse(global['_vsts_task_lib_proxy_bypass'] || "[]"),
+                    };
 
-export var TypeInfo = {
-    CloneOperationCommonResponse: <any>{
-    },
-    CloneTestCaseOperationInformation: <any>{
-    },
-    CloneTestPlanOperationInformation: <any>{
-    },
-    CloneTestPlanParams: <any>{
-    },
-    CloneTestSuiteOperationInformation: <any>{
-    },
-    DestinationTestPlanCloneParams: <any>{
-    },
-    ExcludeFlags: {
-        enumValues: {
-            "none": 0,
-            "pointAssignments": 1,
-            "extraInformation": 2
+                    this.options.proxy = proxyFromEnv;
+                }
+            }
         }
-    },
-    FailureType: {
-        enumValues: {
-            "none": 0,
-            "regression": 1,
-            "new_Issue": 2,
-            "known_Issue": 3,
-            "unknown": 4,
-            "null_Value": 5,
-            "maxValue": 5
+
+        // try get cert setting from environment variable set by VSTS-Task-Lib if there is no cert setting in the options
+        if (!this.options.cert) {
+            if (global['_vsts_task_lib_cert']) {
+                let certFromEnv: VsoBaseInterfaces.ICertConfiguration = {
+                    caFile: global['_vsts_task_lib_cert_ca'],
+                    certFile: global['_vsts_task_lib_cert_clientcert'],
+                    keyFile: global['_vsts_task_lib_cert_key'],
+                    passphrase: this._readTaskLibSecrets(global['_vsts_task_lib_cert_passphrase']),
+                };
+
+                this.options.cert = certFromEnv;
+            }
         }
-    },
-    LastResolutionState: {
-        enumValues: {
-            "none": 0,
-            "needsInvestigation": 1,
-            "testIssue": 2,
-            "productIssue": 3,
-            "configurationIssue": 4,
-            "nullValue": 5,
-            "maxValue": 5
+
+        // try get ignore SSL error setting from environment variable set by VSTS-Task-Lib if there is no ignore SSL error setting in the options
+        if (!this.options.ignoreSslError) {
+            this.options.ignoreSslError = !!global['_vsts_task_lib_skip_cert_validation'];
         }
-    },
-    LibraryTestCasesDataReturnCode: {
-        enumValues: {
-            "success": 0,
-            "error": 1
+
+        let userAgent: string;
+        const nodeApiName: string = 'azure-devops-node-api';
+        if(isBrowser) {
+            if(requestSettings) {
+                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
+            } else {
+                userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
+            }
+        } else {
+            let nodeApiVersion: string = 'unknown';
+            const packageJsonPath: string = path.resolve(__dirname, 'package.json');
+            if (fs.existsSync(packageJsonPath)) {
+                nodeApiVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
+            }
+            const osName: string = os.platform();
+            const osVersion: string = os.release();
+
+            if (requestSettings) {
+                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
+            }
+            else {
+                userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+            }
         }
-    },
-    LibraryWorkItemsData: <any>{
-    },
-    LibraryWorkItemsDataProviderRequest: <any>{
-    },
-    Outcome: {
-        enumValues: {
-            "unspecified": 0,
-            "none": 1,
-            "passed": 2,
-            "failed": 3,
-            "inconclusive": 4,
-            "timeout": 5,
-            "aborted": 6,
-            "blocked": 7,
-            "notExecuted": 8,
-            "warning": 9,
-            "error": 10,
-            "notApplicable": 11,
-            "paused": 12,
-            "inProgress": 13,
-            "notImpacted": 14,
-            "maxValue": 14
+        this.rest = new rm.RestClient(userAgent, null, [this.authHandler], this.options);
+        this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
+    }
+
+    /**
+     *  Convenience factory to create with a bearer token.
+     * @param defaultServerUrl default server url to use when creating new apis from factory methods
+     * @param defaultAuthHandler default authentication credentials to use when creating new apis from factory methods
+     */
+    public static createWithBearerToken(defaultUrl: string, token: string, options?: VsoBaseInterfaces.IRequestOptions) {
+        let bearerHandler = getBearerHandler(token);
+        return new this(defaultUrl, bearerHandler, options);
+    }
+
+    public async connect(): Promise<lim.ConnectionData> {
+        return new Promise<lim.ConnectionData>(async (resolve, reject) => {
+            try {
+                let res: rm.IRestResponse<lim.ConnectionData>;
+                res = await this.rest.get<lim.ConnectionData>(this.vsoClient.resolveUrl('/_apis/connectionData'));
+                resolve(res.result);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Each factory method can take a serverUrl and a list of handlers
+     * if these aren't provided, the default url and auth handler given to the constructor for this class will be used
+     */
+    public async getBuildApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<buildm.IBuildApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, buildm.BuildApi.RESOURCE_AREA_ID);
+        handlers = handlers || [this.authHandler];
+        return new buildm.BuildApi(serverUrl, handlers, this.options);
+    }
+
+    public async getCoreApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<corem.ICoreApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "79134c72-4a58-4b42-976c-04e7115f32bf");
+        handlers = handlers || [this.authHandler];
+        return new corem.CoreApi(serverUrl, handlers, this.options);
+    }
+
+    public async getDashboardApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<dashboardm.IDashboardApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "31c84e0a-3ece-48fd-a29d-100849af99ba");
+        handlers = handlers || [this.authHandler];
+        return new dashboardm.DashboardApi(serverUrl, handlers, this.options);
+    }
+
+    public async getExtensionManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<extmgmtm.IExtensionManagementApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "6c2b0933-3600-42ae-bf8b-93d4f7e83594");
+        handlers = handlers || [this.authHandler];
+        return new extmgmtm.ExtensionManagementApi(serverUrl, handlers, this.options);
+    }
+
+    public async getFeatureManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<featuremgmtm.IFeatureManagementApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        handlers = handlers || [this.authHandler];
+        return new featuremgmtm.FeatureManagementApi(serverUrl, handlers, this.options);
+    }
+
+    public async getFileContainerApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<filecontainerm.IFileContainerApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        handlers = handlers || [this.authHandler];
+        return new filecontainerm.FileContainerApi(serverUrl, handlers, this.options);
+    }
+
+    public async getGalleryApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gallerym.IGalleryApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gallerym.GalleryApi.RESOURCE_AREA_ID);
+        handlers = handlers || [this.authHandler];
+        return new gallerym.GalleryApi(serverUrl, handlers, this.options);
+    }
+
+    public async getGitApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gitm.IGitApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gitm.GitApi.RESOURCE_AREA_ID);
+        handlers = handlers || [this.authHandler];
+        return new gitm.GitApi(serverUrl, handlers, this.options);
+    }
+
+    // TODO: Don't call resource area here? Will cause infinite loop?
+    public async getLocationsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<locationsm.ILocationsApi> {
+        let optionsClone: VsoBaseInterfaces.IRequestOptions = Object.assign({}, this.options);
+        optionsClone.allowRetries = true;
+        optionsClone.maxRetries = 5;
+        serverUrl = await serverUrl || this.serverUrl;
+        handlers = handlers || [this.authHandler];
+        return new locationsm.LocationsApi(serverUrl, handlers, optionsClone);
+    }
+
+    public async getNotificationApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<notificationm.INotificationApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        handlers = handlers || [this.authHandler];
+        return new notificationm.NotificationApi(serverUrl, handlers, this.options);
+    }
+
+    public async getPolicyApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<policym.IPolicyApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "fb13a388-40dd-4a04-b530-013a739c72ef");
+        handlers = handlers || [this.authHandler];
+        return new policym.PolicyApi(serverUrl, handlers, this.options);
+    }
+
+    public async getProfileApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<profilem.IProfileApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8ccfef3d-2b87-4e99-8ccb-66e343d2daa8");
+        handlers = handlers || [this.authHandler];
+        return new profilem.ProfileApi(serverUrl, handlers, this.options);
+    }
+
+    public async getProjectAnalysisApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<projectm.IProjectAnalysisApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "7658fa33-b1bf-4580-990f-fac5896773d3");
+        handlers = handlers || [this.authHandler];
+        return new projectm.ProjectAnalysisApi(serverUrl, handlers, this.options);
+    }
+
+    public async getSecurityRolesApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<securityrolesm.ISecurityRolesApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        handlers = handlers || [this.authHandler];
+        return new securityrolesm.SecurityRolesApi(serverUrl, handlers, this.options);
+    }
+
+    public async getReleaseApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<releasem.IReleaseApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "efc2f575-36ef-48e9-b672-0c6fb4a48ac5");
+        handlers = handlers || [this.authHandler];
+        return new releasem.ReleaseApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTaskApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskm.ITaskApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
+        handlers = handlers || [this.authHandler];
+        return new taskm.TaskApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTaskAgentApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskagentm.ITaskAgentApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd");
+        handlers = handlers || [this.authHandler];
+        return new taskagentm.TaskAgentApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTestApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testm.ITestApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e");
+        handlers = handlers || [this.authHandler];
+        return new testm.TestApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testplanm.ITestPlanApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "e4c27205-9d23-4c98-b958-d798bc3f9cd4");
+        handlers = handlers || [this.authHandler];
+        return new testplanm.TestPlanApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTestResultsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestResultsApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c83eaf52-edf3-4034-ae11-17d38f25404c");
+        handlers = handlers || [this.authHandler];
+        return new testresultsm.TestResultsApi(serverUrl, handlers, this.options);
+    }
+
+    public async getTfvcApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<tfvcm.ITfvcApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8aa40520-446d-40e6-89f6-9c9f9ce44c48");
+        handlers = handlers || [this.authHandler];
+        return new tfvcm.TfvcApi(serverUrl, handlers, this.options);
+    }
+
+    public async getWikiApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<wikim.IWikiApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3");
+        handlers = handlers || [this.authHandler];
+        return new wikim.WikiApi(serverUrl, handlers, this.options);
+    }
+
+    public async getWorkApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workm.IWorkApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9");
+        handlers = handlers || [this.authHandler];
+        return new workm.WorkApi(serverUrl, handlers, this.options);
+    }
+
+    public async getWorkItemTrackingApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingm.IWorkItemTrackingApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workitemtrackingm.WorkItemTrackingApi.RESOURCE_AREA_ID);
+        handlers = handlers || [this.authHandler];
+        return new workitemtrackingm.WorkItemTrackingApi(serverUrl, handlers, this.options);
+    }
+
+    public async getWorkItemTrackingProcessApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessm.IWorkItemTrackingProcessApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
+        handlers = handlers || [this.authHandler];
+        return new workitemtrackingprocessm.WorkItemTrackingProcessApi(serverUrl, handlers, this.options);
+    }
+
+    public async getWorkItemTrackingProcessDefinitionApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessdefinitionm.IWorkItemTrackingProcessDefinitionsApi> {
+        // TODO: Load RESOURCE_AREA_ID correctly.
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
+        handlers = handlers || [this.authHandler];
+        return new workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi(serverUrl, handlers, this.options);
+    }
+
+    /**
+     * Determines if the domain is exluded for proxy via the no_proxy env var
+     * @param url: the server url
+     */
+    public isNoProxyHost = function(_url: string) {
+        if (!process.env.no_proxy) {
+            return false;
         }
-    },
-    PointState: {
-        enumValues: {
-            "none": 0,
-            "ready": 1,
-            "completed": 2,
-            "notReady": 3,
-            "inProgress": 4,
-            "maxValue": 4
+        const noProxyDomains = (process.env.no_proxy || '')
+        .split(',')
+        .map(v => v.toLowerCase());
+        const serverUrl = url.parse(_url).host.toLowerCase();
+        // return true if the no_proxy includes the host
+        return noProxyDomains.indexOf(serverUrl) !== -1;
+    }
+
+    private async _getResourceAreaUrl(serverUrl: string, resourceId: string): Promise<string> {
+        if (!resourceId) {
+            return serverUrl;
         }
-    },
-    Results: <any>{
-    },
-    ResultState: {
-        enumValues: {
-            "unspecified": 0,
-            "pending": 1,
-            "queued": 2,
-            "inProgress": 3,
-            "paused": 4,
-            "completed": 5,
-            "maxValue": 5
+
+        // This must be of type any, see comment just below.
+        const resourceAreas: any = await this._getResourceAreas();
+
+        if (resourceAreas === undefined) {
+            throw new Error((`Failed to retrieve resource areas ' + 'from server: ${serverUrl}`));
         }
-    },
-    SourceTestplanResponse: <any>{
-    },
-    SourceTestSuiteResponse: <any>{
-    },
-    SuiteEntry: <any>{
-    },
-    SuiteEntryTypes: {
-        enumValues: {
-            "testCase": 0,
-            "suite": 1
+
+        // The response type differs based on whether or not there are resource areas. When we are on prem we get:
+        // {"count":0,"value":null} and when we are on VSTS we get an array of resource areas.
+        // Due to this strangeness the type of resourceAreas needs to be any and we need to check .count
+        // When going against vsts count will be undefined. On prem it will be 0
+        if (!resourceAreas || resourceAreas.length === 0 || resourceAreas.count === 0) {
+            // For on prem environments we get an empty list
+            return serverUrl;
         }
-    },
-    SuiteEntryUpdateParams: <any>{
-    },
-    SuiteExpand: {
-        enumValues: {
-            "none": 0,
-            "children": 1,
-            "defaultTesters": 2
+
+        for (var resourceArea of resourceAreas) {
+            if (resourceArea.id.toLowerCase() === resourceId.toLowerCase()) {
+                return resourceArea.locationUrl;
+            }
         }
-    },
-    TestCase: <any>{
-    },
-    TestCaseAssociatedResult: <any>{
-    },
-    TestCaseResultsData: <any>{
-    },
-    TestConfiguration: <any>{
-    },
-    TestConfigurationCreateUpdateParameters: <any>{
-    },
-    TestEntityTypes: {
-        enumValues: {
-            "testCase": 0,
-            "testPoint": 1
+
+        throw new Error((`Could not find information for resource area ${resourceId} ' + 'from server: ${serverUrl}`));
+    }
+
+    private async _getResourceAreas(): Promise<lim.ResourceAreaInfo[]> {
+        if (!this._resourceAreas) {
+            const locationClient: locationsm.ILocationsApi = await this.getLocationsApi();
+            this._resourceAreas = await locationClient.getResourceAreas();
         }
-    },
-    TestPlan: <any>{
-    },
-    TestPlanCreateParams: <any>{
-    },
-    TestPlanDetailedReference: <any>{
-    },
-    TestPlansHubRefreshData: <any>{
-    },
-    TestPlansLibraryQuery: {
-        enumValues: {
-            "none": 0,
-            "allTestCases": 1,
-            "testCasesWithActiveBugs": 2,
-            "testCasesNotLinkedToRequirements": 3,
-            "testCasesLinkedToRequirements": 4,
-            "allSharedSteps": 11,
-            "sharedStepsNotLinkedToRequirement": 12
+
+        return this._resourceAreas;
+    }
+
+    private _readTaskLibSecrets(lookupKey: string): string {
+        if (isBrowser) {
+            throw new Error("Browsers can't securely keep secrets");
         }
-    },
-    TestPlansLibraryWorkItemFilter: <any>{
-    },
-    TestPlansLibraryWorkItemFilterMode: {
-        enumValues: {
-            "or": 0,
-            "and": 1
+        // the lookupKey should has following format
+        // base64encoded<keyFilePath>:base64encoded<encryptedContent>
+        if (lookupKey && lookupKey.indexOf(':') > 0) {
+            let lookupInfo: string[] = lookupKey.split(':', 2);
+
+            // file contains encryption key
+            let keyFile = new Buffer(lookupInfo[0], 'base64').toString('utf8');
+            let encryptKey = new Buffer(fs.readFileSync(keyFile, 'utf8'), 'base64');
+
+            let encryptedContent: string = new Buffer(lookupInfo[1], 'base64').toString('utf8');
+
+            let decipher = crypto.createDecipher("aes-256-ctr", encryptKey)
+            let decryptedContent = decipher.update(encryptedContent, 'hex', 'utf8')
+            decryptedContent += decipher.final('utf8');
+
+            return decryptedContent;
         }
-    },
-    TestPlanUpdateParams: <any>{
-    },
-    TestPoint: <any>{
-    },
-    TestPointResults: <any>{
-    },
-    TestPointUpdateParams: <any>{
-    },
-    TestSuite: <any>{
-    },
-    TestSuiteCreateParams: <any>{
-    },
-    TestSuiteReferenceWithProject: <any>{
-    },
-    TestSuiteType: {
-        enumValues: {
-            "none": 0,
-            "dynamicTestSuite": 1,
-            "staticTestSuite": 2,
-            "requirementTestSuite": 3
-        }
-    },
-    TestVariable: <any>{
-    },
-    UserFriendlyTestOutcome: {
-        enumValues: {
-            "inProgress": 0,
-            "blocked": 1,
-            "failed": 2,
-            "passed": 3,
-            "ready": 4,
-            "notApplicable": 5,
-            "paused": 6,
-            "timeout": 7,
-            "warning": 8,
-            "error": 9,
-            "notExecuted": 10,
-            "inconclusive": 11,
-            "aborted": 12,
-            "none": 13,
-            "notImpacted": 14,
-            "unspecified": 15,
-            "maxValue": 15
-        }
-    },
-};
-
-TypeInfo.CloneOperationCommonResponse.fields = {
-    completionDate: {
-        isDate: true,
-    },
-    creationDate: {
-        isDate: true,
-    },
-    state: {
-        enumType: TFS_TestManagement_Contracts.TypeInfo.CloneOperationState
     }
-};
-
-TypeInfo.CloneTestCaseOperationInformation.fields = {
-    cloneOperationResponse: {
-        typeInfo: TypeInfo.CloneOperationCommonResponse
-    },
-    destinationTestSuite: {
-        typeInfo: TypeInfo.TestSuiteReferenceWithProject
-    },
-    sourceTestSuite: {
-        typeInfo: TypeInfo.SourceTestSuiteResponse
-    }
-};
-
-TypeInfo.CloneTestPlanOperationInformation.fields = {
-    cloneOperationResponse: {
-        typeInfo: TypeInfo.CloneOperationCommonResponse
-    },
-    destinationTestPlan: {
-        typeInfo: TypeInfo.TestPlan
-    },
-    sourceTestPlan: {
-        typeInfo: TypeInfo.SourceTestplanResponse
-    }
-};
-
-TypeInfo.CloneTestPlanParams.fields = {
-    destinationTestPlan: {
-        typeInfo: TypeInfo.DestinationTestPlanCloneParams
-    }
-};
-
-TypeInfo.CloneTestSuiteOperationInformation.fields = {
-    clonedTestSuite: {
-        typeInfo: TypeInfo.TestSuiteReferenceWithProject
-    },
-    cloneOperationResponse: {
-        typeInfo: TypeInfo.CloneOperationCommonResponse
-    },
-    destinationTestSuite: {
-        typeInfo: TypeInfo.TestSuiteReferenceWithProject
-    },
-    sourceTestSuite: {
-        typeInfo: TypeInfo.TestSuiteReferenceWithProject
-    }
-};
-
-TypeInfo.DestinationTestPlanCloneParams.fields = {
-    endDate: {
-        isDate: true,
-    },
-    startDate: {
-        isDate: true,
-    }
-};
-
-TypeInfo.LibraryWorkItemsData.fields = {
-    returnCode: {
-        enumType: TypeInfo.LibraryTestCasesDataReturnCode
-    }
-};
-
-TypeInfo.LibraryWorkItemsDataProviderRequest.fields = {
-    filterValues: {
-        isArray: true,
-        typeInfo: TypeInfo.TestPlansLibraryWorkItemFilter
-    },
-    libraryQueryType: {
-        enumType: TypeInfo.TestPlansLibraryQuery
-    }
-};
-
-TypeInfo.Results.fields = {
-    outcome: {
-        enumType: TypeInfo.Outcome
-    }
-};
-
-TypeInfo.SourceTestplanResponse.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    }
-};
-
-TypeInfo.SourceTestSuiteResponse.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    }
-};
-
-TypeInfo.SuiteEntry.fields = {
-    suiteEntryType: {
-        enumType: TypeInfo.SuiteEntryTypes
-    }
-};
-
-TypeInfo.SuiteEntryUpdateParams.fields = {
-    suiteEntryType: {
-        enumType: TypeInfo.SuiteEntryTypes
-    }
-};
-
-TypeInfo.TestCase.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    }
-};
-
-TypeInfo.TestCaseAssociatedResult.fields = {
-    completedDate: {
-        isDate: true,
-    },
-    outcome: {
-        enumType: TypeInfo.UserFriendlyTestOutcome
-    }
-};
-
-TypeInfo.TestCaseResultsData.fields = {
-    results: {
-        isArray: true,
-        typeInfo: TypeInfo.TestCaseAssociatedResult
-    }
-};
-
-TypeInfo.TestConfiguration.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    },
-    state: {
-        enumType: TFS_TestManagement_Contracts.TypeInfo.TestConfigurationState
-    }
-};
-
-TypeInfo.TestConfigurationCreateUpdateParameters.fields = {
-    state: {
-        enumType: TFS_TestManagement_Contracts.TypeInfo.TestConfigurationState
-    }
-};
-
-TypeInfo.TestPlan.fields = {
-    endDate: {
-        isDate: true,
-    },
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    },
-    startDate: {
-        isDate: true,
-    },
-    updatedDate: {
-        isDate: true,
-    }
-};
-
-TypeInfo.TestPlanCreateParams.fields = {
-    endDate: {
-        isDate: true,
-    },
-    startDate: {
-        isDate: true,
-    }
-};
-
-TypeInfo.TestPlanDetailedReference.fields = {
-    endDate: {
-        isDate: true,
-    },
-    startDate: {
-        isDate: true,
-    }
-};
-
-TypeInfo.TestPlansHubRefreshData.fields = {
-    testCases: {
-        isArray: true,
-        typeInfo: TypeInfo.TestCase
-    },
-    testPlan: {
-        typeInfo: TypeInfo.TestPlanDetailedReference
-    },
-    testPoints: {
-        isArray: true,
-        typeInfo: TypeInfo.TestPoint
-    },
-    testSuites: {
-        isArray: true,
-        typeInfo: TypeInfo.TestSuite
-    }
-};
-
-TypeInfo.TestPlansLibraryWorkItemFilter.fields = {
-    filterMode: {
-        enumType: TypeInfo.TestPlansLibraryWorkItemFilterMode
-    }
-};
-
-TypeInfo.TestPlanUpdateParams.fields = {
-    endDate: {
-        isDate: true,
-    },
-    startDate: {
-        isDate: true,
-    }
-};
-
-TypeInfo.TestPoint.fields = {
-    lastResetToActive: {
-        isDate: true,
-    },
-    lastUpdatedDate: {
-        isDate: true,
-    },
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    },
-    results: {
-        typeInfo: TypeInfo.TestPointResults
-    }
-};
-
-TypeInfo.TestPointResults.fields = {
-    failureType: {
-        enumType: TypeInfo.FailureType
-    },
-    lastResolutionState: {
-        enumType: TypeInfo.LastResolutionState
-    },
-    lastResultDetails: {
-        typeInfo: TFS_TestManagement_Contracts.TypeInfo.LastResultDetails
-    },
-    lastResultState: {
-        enumType: TypeInfo.ResultState
-    },
-    outcome: {
-        enumType: TypeInfo.Outcome
-    },
-    state: {
-        enumType: TypeInfo.PointState
-    }
-};
-
-TypeInfo.TestPointUpdateParams.fields = {
-    results: {
-        typeInfo: TypeInfo.Results
-    }
-};
-
-TypeInfo.TestSuite.fields = {
-    children: {
-        isArray: true,
-        typeInfo: TypeInfo.TestSuite
-    },
-    lastPopulatedDate: {
-        isDate: true,
-    },
-    lastUpdatedDate: {
-        isDate: true,
-    },
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    },
-    suiteType: {
-        enumType: TypeInfo.TestSuiteType
-    }
-};
-
-TypeInfo.TestSuiteCreateParams.fields = {
-    suiteType: {
-        enumType: TypeInfo.TestSuiteType
-    }
-};
-
-TypeInfo.TestSuiteReferenceWithProject.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    }
-};
-
-TypeInfo.TestVariable.fields = {
-    project: {
-        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
-    }
-};
+}

--- a/api/interfaces/TestPlanInterfaces.ts
+++ b/api/interfaces/TestPlanInterfaces.ts
@@ -1,454 +1,1873 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
-import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
-import basem = require('./ClientApiBases');
-import buildm = require('./BuildApi');
-import corem = require('./CoreApi');
-import dashboardm = require('./DashboardApi');
-import extmgmtm = require("./ExtensionManagementApi");
-import featuremgmtm = require("./FeatureManagementApi");
-import filecontainerm = require('./FileContainerApi');
-import gallerym = require('./GalleryApi');
-import gitm = require('./GitApi');
-import locationsm = require('./LocationsApi');
-import notificationm = require('./NotificationApi');
-import policym = require('./PolicyApi');
-import profilem = require('./ProfileApi');
-import projectm = require('./ProjectAnalysisApi');
-import releasem = require('./ReleaseApi');
-import securityrolesm = require('./SecurityRolesApi');
-import taskagentm = require('./TaskAgentApi');
-import taskm = require('./TaskApi');
-import testm = require('./TestApi');
-import testplanm = require('./TestPlanApi')
-import testresultsm = require('./TestResultsApi');
-import tfvcm = require('./TfvcApi');
-import wikim = require('./WikiApi');
-import workm = require('./WorkApi');
-import workitemtrackingm = require('./WorkItemTrackingApi');
-import workitemtrackingprocessm = require('./WorkItemTrackingProcessApi');
-import workitemtrackingprocessdefinitionm = require('./WorkItemTrackingProcessDefinitionsApi');
-import basicm = require('./handlers/basiccreds');
-import bearm = require('./handlers/bearertoken');
-import ntlmm = require('./handlers/ntlm');
-import patm = require('./handlers/personalaccesstoken');
-
-import * as rm from 'typed-rest-client/RestClient';
-import vsom = require('./VsoClient');
-import lim = require("./interfaces/LocationsInterfaces");
-
-import crypto = require('crypto');
-import fs = require('fs');
-import os = require('os');
-import url = require('url');
-import path = require('path');
-
-const isBrowser: boolean = typeof window !== 'undefined';
-/**
- * Methods to return handler objects (see handlers folder)
+/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
  */
 
-export function getBasicHandler(username: string, password: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
-    return new basicm.BasicCredentialHandler(username, password, allowCrossOriginAuthentication);
+"use strict";
+
+import TFS_TestManagement_Contracts = require("../interfaces/TestInterfaces");
+import TfsCoreInterfaces = require("../interfaces/CoreInterfaces");
+import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
+
+
+/**
+ * The build definition reference resource
+ */
+export interface BuildDefinitionReference {
+    /**
+     * ID of the build definition
+     */
+    id?: number;
+    /**
+     * Name of the build definition
+     */
+    name?: string;
 }
 
-export function getNtlmHandler(username: string, password: string, workstation?: string, domain?: string): VsoBaseInterfaces.IRequestHandler {
-    return new ntlmm.NtlmCredentialHandler(username, password, workstation, domain);
+/**
+ * Common Response for clone operation
+ */
+export interface CloneOperationCommonResponse {
+    /**
+     * Various statistics related to the clone operation
+     */
+    cloneStatistics?: TFS_TestManagement_Contracts.CloneStatistics;
+    /**
+     * Completion data of the operation
+     */
+    completionDate?: Date;
+    /**
+     * Creation data of the operation
+     */
+    creationDate?: Date;
+    /**
+     * Reference links
+     */
+    links?: any;
+    /**
+     * Message related to the job
+     */
+    message?: string;
+    /**
+     * Clone operation Id
+     */
+    opId: number;
+    /**
+     * Clone operation state
+     */
+    state?: TFS_TestManagement_Contracts.CloneOperationState;
 }
 
-export function getBearerHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
-    return new bearm.BearerCredentialHandler(token, allowCrossOriginAuthentication);
+export interface CloneTestCaseOperationInformation {
+    /**
+     * Various information related to the clone
+     */
+    cloneOperationResponse: CloneOperationCommonResponse;
+    /**
+     * Test Plan Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneTestCaseOptions;
+    /**
+     * Information of destination Test Suite
+     */
+    destinationTestSuite: TestSuiteReferenceWithProject;
+    /**
+     * Information of source Test Suite
+     */
+    sourceTestSuite: SourceTestSuiteResponse;
 }
 
-export function getPersonalAccessTokenHandler(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
-    return new patm.PersonalAccessTokenCredentialHandler(token, allowCrossOriginAuthentication);
+/**
+ * Parameters for Test Suite clone operation
+ */
+export interface CloneTestCaseParams {
+    /**
+     * Test Case Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneTestCaseOptions;
+    /**
+     * Information about destination Test Plan
+     */
+    destinationTestPlan: TestPlanReference;
+    /**
+     * Information about destination Test Suite
+     */
+    destinationTestSuite: DestinationTestSuiteInfo;
+    /**
+     * Information about source Test Plan
+     */
+    sourceTestPlan: TestPlanReference;
+    /**
+     * Information about source Test Suite
+     */
+    sourceTestSuite: SourceTestSuiteInfo;
+    /**
+     * Test Case IDs
+     */
+    testCaseIds?: number[];
 }
 
-export function getHandlerFromToken(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
-    if (token.length === 52) {
-        return getPersonalAccessTokenHandler(token, allowCrossOriginAuthentication);
-    }
-    else {
-        return getBearerHandler(token, allowCrossOriginAuthentication);
-    }
+/**
+ * Response for Test Plan clone operation
+ */
+export interface CloneTestPlanOperationInformation {
+    /**
+     * Various information related to the clone
+     */
+    cloneOperationResponse: CloneOperationCommonResponse;
+    /**
+     * Test Plan Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
+    /**
+     * Information of destination Test Plan
+     */
+    destinationTestPlan: TestPlan;
+    /**
+     * Information of source Test Plan
+     */
+    sourceTestPlan: SourceTestplanResponse;
 }
 
-export interface IWebApiRequestSettings {
-    productName: string,
-    productVersion: string
+/**
+ * Parameters for Test Plan clone operation
+ */
+export interface CloneTestPlanParams {
+    /**
+     * Test Plan Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
+    /**
+     * Information about destination Test Plan
+     */
+    destinationTestPlan: DestinationTestPlanCloneParams;
+    /**
+     * Information about source Test Plan
+     */
+    sourceTestPlan: SourceTestPlanInfo;
+}
+
+/**
+ * Response for Test Suite clone operation
+ */
+export interface CloneTestSuiteOperationInformation {
+    /**
+     * Information of newly cloned Test Suite
+     */
+    clonedTestSuite?: TestSuiteReferenceWithProject;
+    /**
+     * Various information related to the clone
+     */
+    cloneOperationResponse: CloneOperationCommonResponse;
+    /**
+     * Test Plan Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
+    /**
+     * Information of destination Test Suite
+     */
+    destinationTestSuite: TestSuiteReferenceWithProject;
+    /**
+     * Information of source Test Suite
+     */
+    sourceTestSuite: TestSuiteReferenceWithProject;
+}
+
+/**
+ * Parameters for Test Suite clone operation
+ */
+export interface CloneTestSuiteParams {
+    /**
+     * Test Plan Clone create parameters
+     */
+    cloneOptions?: TFS_TestManagement_Contracts.CloneOptions;
+    /**
+     * Information about destination Test Suite
+     */
+    destinationTestSuite: DestinationTestSuiteInfo;
+    /**
+     * Information about source Test Suite
+     */
+    sourceTestSuite: SourceTestSuiteInfo;
+}
+
+/**
+ * Configuration of the Test Point
+ */
+export interface Configuration {
+    /**
+     * Id of the Configuration Assigned to the Test Point
+     */
+    configurationId?: number;
+}
+
+/**
+ * Destination Test Plan create parameters
+ */
+export interface DestinationTestPlanCloneParams extends TestPlanCreateParams {
+    /**
+     * Destination Project Name
+     */
+    project?: string;
+}
+
+/**
+ * Destination Test Suite information for Test Suite clone operation
+ */
+export interface DestinationTestSuiteInfo {
+    /**
+     * Destination Suite Id
+     */
+    id: number;
+    /**
+     * Destination Project Name
+     */
+    project?: string;
+}
+
+/**
+ * Exclude Flags for suite test case object. Exclude Flags exclude various objects from payload depending on the value passed
+ */
+export enum ExcludeFlags {
+    /**
+     * To exclude nothing
+     */
+    None = 0,
+    /**
+     * To exclude point assignments, pass exclude = 1
+     */
+    PointAssignments = 1,
+    /**
+     * To exclude extra information (links, test plan, test suite), pass exclude = 2
+     */
+    ExtraInformation = 2,
+}
+
+/**
+ * Parameters for test case export operation
+ */
+export interface ExportTestCaseParams {
+    /**
+     * Test Case IDs to exported
+     */
+    testCaseIds: number[];
+    /**
+     * ID of test plan containing test cases
+     */
+    testPlanId: number;
+    /**
+     * ID of test suite containing test cases
+     */
+    testSuiteId: number;
+}
+
+export enum FailureType {
+    None = 0,
+    Regression = 1,
+    New_Issue = 2,
+    Known_Issue = 3,
+    Unknown = 4,
+    Null_Value = 5,
+    MaxValue = 5,
+}
+
+export enum LastResolutionState {
+    None = 0,
+    NeedsInvestigation = 1,
+    TestIssue = 2,
+    ProductIssue = 3,
+    ConfigurationIssue = 4,
+    NullValue = 5,
+    MaxValue = 5,
+}
+
+/**
+ * Enum representing the return code of data provider.
+ */
+export enum LibraryTestCasesDataReturnCode {
+    Success = 0,
+    Error = 1,
+}
+
+/**
+ * This data model is used in Work item-based tabs of Test Plans Library.
+ */
+export interface LibraryWorkItemsData {
+    /**
+     * Specifies the column option field names
+     */
+    columnOptions?: string[];
+    /**
+     * Continuation token to fetch next set of elements. Present only when HasMoreElements is true.
+     */
+    continuationToken?: string;
+    /**
+     * Boolean indicating if the WIQL query has exceeded the limit of items returned.
+     */
+    exceededWorkItemQueryLimit: boolean;
+    /**
+     * Boolean indicating if there are more elements present than what are being sent.
+     */
+    hasMoreElements: boolean;
+    /**
+     * Specifies if there was an error while execution of data provider.
+     */
+    returnCode: LibraryTestCasesDataReturnCode;
+    /**
+     * List of work items returned when OrderByField is sent something other than Id.
+     */
+    workItemIds?: number[];
+    /**
+     * List of work items to be returned.
+     */
+    workItems: WorkItemDetails[];
+}
+
+/**
+ * This is the request data contract for LibraryTestCaseDataProvider.
+ */
+export interface LibraryWorkItemsDataProviderRequest {
+    /**
+     * Specifies the list of column options to show in test cases table.
+     */
+    columnOptions?: string[];
+    /**
+     * The continuation token required for paging of work items. This is required when getting subsequent sets of work items when OrderByField is Id.
+     */
+    continuationToken?: string;
+    /**
+     * List of filter values to be supplied. Currently supported filters are Title, State, AssignedTo, Priority, AreaPath.
+     */
+    filterValues?: TestPlansLibraryWorkItemFilter[];
+    /**
+     * Whether the data is to be sorted in ascending or descending order. When not supplied, defaults to descending.
+     */
+    isAscending?: boolean;
+    /**
+     * The type of query to run.
+     */
+    libraryQueryType?: TestPlansLibraryQuery;
+    /**
+     * Work item field on which to order the results. When not supplied, defaults to work item IDs.
+     */
+    orderByField?: string;
+    /**
+     * List of work items to query for field details. This is required when getting subsequent sets of work item fields when OrderByField is other than Id.
+     */
+    workItemIds?: number[];
+}
+
+export enum Outcome {
+    /**
+     * Only used during an update to preserve the existing value.
+     */
+    Unspecified = 0,
+    /**
+     * Test has not been completed, or the test type does not report pass/failure.
+     */
+    None = 1,
+    /**
+     * Test was executed w/o any issues.
+     */
+    Passed = 2,
+    /**
+     * Test was executed, but there were issues. Issues may involve exceptions or failed assertions.
+     */
+    Failed = 3,
+    /**
+     * Test has completed, but we can't say if it passed or failed. May be used for aborted tests...
+     */
+    Inconclusive = 4,
+    /**
+     * The test timed out
+     */
+    Timeout = 5,
+    /**
+     * Test was aborted. This was not caused by a user gesture, but rather by a framework decision.
+     */
+    Aborted = 6,
+    /**
+     * Test had it chance for been executed but was not, as ITestElement.IsRunnable == false.
+     */
+    Blocked = 7,
+    /**
+     * Test was not executed. This was caused by a user gesture - e.g. user hit stop button.
+     */
+    NotExecuted = 8,
+    /**
+     * To be used by Run level results. This is not a failure.
+     */
+    Warning = 9,
+    /**
+     * There was a system error while we were trying to execute a test.
+     */
+    Error = 10,
+    /**
+     * Test is Not Applicable for execution.
+     */
+    NotApplicable = 11,
+    /**
+     * Test is paused.
+     */
+    Paused = 12,
+    /**
+     * Test is currently executing. Added this for TCM charts
+     */
+    InProgress = 13,
+    /**
+     * Test is not impacted. Added fot TIA.
+     */
+    NotImpacted = 14,
+    MaxValue = 14,
+}
+
+/**
+ * Assignments for the Test Point
+ */
+export interface PointAssignment extends Configuration {
+    /**
+     * Name of the Configuration Assigned to the Test Point
+     */
+    configurationName?: string;
+    /**
+     * Id of the Test Point
+     */
+    id?: number;
+    /**
+     * Tester Assigned to the Test Point
+     */
+    tester?: VSSInterfaces.IdentityRef;
+}
+
+export enum PointState {
+    /**
+     * Default
+     */
+    None = 0,
+    /**
+     * The test point needs to be executed in order for the test pass to be considered complete.  Either the test has not been run before or the previous run failed.
+     */
+    Ready = 1,
+    /**
+     * The test has passed successfully and does not need to be re-run for the test pass to be considered complete.
+     */
+    Completed = 2,
+    /**
+     * The test point needs to be executed but is not able to.
+     */
+    NotReady = 3,
+    /**
+     * The test is being executed.
+     */
+    InProgress = 4,
+    MaxValue = 4,
+}
+
+/**
+ * Results class for Test Point
+ */
+export interface Results {
+    /**
+     * Outcome of the Test Point
+     */
+    outcome?: Outcome;
+}
+
+export enum ResultState {
+    /**
+     * Only used during an update to preserve the existing value.
+     */
+    Unspecified = 0,
+    /**
+     * Test is in the execution queue, was not started yet.
+     */
+    Pending = 1,
+    /**
+     * Test has been queued. This is applicable when a test case is queued for execution
+     */
+    Queued = 2,
+    /**
+     * Test is currently executing.
+     */
+    InProgress = 3,
+    /**
+     * Test has been paused. This is applicable when a test case is paused by the user (For e.g. Manual Tester can pause the execution of the manual test case)
+     */
+    Paused = 4,
+    /**
+     * Test has completed, but there is no quantitative measure of completeness. This may apply to load tests.
+     */
+    Completed = 5,
+    MaxValue = 5,
+}
+
+/**
+ * Source Test Plan information for Test Plan clone operation
+ */
+export interface SourceTestPlanInfo {
+    /**
+     * ID of the source Test Plan
+     */
+    id: number;
+    /**
+     * Id of suites to be cloned inside source Test Plan
+     */
+    suiteIds?: number[];
+}
+
+/**
+ * Source Test Plan Response for Test Plan clone operation
+ */
+export interface SourceTestplanResponse extends TestPlanReference {
+    /**
+     * project reference
+     */
+    project: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Id of suites to be cloned inside source Test Plan
+     */
+    suiteIds?: number[];
+}
+
+/**
+ * Source Test Suite information for Test Suite clone operation
+ */
+export interface SourceTestSuiteInfo {
+    /**
+     * Id of the Source Test Suite
+     */
+    id: number;
+}
+
+/**
+ * Source Test Suite Response for Test Case clone operation
+ */
+export interface SourceTestSuiteResponse extends TestSuiteReference {
+    /**
+     * project reference
+     */
+    project: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Id of suites to be cloned inside source Test Plan
+     */
+    testCaseIds?: number[];
+}
+
+/**
+ * A suite entry defines properties for a test suite.
+ */
+export interface SuiteEntry extends SuiteEntryUpdateParams {
+    /**
+     * Id for the test suite.
+     */
+    suiteId?: number;
+}
+
+export enum SuiteEntryTypes {
+    /**
+     * Test Case
+     */
+    TestCase = 0,
+    /**
+     * Child Suite
+     */
+    Suite = 1,
+}
+
+/**
+ * A suite entry defines properties for a test suite.
+ */
+export interface SuiteEntryUpdateParams {
+    /**
+     * Id of the suite entry in the test suite: either a test case id or child suite id.
+     */
+    id?: number;
+    /**
+     * Sequence number for the suite entry object in the test suite.
+     */
+    sequenceNumber?: number;
+    /**
+     * Defines whether the entry is of type test case or suite.
+     */
+    suiteEntryType?: SuiteEntryTypes;
+}
+
+/**
+ * Option to get details in response
+ */
+export enum SuiteExpand {
+    /**
+     * Dont include any of the expansions in output.
+     */
+    None = 0,
+    /**
+     * Include children in response.
+     */
+    Children = 1,
+    /**
+     * Include default testers in response.
+     */
+    DefaultTesters = 2,
+}
+
+/**
+ * Create and Update Suite Test Case Parameters
+ */
+export interface SuiteTestCaseCreateUpdateParameters {
+    /**
+     * Configurations Ids
+     */
+    pointAssignments?: Configuration[];
+    /**
+     * Id of Test Case to be updated or created
+     */
+    workItem?: WorkItem;
+}
+
+/**
+ * Test Case Class
+ */
+export interface TestCase {
+    /**
+     * Reference links
+     */
+    links: any;
+    /**
+     * Order of the TestCase in the Suite
+     */
+    order?: number;
+    /**
+     * List of Points associated with the Test Case
+     */
+    pointAssignments?: PointAssignment[];
+    /**
+     * Project under which the Test Case is
+     */
+    project?: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Test Plan under which the Test Case is
+     */
+    testPlan?: TestPlanReference;
+    /**
+     * Test Suite under which the Test Case is
+     */
+    testSuite?: TestSuiteReference;
+    /**
+     * Work Item details of the TestCase
+     */
+    workItem?: WorkItemDetails;
+}
+
+export interface TestCaseAssociatedResult {
+    completedDate: Date;
+    configuration: TestConfigurationReference;
+    outcome: UserFriendlyTestOutcome;
+    plan: TestPlanReference;
+    pointId?: number;
+    resultId: number;
+    runBy: VSSInterfaces.IdentityRef;
+    runId: number;
+    suite: TestSuiteReference;
+    tester: VSSInterfaces.IdentityRef;
+}
+
+/**
+ * Test Case Reference
+ */
+export interface TestCaseReference {
+    /**
+     * Identity to whom the test case is assigned
+     */
+    assignedTo?: VSSInterfaces.IdentityRef;
+    /**
+     * Test Case Id
+     */
+    id: number;
+    /**
+     * Test Case Name
+     */
+    name: string;
+    /**
+     * State of the test case work item
+     */
+    state?: string;
+}
+
+/**
+ * This data model is used in TestCaseResultsDataProvider and populates the data required for initial page load
+ */
+export interface TestCaseResultsData {
+    /**
+     * Point information from where the execution history was viewed. Used to set initial filters.
+     */
+    contextPoint?: TestPointDetailedReference;
+    /**
+     * Use to store the results displayed in the table
+     */
+    results: TestCaseAssociatedResult[];
+    /**
+     * Test Case Name to be displayed in the table header
+     */
+    testCaseName: string;
+}
+
+/**
+ * Test configuration
+ */
+export interface TestConfiguration extends TestConfigurationCreateUpdateParameters {
+    /**
+     * Id of the configuration
+     */
+    id: number;
+    /**
+     * Id of the test configuration variable
+     */
+    project?: TfsCoreInterfaces.TeamProjectReference;
+}
+
+/**
+ * Test Configuration Create or Update Parameters
+ */
+export interface TestConfigurationCreateUpdateParameters {
+    /**
+     * Description of the configuration
+     */
+    description?: string;
+    /**
+     * Is the configuration a default for the test plans
+     */
+    isDefault?: boolean;
+    /**
+     * Name of the configuration
+     */
+    name: string;
+    /**
+     * State of the configuration
+     */
+    state?: TFS_TestManagement_Contracts.TestConfigurationState;
+    /**
+     * Dictionary of Test Variable, Selected Value
+     */
+    values?: TFS_TestManagement_Contracts.NameValuePair[];
+}
+
+/**
+ * Test Configuration Reference
+ */
+export interface TestConfigurationReference {
+    /**
+     * Id of the configuration
+     */
+    id: number;
+    /**
+     * Name of the configuration
+     */
+    name: string;
+}
+
+/**
+ * Test Entity Count Used to store test cases count (define tab) and test point count (execute tab) Used to store test cases count (define tab) and test point count (execute tab)
+ */
+export interface TestEntityCount {
+    /**
+     * Test Entity Count
+     */
+    count?: number;
+    /**
+     * Test Plan under which the Test Entities are
+     */
+    testPlanId?: number;
+    /**
+     * Test Suite under which the Test Entities are
+     */
+    testSuiteId?: number;
+    /**
+     * Total test entities in the suite without the applied filters
+     */
+    totalCount?: number;
+}
+
+export enum TestEntityTypes {
+    TestCase = 0,
+    TestPoint = 1,
+}
+
+/**
+ * The test plan resource.
+ */
+export interface TestPlan extends TestPlanUpdateParams {
+    /**
+     * Relevant links
+     */
+    _links: any;
+    /**
+     * ID of the test plan.
+     */
+    id: number;
+    /**
+     * Previous build Id associated with the test plan
+     */
+    previousBuildId?: number;
+    /**
+     * Project which contains the test plan.
+     */
+    project?: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Root test suite of the test plan.
+     */
+    rootSuite: TestSuiteReference;
+    /**
+     * Identity Reference for the last update of the test plan
+     */
+    updatedBy?: VSSInterfaces.IdentityRef;
+    /**
+     * Updated date of the test plan
+     */
+    updatedDate?: Date;
+}
+
+/**
+ * The test plan create parameters.
+ */
+export interface TestPlanCreateParams {
+    /**
+     * Area of the test plan.
+     */
+    areaPath?: string;
+    automatedTestEnvironment?: TFS_TestManagement_Contracts.TestEnvironment;
+    automatedTestSettings?: TFS_TestManagement_Contracts.TestSettings;
+    /**
+     * The Build Definition that generates a build associated with this test plan.
+     */
+    buildDefinition?: BuildDefinitionReference;
+    /**
+     * Build to be tested.
+     */
+    buildId?: number;
+    /**
+     * Description of the test plan.
+     */
+    description?: string;
+    /**
+     * End date for the test plan.
+     */
+    endDate?: Date;
+    /**
+     * Iteration path of the test plan.
+     */
+    iteration: string;
+    manualTestEnvironment?: TFS_TestManagement_Contracts.TestEnvironment;
+    manualTestSettings?: TFS_TestManagement_Contracts.TestSettings;
+    /**
+     * Name of the test plan.
+     */
+    name: string;
+    /**
+     * Owner of the test plan.
+     */
+    owner?: VSSInterfaces.IdentityRef;
+    /**
+     * Release Environment to be used to deploy the build and run automated tests from this test plan.
+     */
+    releaseEnvironmentDefinition?: TFS_TestManagement_Contracts.ReleaseEnvironmentDefinitionReference;
+    /**
+     * Start date for the test plan.
+     */
+    startDate?: Date;
+    /**
+     * State of the test plan.
+     */
+    state?: string;
+    /**
+     * Value to configure how same tests across test suites under a test plan need to behave
+     */
+    testOutcomeSettings?: TFS_TestManagement_Contracts.TestOutcomeSettings;
+}
+
+/**
+ * The test plan detailed reference resource. Contains additional workitem realted information
+ */
+export interface TestPlanDetailedReference extends TestPlanReference {
+    /**
+     * Area of the test plan.
+     */
+    areaPath?: string;
+    /**
+     * End date for the test plan.
+     */
+    endDate?: Date;
+    /**
+     * Iteration path of the test plan.
+     */
+    iteration?: string;
+    /**
+     * Root Suite Id
+     */
+    rootSuiteId: number;
+    /**
+     * Start date for the test plan.
+     */
+    startDate?: Date;
+}
+
+/**
+ * The test plan reference resource.
+ */
+export interface TestPlanReference {
+    /**
+     * ID of the test plan.
+     */
+    id: number;
+    /**
+     * Name of the test plan.
+     */
+    name: string;
+}
+
+/**
+ * This data model is used in TestPlansHubRefreshDataProvider and populates the data required for initial page load
+ */
+export interface TestPlansHubRefreshData {
+    defineColumnOptionFields?: string[];
+    defineTabCustomColumnFieldMap?: { [key: string]: string; };
+    errorMessage?: string;
+    executeColumnOptionFields?: string[];
+    executeTabCustomColumnFieldMap?: { [key: string]: string; };
+    isAdvancedExtensionEnabled?: boolean;
+    selectedPivotId?: string;
+    selectedSuiteId?: number;
+    testCasePageSize: number;
+    testCases?: TestCase[];
+    testCasesContinuationToken?: string;
+    testPlan: TestPlanDetailedReference;
+    testPointPageSize: number;
+    testPoints?: TestPoint[];
+    testPointsContinuationToken?: string;
+    testSuites: TestSuite[];
+    testSuitesContinuationToken?: string;
+}
+
+/**
+ * Enum used to define the queries used in Test Plans Library.
+ */
+export enum TestPlansLibraryQuery {
+    None = 0,
+    AllTestCases = 1,
+    TestCasesWithActiveBugs = 2,
+    TestCasesNotLinkedToRequirements = 3,
+    TestCasesLinkedToRequirements = 4,
+    AllSharedSteps = 11,
+    SharedStepsNotLinkedToRequirement = 12,
+}
+
+/**
+ * Container to hold information about a filter being applied in Test Plans Library.
+ */
+export interface TestPlansLibraryWorkItemFilter {
+    /**
+     * Work item field name on which the items are to be filtered.
+     */
+    fieldName: string;
+    /**
+     * Work item field values corresponding to the field name.
+     */
+    fieldValues: string[];
+    /**
+     * Mode of the filter.
+     */
+    filterMode?: TestPlansLibraryWorkItemFilterMode;
+}
+
+export enum TestPlansLibraryWorkItemFilterMode {
+    /**
+     * Default. Have the field values separated by an OR clause.
+     */
+    Or = 0,
+    /**
+     * Have the field values separated by an AND clause.
+     */
+    And = 1,
+}
+
+/**
+ * The test plan update parameters.
+ */
+export interface TestPlanUpdateParams extends TestPlanCreateParams {
+    /**
+     * Revision of the test plan.
+     */
+    revision?: number;
+}
+
+/**
+ * Test Point Class
+ */
+export interface TestPoint {
+    /**
+     * Comment associated to the Test Point
+     */
+    comment?: string;
+    /**
+     * Configuration associated with the Test Point
+     */
+    configuration: TestConfigurationReference;
+    /**
+     * Id of the Test Point
+     */
+    id: number;
+    /**
+     * Variable to decide whether the test case is Active or not
+     */
+    isActive: boolean;
+    /**
+     * Is the Test Point for Automated Test Case or Manual
+     */
+    isAutomated?: boolean;
+    /**
+     * Last Reset to Active Time Stamp for the Test Point
+     */
+    lastResetToActive?: Date;
+    /**
+     * Last Updated details for the Test Point
+     */
+    lastUpdatedBy: VSSInterfaces.IdentityRef;
+    /**
+     * Last Update Time Stamp for the Test Point
+     */
+    lastUpdatedDate: Date;
+    /**
+     * Reference links
+     */
+    links: any;
+    /**
+     * Project under which the Test Point is
+     */
+    project: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Results associated to the Test Point
+     */
+    results: TestPointResults;
+    /**
+     * Test Case Reference
+     */
+    testCaseReference: TestCaseReference;
+    /**
+     * Tester associated with the Test Point
+     */
+    tester?: VSSInterfaces.IdentityRef;
+    /**
+     * Test Plan under which the Test Point is
+     */
+    testPlan: TestPlanReference;
+    /**
+     * Test Suite under which the Test Point is
+     */
+    testSuite: TestSuiteReference;
+}
+
+export interface TestPointDetailedReference {
+    configuration: TestConfigurationReference;
+    plan: TestPlanReference;
+    pointId?: number;
+    suite: TestSuiteReference;
+    tester: VSSInterfaces.IdentityRef;
+}
+
+/**
+ * Test Point Results
+ */
+export interface TestPointResults {
+    /**
+     * Failure Type for the Test Point
+     */
+    failureType?: FailureType;
+    /**
+     * Last Resolution State Id for the Test Point
+     */
+    lastResolutionState?: LastResolutionState;
+    /**
+     * Last Result Details for the Test Point
+     */
+    lastResultDetails?: TFS_TestManagement_Contracts.LastResultDetails;
+    /**
+     * Last Result Id
+     */
+    lastResultId?: number;
+    /**
+     * Last Result State of the Test Point
+     */
+    lastResultState?: ResultState;
+    /**
+     * Last RUn Build Number for the Test Point
+     */
+    lastRunBuildNumber?: string;
+    /**
+     * Last Test Run Id for the Test Point
+     */
+    lastTestRunId?: number;
+    /**
+     * Outcome of the Test Point
+     */
+    outcome: Outcome;
+    /**
+     * State of the Test Point
+     */
+    state?: PointState;
+}
+
+/**
+ * Test Point Update Parameters
+ */
+export interface TestPointUpdateParams {
+    /**
+     * Id of Test Point to be updated
+     */
+    id?: number;
+    /**
+     * Reset the Test Point to Active
+     */
+    isActive?: boolean;
+    /**
+     * Results of the test point
+     */
+    results?: Results;
+    /**
+     * Tester of the Test Point
+     */
+    tester?: VSSInterfaces.IdentityRef;
+}
+
+/**
+ * Test suite
+ */
+export interface TestSuite extends TestSuiteCreateParams {
+    /**
+     * Links: self, testPoints, testCases, parent
+     */
+    _links: any;
+    /**
+     * Child test suites of current test suite.
+     */
+    children?: TestSuite[];
+    /**
+     * Boolean value dictating if Child test suites are present
+     */
+    hasChildren?: boolean;
+    /**
+     * Id of test suite.
+     */
+    id: number;
+    /**
+     * Last error for test suite.
+     */
+    lastError?: string;
+    /**
+     * Last populated date.
+     */
+    lastPopulatedDate?: Date;
+    /**
+     * IdentityRef of user who has updated test suite recently.
+     */
+    lastUpdatedBy?: VSSInterfaces.IdentityRef;
+    /**
+     * Last update date.
+     */
+    lastUpdatedDate?: Date;
+    /**
+     * Test plan to which the test suite belongs.
+     */
+    plan: TestPlanReference;
+    /**
+     * Test suite project shallow reference.
+     */
+    project?: TfsCoreInterfaces.TeamProjectReference;
+    /**
+     * Test suite revision.
+     */
+    revision?: number;
+}
+
+/**
+ * Test suite Create Parameters
+ */
+export interface TestSuiteCreateParams extends TestSuiteCreateUpdateCommonParams {
+    /**
+     * Test suite requirement id.
+     */
+    requirementId?: number;
+    /**
+     * Test suite type.
+     */
+    suiteType?: TestSuiteType;
+}
+
+/**
+ * Test Suite Create/Update Common Parameters
+ */
+export interface TestSuiteCreateUpdateCommonParams {
+    /**
+     * Test suite default configurations.
+     */
+    defaultConfigurations?: TestConfigurationReference[];
+    /**
+     * Test suite default testers.
+     */
+    defaultTesters?: VSSInterfaces.IdentityRef[];
+    /**
+     * Default configuration was inherited or not.
+     */
+    inheritDefaultConfigurations?: boolean;
+    /**
+     * Name of test suite.
+     */
+    name: string;
+    /**
+     * Test suite parent shallow reference.
+     */
+    parentSuite?: TestSuiteReference;
+    /**
+     * Test suite query string, for dynamic suites.
+     */
+    queryString?: string;
+}
+
+/**
+ * The test suite reference resource.
+ */
+export interface TestSuiteReference {
+    /**
+     * ID of the test suite.
+     */
+    id: number;
+    /**
+     * Name of the test suite.
+     */
+    name: string;
+}
+
+/**
+ * Test Suite Reference with Project
+ */
+export interface TestSuiteReferenceWithProject extends TestSuiteReference {
+    /**
+     * Reference of destination Project
+     */
+    project: TfsCoreInterfaces.TeamProjectReference;
+}
+
+/**
+ * Type of TestSuite
+ */
+export enum TestSuiteType {
+    /**
+     * Default suite type
+     */
+    None = 0,
+    /**
+     * Query Based test Suite
+     */
+    DynamicTestSuite = 1,
+    /**
+     * Static Test Suite
+     */
+    StaticTestSuite = 2,
+    /**
+     * Requirement based Test Suite
+     */
+    RequirementTestSuite = 3,
+}
+
+/**
+ * Test Suite Update Parameters
+ */
+export interface TestSuiteUpdateParams extends TestSuiteCreateUpdateCommonParams {
+    /**
+     * Test suite revision.
+     */
+    revision?: number;
+}
+
+/**
+ * Test Variable
+ */
+export interface TestVariable extends TestVariableCreateUpdateParameters {
+    /**
+     * Id of the test variable
+     */
+    id: number;
+    /**
+     * Id of the test variable
+     */
+    project?: TfsCoreInterfaces.TeamProjectReference;
+}
+
+/**
+ * Test Variable Create or Update Parameters
+ */
+export interface TestVariableCreateUpdateParameters {
+    /**
+     * Description of the test variable
+     */
+    description?: string;
+    /**
+     * Name of the test variable
+     */
+    name: string;
+    /**
+     * List of allowed values
+     */
+    values?: string[];
+}
+
+export enum UserFriendlyTestOutcome {
+    InProgress = 0,
+    Blocked = 1,
+    Failed = 2,
+    Passed = 3,
+    Ready = 4,
+    NotApplicable = 5,
+    Paused = 6,
+    Timeout = 7,
+    Warning = 8,
+    Error = 9,
+    NotExecuted = 10,
+    Inconclusive = 11,
+    Aborted = 12,
+    None = 13,
+    NotImpacted = 14,
+    Unspecified = 15,
+    MaxValue = 15,
+}
+
+/**
+ * Work Item
+ */
+export interface WorkItem {
+    /**
+     * Id of the Work Item
+     */
+    id?: number;
+}
+
+/**
+ * Work Item Class
+ */
+export interface WorkItemDetails {
+    /**
+     * Work Item Id
+     */
+    id: number;
+    /**
+     * Work Item Name
+     */
+    name: string;
+    /**
+     * Work Item Fields
+     */
+    workItemFields?: any[];
+}
+
+export var TypeInfo = {
+    CloneOperationCommonResponse: <any>{
+    },
+    CloneTestCaseOperationInformation: <any>{
+    },
+    CloneTestPlanOperationInformation: <any>{
+    },
+    CloneTestPlanParams: <any>{
+    },
+    CloneTestSuiteOperationInformation: <any>{
+    },
+    DestinationTestPlanCloneParams: <any>{
+    },
+    ExcludeFlags: {
+        enumValues: {
+            "none": 0,
+            "pointAssignments": 1,
+            "extraInformation": 2
+        }
+    },
+    FailureType: {
+        enumValues: {
+            "none": 0,
+            "regression": 1,
+            "new_Issue": 2,
+            "known_Issue": 3,
+            "unknown": 4,
+            "null_Value": 5,
+            "maxValue": 5
+        }
+    },
+    LastResolutionState: {
+        enumValues: {
+            "none": 0,
+            "needsInvestigation": 1,
+            "testIssue": 2,
+            "productIssue": 3,
+            "configurationIssue": 4,
+            "nullValue": 5,
+            "maxValue": 5
+        }
+    },
+    LibraryTestCasesDataReturnCode: {
+        enumValues: {
+            "success": 0,
+            "error": 1
+        }
+    },
+    LibraryWorkItemsData: <any>{
+    },
+    LibraryWorkItemsDataProviderRequest: <any>{
+    },
+    Outcome: {
+        enumValues: {
+            "unspecified": 0,
+            "none": 1,
+            "passed": 2,
+            "failed": 3,
+            "inconclusive": 4,
+            "timeout": 5,
+            "aborted": 6,
+            "blocked": 7,
+            "notExecuted": 8,
+            "warning": 9,
+            "error": 10,
+            "notApplicable": 11,
+            "paused": 12,
+            "inProgress": 13,
+            "notImpacted": 14,
+            "maxValue": 14
+        }
+    },
+    PointState: {
+        enumValues: {
+            "none": 0,
+            "ready": 1,
+            "completed": 2,
+            "notReady": 3,
+            "inProgress": 4,
+            "maxValue": 4
+        }
+    },
+    Results: <any>{
+    },
+    ResultState: {
+        enumValues: {
+            "unspecified": 0,
+            "pending": 1,
+            "queued": 2,
+            "inProgress": 3,
+            "paused": 4,
+            "completed": 5,
+            "maxValue": 5
+        }
+    },
+    SourceTestplanResponse: <any>{
+    },
+    SourceTestSuiteResponse: <any>{
+    },
+    SuiteEntry: <any>{
+    },
+    SuiteEntryTypes: {
+        enumValues: {
+            "testCase": 0,
+            "suite": 1
+        }
+    },
+    SuiteEntryUpdateParams: <any>{
+    },
+    SuiteExpand: {
+        enumValues: {
+            "none": 0,
+            "children": 1,
+            "defaultTesters": 2
+        }
+    },
+    TestCase: <any>{
+    },
+    TestCaseAssociatedResult: <any>{
+    },
+    TestCaseResultsData: <any>{
+    },
+    TestConfiguration: <any>{
+    },
+    TestConfigurationCreateUpdateParameters: <any>{
+    },
+    TestEntityTypes: {
+        enumValues: {
+            "testCase": 0,
+            "testPoint": 1
+        }
+    },
+    TestPlan: <any>{
+    },
+    TestPlanCreateParams: <any>{
+    },
+    TestPlanDetailedReference: <any>{
+    },
+    TestPlansHubRefreshData: <any>{
+    },
+    TestPlansLibraryQuery: {
+        enumValues: {
+            "none": 0,
+            "allTestCases": 1,
+            "testCasesWithActiveBugs": 2,
+            "testCasesNotLinkedToRequirements": 3,
+            "testCasesLinkedToRequirements": 4,
+            "allSharedSteps": 11,
+            "sharedStepsNotLinkedToRequirement": 12
+        }
+    },
+    TestPlansLibraryWorkItemFilter: <any>{
+    },
+    TestPlansLibraryWorkItemFilterMode: {
+        enumValues: {
+            "or": 0,
+            "and": 1
+        }
+    },
+    TestPlanUpdateParams: <any>{
+    },
+    TestPoint: <any>{
+    },
+    TestPointResults: <any>{
+    },
+    TestPointUpdateParams: <any>{
+    },
+    TestSuite: <any>{
+    },
+    TestSuiteCreateParams: <any>{
+    },
+    TestSuiteReferenceWithProject: <any>{
+    },
+    TestSuiteType: {
+        enumValues: {
+            "none": 0,
+            "dynamicTestSuite": 1,
+            "staticTestSuite": 2,
+            "requirementTestSuite": 3
+        }
+    },
+    TestVariable: <any>{
+    },
+    UserFriendlyTestOutcome: {
+        enumValues: {
+            "inProgress": 0,
+            "blocked": 1,
+            "failed": 2,
+            "passed": 3,
+            "ready": 4,
+            "notApplicable": 5,
+            "paused": 6,
+            "timeout": 7,
+            "warning": 8,
+            "error": 9,
+            "notExecuted": 10,
+            "inconclusive": 11,
+            "aborted": 12,
+            "none": 13,
+            "notImpacted": 14,
+            "unspecified": 15,
+            "maxValue": 15
+        }
+    },
 };
 
-// ---------------------------------------------------------------------------
-// Factory to return client apis
-// When new APIs are added, a method must be added here to instantiate the API
-//----------------------------------------------------------------------------
-export class WebApi {
-
-    public serverUrl: string;
-    public authHandler: VsoBaseInterfaces.IRequestHandler;
-    public rest: rm.RestClient;
-    public vsoClient: vsom.VsoClient;
-    public options: VsoBaseInterfaces.IRequestOptions;
-
-    private _resourceAreas: lim.ResourceAreaInfo[];
-
-    /*
-     * Factory to return client apis and handlers
-     * @param defaultUrl default server url to use when creating new apis from factory methods
-     * @param authHandler default authentication credentials to use when creating new apis from factory methods
-     */
-    constructor(defaultUrl: string, authHandler: VsoBaseInterfaces.IRequestHandler, options?: VsoBaseInterfaces.IRequestOptions, requestSettings?: IWebApiRequestSettings) {
-        this.serverUrl = defaultUrl;
-        this.authHandler = authHandler;
-        this.options = options || {};
-
-        if (!this.isNoProxyHost(this.serverUrl)) {
-            // try to get proxy setting from environment variable set by VSTS-Task-Lib if there is no proxy setting in the options
-            if (!this.options.proxy || !this.options.proxy.proxyUrl) {
-                if (global['_vsts_task_lib_proxy']) {
-                    let proxyFromEnv: VsoBaseInterfaces.IProxyConfiguration = {
-                        proxyUrl: global['_vsts_task_lib_proxy_url'],
-                        proxyUsername: global['_vsts_task_lib_proxy_username'],
-                        proxyPassword: this._readTaskLibSecrets(global['_vsts_task_lib_proxy_password']),
-                        proxyBypassHosts: JSON.parse(global['_vsts_task_lib_proxy_bypass'] || "[]"),
-                    };
-
-                    this.options.proxy = proxyFromEnv;
-                }
-            }
-        }
-
-        // try get cert setting from environment variable set by VSTS-Task-Lib if there is no cert setting in the options
-        if (!this.options.cert) {
-            if (global['_vsts_task_lib_cert']) {
-                let certFromEnv: VsoBaseInterfaces.ICertConfiguration = {
-                    caFile: global['_vsts_task_lib_cert_ca'],
-                    certFile: global['_vsts_task_lib_cert_clientcert'],
-                    keyFile: global['_vsts_task_lib_cert_key'],
-                    passphrase: this._readTaskLibSecrets(global['_vsts_task_lib_cert_passphrase']),
-                };
-
-                this.options.cert = certFromEnv;
-            }
-        }
-
-        // try get ignore SSL error setting from environment variable set by VSTS-Task-Lib if there is no ignore SSL error setting in the options
-        if (!this.options.ignoreSslError) {
-            this.options.ignoreSslError = !!global['_vsts_task_lib_skip_cert_validation'];
-        }
-
-        let userAgent: string;
-        const nodeApiName: string = 'azure-devops-node-api';
-        if(isBrowser) {
-            if(requestSettings) {
-                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
-            } else {
-                userAgent = `${nodeApiName} (${window.navigator.userAgent})`;
-            }
-        } else {
-            let nodeApiVersion: string = 'unknown';
-            const packageJsonPath: string = path.resolve(__dirname, 'package.json');
-            if (fs.existsSync(packageJsonPath)) {
-                nodeApiVersion = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')).version;
-            }
-            const osName: string = os.platform();
-            const osVersion: string = os.release();
-
-            if (requestSettings) {
-                userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
-            }
-            else {
-                userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
-            }
-        }
-        this.rest = new rm.RestClient(userAgent, null, [this.authHandler], this.options);
-        this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
+TypeInfo.CloneOperationCommonResponse.fields = {
+    completionDate: {
+        isDate: true,
+    },
+    creationDate: {
+        isDate: true,
+    },
+    state: {
+        enumType: TFS_TestManagement_Contracts.TypeInfo.CloneOperationState
     }
+};
 
-    /**
-     *  Convenience factory to create with a bearer token.
-     * @param defaultServerUrl default server url to use when creating new apis from factory methods
-     * @param defaultAuthHandler default authentication credentials to use when creating new apis from factory methods
-     */
-    public static createWithBearerToken(defaultUrl: string, token: string, options?: VsoBaseInterfaces.IRequestOptions) {
-        let bearerHandler = getBearerHandler(token);
-        return new this(defaultUrl, bearerHandler, options);
+TypeInfo.CloneTestCaseOperationInformation.fields = {
+    cloneOperationResponse: {
+        typeInfo: TypeInfo.CloneOperationCommonResponse
+    },
+    destinationTestSuite: {
+        typeInfo: TypeInfo.TestSuiteReferenceWithProject
+    },
+    sourceTestSuite: {
+        typeInfo: TypeInfo.SourceTestSuiteResponse
     }
+};
 
-    public async connect(): Promise<lim.ConnectionData> {
-        return new Promise<lim.ConnectionData>(async (resolve, reject) => {
-            try {
-                let res: rm.IRestResponse<lim.ConnectionData>;
-                res = await this.rest.get<lim.ConnectionData>(this.vsoClient.resolveUrl('/_apis/connectionData'));
-                resolve(res.result);
-            }
-            catch (err) {
-                reject(err);
-            }
-        });
+TypeInfo.CloneTestPlanOperationInformation.fields = {
+    cloneOperationResponse: {
+        typeInfo: TypeInfo.CloneOperationCommonResponse
+    },
+    destinationTestPlan: {
+        typeInfo: TypeInfo.TestPlan
+    },
+    sourceTestPlan: {
+        typeInfo: TypeInfo.SourceTestplanResponse
     }
+};
 
-    /**
-     * Each factory method can take a serverUrl and a list of handlers
-     * if these aren't provided, the default url and auth handler given to the constructor for this class will be used
-     */
-    public async getBuildApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<buildm.IBuildApi> {
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, buildm.BuildApi.RESOURCE_AREA_ID);
-        handlers = handlers || [this.authHandler];
-        return new buildm.BuildApi(serverUrl, handlers, this.options);
+TypeInfo.CloneTestPlanParams.fields = {
+    destinationTestPlan: {
+        typeInfo: TypeInfo.DestinationTestPlanCloneParams
     }
+};
 
-    public async getCoreApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<corem.ICoreApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "79134c72-4a58-4b42-976c-04e7115f32bf");
-        handlers = handlers || [this.authHandler];
-        return new corem.CoreApi(serverUrl, handlers, this.options);
+TypeInfo.CloneTestSuiteOperationInformation.fields = {
+    clonedTestSuite: {
+        typeInfo: TypeInfo.TestSuiteReferenceWithProject
+    },
+    cloneOperationResponse: {
+        typeInfo: TypeInfo.CloneOperationCommonResponse
+    },
+    destinationTestSuite: {
+        typeInfo: TypeInfo.TestSuiteReferenceWithProject
+    },
+    sourceTestSuite: {
+        typeInfo: TypeInfo.TestSuiteReferenceWithProject
     }
+};
 
-    public async getDashboardApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<dashboardm.IDashboardApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "31c84e0a-3ece-48fd-a29d-100849af99ba");
-        handlers = handlers || [this.authHandler];
-        return new dashboardm.DashboardApi(serverUrl, handlers, this.options);
+TypeInfo.DestinationTestPlanCloneParams.fields = {
+    endDate: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
     }
+};
 
-    public async getExtensionManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<extmgmtm.IExtensionManagementApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "6c2b0933-3600-42ae-bf8b-93d4f7e83594");
-        handlers = handlers || [this.authHandler];
-        return new extmgmtm.ExtensionManagementApi(serverUrl, handlers, this.options);
+TypeInfo.LibraryWorkItemsData.fields = {
+    returnCode: {
+        enumType: TypeInfo.LibraryTestCasesDataReturnCode
     }
+};
 
-    public async getFeatureManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<featuremgmtm.IFeatureManagementApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
-        handlers = handlers || [this.authHandler];
-        return new featuremgmtm.FeatureManagementApi(serverUrl, handlers, this.options);
+TypeInfo.LibraryWorkItemsDataProviderRequest.fields = {
+    filterValues: {
+        isArray: true,
+        typeInfo: TypeInfo.TestPlansLibraryWorkItemFilter
+    },
+    libraryQueryType: {
+        enumType: TypeInfo.TestPlansLibraryQuery
     }
+};
 
-    public async getFileContainerApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<filecontainerm.IFileContainerApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
-        handlers = handlers || [this.authHandler];
-        return new filecontainerm.FileContainerApi(serverUrl, handlers, this.options);
+TypeInfo.Results.fields = {
+    outcome: {
+        enumType: TypeInfo.Outcome
     }
+};
 
-    public async getGalleryApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gallerym.IGalleryApi> {
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gallerym.GalleryApi.RESOURCE_AREA_ID);
-        handlers = handlers || [this.authHandler];
-        return new gallerym.GalleryApi(serverUrl, handlers, this.options);
+TypeInfo.SourceTestplanResponse.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
     }
+};
 
-    public async getGitApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gitm.IGitApi> {
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gitm.GitApi.RESOURCE_AREA_ID);
-        handlers = handlers || [this.authHandler];
-        return new gitm.GitApi(serverUrl, handlers, this.options);
+TypeInfo.SourceTestSuiteResponse.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
     }
+};
 
-    // TODO: Don't call resource area here? Will cause infinite loop?
-    public async getLocationsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<locationsm.ILocationsApi> {
-        let optionsClone: VsoBaseInterfaces.IRequestOptions = Object.assign({}, this.options);
-        optionsClone.allowRetries = true;
-        optionsClone.maxRetries = 5;
-        serverUrl = await serverUrl || this.serverUrl;
-        handlers = handlers || [this.authHandler];
-        return new locationsm.LocationsApi(serverUrl, handlers, optionsClone);
+TypeInfo.SuiteEntry.fields = {
+    suiteEntryType: {
+        enumType: TypeInfo.SuiteEntryTypes
     }
+};
 
-    public async getNotificationApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<notificationm.INotificationApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
-        handlers = handlers || [this.authHandler];
-        return new notificationm.NotificationApi(serverUrl, handlers, this.options);
+TypeInfo.SuiteEntryUpdateParams.fields = {
+    suiteEntryType: {
+        enumType: TypeInfo.SuiteEntryTypes
     }
+};
 
-    public async getPolicyApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<policym.IPolicyApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "fb13a388-40dd-4a04-b530-013a739c72ef");
-        handlers = handlers || [this.authHandler];
-        return new policym.PolicyApi(serverUrl, handlers, this.options);
+TypeInfo.TestCase.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
     }
+};
 
-    public async getProfileApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<profilem.IProfileApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8ccfef3d-2b87-4e99-8ccb-66e343d2daa8");
-        handlers = handlers || [this.authHandler];
-        return new profilem.ProfileApi(serverUrl, handlers, this.options);
+TypeInfo.TestCaseAssociatedResult.fields = {
+    completedDate: {
+        isDate: true,
+    },
+    outcome: {
+        enumType: TypeInfo.UserFriendlyTestOutcome
     }
+};
 
-    public async getProjectAnalysisApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<projectm.IProjectAnalysisApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "7658fa33-b1bf-4580-990f-fac5896773d3");
-        handlers = handlers || [this.authHandler];
-        return new projectm.ProjectAnalysisApi(serverUrl, handlers, this.options);
+TypeInfo.TestCaseResultsData.fields = {
+    results: {
+        isArray: true,
+        typeInfo: TypeInfo.TestCaseAssociatedResult
     }
+};
 
-    public async getSecurityRolesApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<securityrolesm.ISecurityRolesApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
-        handlers = handlers || [this.authHandler];
-        return new securityrolesm.SecurityRolesApi(serverUrl, handlers, this.options);
+TypeInfo.TestConfiguration.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
+    },
+    state: {
+        enumType: TFS_TestManagement_Contracts.TypeInfo.TestConfigurationState
     }
+};
 
-    public async getReleaseApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<releasem.IReleaseApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "efc2f575-36ef-48e9-b672-0c6fb4a48ac5");
-        handlers = handlers || [this.authHandler];
-        return new releasem.ReleaseApi(serverUrl, handlers, this.options);
+TypeInfo.TestConfigurationCreateUpdateParameters.fields = {
+    state: {
+        enumType: TFS_TestManagement_Contracts.TypeInfo.TestConfigurationState
     }
+};
 
-    public async getTaskApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskm.ITaskApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
-        handlers = handlers || [this.authHandler];
-        return new taskm.TaskApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlan.fields = {
+    endDate: {
+        isDate: true,
+    },
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
+    },
+    startDate: {
+        isDate: true,
+    },
+    updatedDate: {
+        isDate: true,
     }
+};
 
-    public async getTaskAgentApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskagentm.ITaskAgentApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd");
-        handlers = handlers || [this.authHandler];
-        return new taskagentm.TaskAgentApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlanCreateParams.fields = {
+    endDate: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
     }
+};
 
-    public async getTestApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testm.ITestApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e");
-        handlers = handlers || [this.authHandler];
-        return new testm.TestApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlanDetailedReference.fields = {
+    endDate: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
     }
+};
 
-    public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testplanm.ITestPlanApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "e4c27205-9d23-4c98-b958-d798bc3f9cd4");
-        handlers = handlers || [this.authHandler];
-        return new testplanm.TestPlanApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlansHubRefreshData.fields = {
+    testCases: {
+        isArray: true,
+        typeInfo: TypeInfo.TestCase
+    },
+    testPlan: {
+        typeInfo: TypeInfo.TestPlanDetailedReference
+    },
+    testPoints: {
+        isArray: true,
+        typeInfo: TypeInfo.TestPoint
+    },
+    testSuites: {
+        isArray: true,
+        typeInfo: TypeInfo.TestSuite
     }
+};
 
-    public async getTestResultsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestResultsApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c83eaf52-edf3-4034-ae11-17d38f25404c");
-        handlers = handlers || [this.authHandler];
-        return new testresultsm.TestResultsApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlansLibraryWorkItemFilter.fields = {
+    filterMode: {
+        enumType: TypeInfo.TestPlansLibraryWorkItemFilterMode
     }
+};
 
-    public async getTfvcApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<tfvcm.ITfvcApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8aa40520-446d-40e6-89f6-9c9f9ce44c48");
-        handlers = handlers || [this.authHandler];
-        return new tfvcm.TfvcApi(serverUrl, handlers, this.options);
+TypeInfo.TestPlanUpdateParams.fields = {
+    endDate: {
+        isDate: true,
+    },
+    startDate: {
+        isDate: true,
     }
+};
 
-    public async getWikiApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<wikim.IWikiApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3");
-        handlers = handlers || [this.authHandler];
-        return new wikim.WikiApi(serverUrl, handlers, this.options);
+TypeInfo.TestPoint.fields = {
+    lastResetToActive: {
+        isDate: true,
+    },
+    lastUpdatedDate: {
+        isDate: true,
+    },
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
+    },
+    results: {
+        typeInfo: TypeInfo.TestPointResults
     }
+};
 
-    public async getWorkApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workm.IWorkApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9");
-        handlers = handlers || [this.authHandler];
-        return new workm.WorkApi(serverUrl, handlers, this.options);
+TypeInfo.TestPointResults.fields = {
+    failureType: {
+        enumType: TypeInfo.FailureType
+    },
+    lastResolutionState: {
+        enumType: TypeInfo.LastResolutionState
+    },
+    lastResultDetails: {
+        typeInfo: TFS_TestManagement_Contracts.TypeInfo.LastResultDetails
+    },
+    lastResultState: {
+        enumType: TypeInfo.ResultState
+    },
+    outcome: {
+        enumType: TypeInfo.Outcome
+    },
+    state: {
+        enumType: TypeInfo.PointState
     }
+};
 
-    public async getWorkItemTrackingApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingm.IWorkItemTrackingApi> {
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workitemtrackingm.WorkItemTrackingApi.RESOURCE_AREA_ID);
-        handlers = handlers || [this.authHandler];
-        return new workitemtrackingm.WorkItemTrackingApi(serverUrl, handlers, this.options);
+TypeInfo.TestPointUpdateParams.fields = {
+    results: {
+        typeInfo: TypeInfo.Results
     }
+};
 
-    public async getWorkItemTrackingProcessApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessm.IWorkItemTrackingProcessApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
-        handlers = handlers || [this.authHandler];
-        return new workitemtrackingprocessm.WorkItemTrackingProcessApi(serverUrl, handlers, this.options);
+TypeInfo.TestSuite.fields = {
+    children: {
+        isArray: true,
+        typeInfo: TypeInfo.TestSuite
+    },
+    lastPopulatedDate: {
+        isDate: true,
+    },
+    lastUpdatedDate: {
+        isDate: true,
+    },
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
+    },
+    suiteType: {
+        enumType: TypeInfo.TestSuiteType
     }
+};
 
-    public async getWorkItemTrackingProcessDefinitionApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessdefinitionm.IWorkItemTrackingProcessDefinitionsApi> {
-        // TODO: Load RESOURCE_AREA_ID correctly.
-        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
-        handlers = handlers || [this.authHandler];
-        return new workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi(serverUrl, handlers, this.options);
+TypeInfo.TestSuiteCreateParams.fields = {
+    suiteType: {
+        enumType: TypeInfo.TestSuiteType
     }
+};
 
-    /**
-     * Determines if the domain is exluded for proxy via the no_proxy env var
-     * @param url: the server url
-     */
-    public isNoProxyHost = function(_url: string) {
-        if (!process.env.no_proxy) {
-            return false;
-        }
-        const noProxyDomains = (process.env.no_proxy || '')
-        .split(',')
-        .map(v => v.toLowerCase());
-        const serverUrl = url.parse(_url).host.toLowerCase();
-        // return true if the no_proxy includes the host
-        return noProxyDomains.indexOf(serverUrl) !== -1;
+TypeInfo.TestSuiteReferenceWithProject.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
     }
+};
 
-    private async _getResourceAreaUrl(serverUrl: string, resourceId: string): Promise<string> {
-        if (!resourceId) {
-            return serverUrl;
-        }
-
-        // This must be of type any, see comment just below.
-        const resourceAreas: any = await this._getResourceAreas();
-
-        if (resourceAreas === undefined) {
-            throw new Error((`Failed to retrieve resource areas ' + 'from server: ${serverUrl}`));
-        }
-
-        // The response type differs based on whether or not there are resource areas. When we are on prem we get:
-        // {"count":0,"value":null} and when we are on VSTS we get an array of resource areas.
-        // Due to this strangeness the type of resourceAreas needs to be any and we need to check .count
-        // When going against vsts count will be undefined. On prem it will be 0
-        if (!resourceAreas || resourceAreas.length === 0 || resourceAreas.count === 0) {
-            // For on prem environments we get an empty list
-            return serverUrl;
-        }
-
-        for (var resourceArea of resourceAreas) {
-            if (resourceArea.id.toLowerCase() === resourceId.toLowerCase()) {
-                return resourceArea.locationUrl;
-            }
-        }
-
-        throw new Error((`Could not find information for resource area ${resourceId} ' + 'from server: ${serverUrl}`));
+TypeInfo.TestVariable.fields = {
+    project: {
+        typeInfo: TfsCoreInterfaces.TypeInfo.TeamProjectReference
     }
-
-    private async _getResourceAreas(): Promise<lim.ResourceAreaInfo[]> {
-        if (!this._resourceAreas) {
-            const locationClient: locationsm.ILocationsApi = await this.getLocationsApi();
-            this._resourceAreas = await locationClient.getResourceAreas();
-        }
-
-        return this._resourceAreas;
-    }
-
-    private _readTaskLibSecrets(lookupKey: string): string {
-        if (isBrowser) {
-            throw new Error("Browsers can't securely keep secrets");
-        }
-        // the lookupKey should has following format
-        // base64encoded<keyFilePath>:base64encoded<encryptedContent>
-        if (lookupKey && lookupKey.indexOf(':') > 0) {
-            let lookupInfo: string[] = lookupKey.split(':', 2);
-
-            // file contains encryption key
-            let keyFile = new Buffer(lookupInfo[0], 'base64').toString('utf8');
-            let encryptKey = new Buffer(fs.readFileSync(keyFile, 'utf8'), 'base64');
-
-            let encryptedContent: string = new Buffer(lookupInfo[1], 'base64').toString('utf8');
-
-            let decipher = crypto.createDecipher("aes-256-ctr", encryptKey)
-            let decryptedContent = decipher.update(encryptedContent, 'hex', 'utf8')
-            decryptedContent += decipher.final('utf8');
-
-            return decryptedContent;
-        }
-    }
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -32,7 +32,8 @@ import { WikiV2 } from "azure-devops-node-api/interfaces/WikiInterfaces";
 // For more information, see:
 // https://github.com/Microsoft/vsts-node-api
 export async function run() {
-    try {
+    try
+    {
         const vstsCollectionLevel: vsoNodeApi.WebApi = await common.getWebApi();
 
         /********** Build **********/
@@ -65,7 +66,7 @@ export async function run() {
         /********** Extension Management **********/
         printSectionStart("Extension Management");
         const extensionManagementApi = await vstsCollectionLevel.getExtensionManagementApi();
-        const requests: RequestedExtension[] = await extensionManagementApi.getRequests();
+        const requests:RequestedExtension[] = await extensionManagementApi.getRequests();
 
         if (requests) {
             console.log(`found ${requests.length} requests`);

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -257,7 +257,7 @@ export async function run() {
         if (workItemFields) {
             console.log(`found ${workItemFields.length} work item fields`);
         }
-
+        
         /********** Work Item Tracking Process **********/
         printSectionStart("Work Item Tracking Process");
         const workItemTrackingProcessApi = await vstsCollectionLevel.getWorkItemTrackingProcessApi();

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -32,10 +32,9 @@ import { WikiV2 } from "azure-devops-node-api/interfaces/WikiInterfaces";
 // For more information, see:
 // https://github.com/Microsoft/vsts-node-api
 export async function run() {
-    try
-    {
+    try {
         const vstsCollectionLevel: vsoNodeApi.WebApi = await common.getWebApi();
-        
+
         /********** Build **********/
         printSectionStart("Build");
         const buildApi = await vstsCollectionLevel.getBuildApi();
@@ -66,7 +65,7 @@ export async function run() {
         /********** Extension Management **********/
         printSectionStart("Extension Management");
         const extensionManagementApi = await vstsCollectionLevel.getExtensionManagementApi();
-        const requests:RequestedExtension[] = await extensionManagementApi.getRequests();
+        const requests: RequestedExtension[] = await extensionManagementApi.getRequests();
 
         if (requests) {
             console.log(`found ${requests.length} requests`);
@@ -202,6 +201,15 @@ export async function run() {
             console.log(`found ${runs.length} test runs`);
         }
 
+        /********** TestPlan **********/
+        printSectionStart('TestPlan');
+        const testPlanApi = await vstsCollectionLevel.getTestPlanApi();
+        const testPlans: TestRun[] = await testPlanApi.getTestPlans(common.getProject());
+
+        if (testPlans) {
+            console.log(`found ${testPlans.length} test plans`);
+        }
+
         /********** TestResults **********/
         printSectionStart('TestResults');
         const testResultsApi = await vstsCollectionLevel.getTestResultsApi();
@@ -248,7 +256,7 @@ export async function run() {
         if (workItemFields) {
             console.log(`found ${workItemFields.length} work item fields`);
         }
-        
+
         /********** Work Item Tracking Process **********/
         printSectionStart("Work Item Tracking Process");
         const workItemTrackingProcessApi = await vstsCollectionLevel.getWorkItemTrackingProcessApi();

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -15,6 +15,7 @@ import { RequestedExtension } from "azure-devops-node-api/interfaces/ExtensionMa
 import { SecurityRole } from "azure-devops-node-api/interfaces/SecurityRolesInterfaces";
 import { TaskAgentPool } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 import { TestRun } from "azure-devops-node-api/interfaces/TestInterfaces";
+import { TestPlan } from "azure-devops-node-api/interfaces/TestPlanInterfaces";
 import { Timeline as TaskAgentTimeline } from "azure-devops-node-api/interfaces/TaskAgentInterfaces";
 import { WebApiTeam } from "azure-devops-node-api/interfaces/CoreInterfaces";
 import { WidgetScope, WidgetTypesResponse } from "azure-devops-node-api/interfaces/DashboardInterfaces";
@@ -205,7 +206,7 @@ export async function run() {
         /********** TestPlan **********/
         printSectionStart('TestPlan');
         const testPlanApi = await vstsCollectionLevel.getTestPlanApi();
-        const testPlans: TestRun[] = await testPlanApi.getTestPlans(common.getProject());
+        const testPlans: TestPlan[] = await testPlanApi.getTestPlans(common.getProject());
 
         if (testPlans) {
             console.log(`found ${testPlans.length} test plans`);

--- a/samples/creation.ts
+++ b/samples/creation.ts
@@ -35,7 +35,7 @@ export async function run() {
     try
     {
         const vstsCollectionLevel: vsoNodeApi.WebApi = await common.getWebApi();
-
+        
         /********** Build **********/
         printSectionStart("Build");
         const buildApi = await vstsCollectionLevel.getBuildApi();

--- a/samples/samples.json
+++ b/samples/samples.json
@@ -12,6 +12,7 @@
     "release",
     "task",
     "test",
+    "testPlan",
     "testResults",
     "wiki",
     "work",


### PR DESCRIPTION
Added testplans API to node sdk : https://dev.azure.com/mseng/AzureDevOps/_git/AzureDevOps?path=%2FTfs%2FClient%2FTestManagement%2FTestPlanning%2FTestPlanResourceIds.cs&_a=contents&version=GBmaster

This is required to be used in new AzureDevOpsTestPlan task here in repo: https://github.com/microsoft/azure-pipelines-tasks/tree/master/Tasks