### PR TITLE
Add Advanced Security Node.js clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ let build: ba.IBuildApi = await connection.getBuildApi();
 
 These clients are available:
 
+* Advanced Security Alert
+* Advanced Security Management
 * Build
 * Core
 * Dashboard

--- a/api/AlertApi.ts
+++ b/api/AlertApi.ts
@@ -1,0 +1,455 @@
+﻿/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+// Licensed under the MIT license.  See LICENSE file in the project root for full license information.
+
+import * as restm from 'typed-rest-client/RestClient';
+import vsom = require('./VsoClient');
+import basem = require('./ClientApiBases');
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+import AlertInterfaces = require("./interfaces/AlertInterfaces");
+import VSSInterfaces = require("./interfaces/common/VSSInterfaces");
+
+export interface IAlertApi extends basem.ClientApiBase {
+    getAlert(project: string, alertId: number, repository: string, ref?: string, expand?: AlertInterfaces.ExpandOption): Promise<AlertInterfaces.Alert>;
+    getAlerts(project: string, repository: string, top?: number, orderBy?: string, criteria?: AlertInterfaces.SearchCriteria, continuationToken?: string): Promise<VSSInterfaces.PagedList<AlertInterfaces.Alert>>;
+    getAlertSarif(project: string, alertId: number, repository: string, ref?: string, expand?: AlertInterfaces.ExpandOption): Promise<string>;
+    updateAlert(stateUpdate: AlertInterfaces.AlertStateUpdate, project: string, alertId: number, repository: string): Promise<AlertInterfaces.Alert>;
+    getAlertInstances(project: string, alertId: number, repository: string, ref?: string): Promise<AlertInterfaces.AlertAnalysisInstance[]>;
+    uploadSarif(customHeaders: any, contentStream: NodeJS.ReadableStream, project: string, repository: string): Promise<number>;
+    getUxFilters(project: string, repository: string, alertType: AlertInterfaces.AlertType): Promise<AlertInterfaces.UxFilters>;
+    getSarif(sarifId: number): Promise<boolean>;
+}
+
+export class AlertApi extends basem.ClientApiBase implements IAlertApi {
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
+        super(baseUrl, handlers, 'node-Alert-api', options);
+    }
+
+    /**
+     * Get an alert.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} alertId - ID of alert to retrieve
+     * @param {string} repository - Name or id  of a repository that alert is part of
+     * @param {string} ref
+     * @param {AlertInterfaces.ExpandOption} expand - Expand alert attributes. Possible options are {ValidationFingerprint, None}
+     */
+    public async getAlert(
+        project: string,
+        alertId: number,
+        repository: string,
+        ref?: string,
+        expand?: AlertInterfaces.ExpandOption
+        ): Promise<AlertInterfaces.Alert> {
+
+        return new Promise<AlertInterfaces.Alert>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                alertId: alertId,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                ref: ref,
+                expand: expand,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "e21b4630-b7d2-4031-99e3-3ad328cc4a7f",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<AlertInterfaces.Alert>;
+                res = await this.rest.get<AlertInterfaces.Alert>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              AlertInterfaces.TypeInfo.Alert,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get alerts for a repository
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} repository - The name or ID of the repository
+     * @param {number} top - The maximum number of alerts to return
+     * @param {string} orderBy - Must be "id" "firstSeen" "lastSeen" "fixedOn" or "severity"  Defaults to "id"
+     * @param {AlertInterfaces.SearchCriteria} criteria - Options to limit the alerts returned
+     * @param {string} continuationToken - If there are more alerts than can be returned, a continuation token is placed in the "x-ms-continuationtoken" header.  Use that token here to get the next page of alerts
+     */
+    public async getAlerts(
+        project: string,
+        repository: string,
+        top?: number,
+        orderBy?: string,
+        criteria?: AlertInterfaces.SearchCriteria,
+        continuationToken?: string
+        ): Promise<VSSInterfaces.PagedList<AlertInterfaces.Alert>> {
+
+        return new Promise<VSSInterfaces.PagedList<AlertInterfaces.Alert>>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                top: top,
+                orderBy: orderBy,
+                criteria: criteria,
+                continuationToken: continuationToken,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "e21b4630-b7d2-4031-99e3-3ad328cc4a7f",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<VSSInterfaces.PagedList<AlertInterfaces.Alert>>;
+                res = await this.rest.get<VSSInterfaces.PagedList<AlertInterfaces.Alert>>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              AlertInterfaces.TypeInfo.Alert,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get an alert.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {number} alertId - ID of alert to retrieve
+     * @param {string} repository - Name or id  of a repository that alert is part of
+     * @param {string} ref
+     * @param {AlertInterfaces.ExpandOption} expand - Expand alert attributes. Possible options are {ValidationFingerprint, None}
+     */
+    public async getAlertSarif(
+        project: string,
+        alertId: number,
+        repository: string,
+        ref?: string,
+        expand?: AlertInterfaces.ExpandOption
+        ): Promise<string> {
+
+        return new Promise<string>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                alertId: alertId,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                ref: ref,
+                expand: expand,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "e21b4630-b7d2-4031-99e3-3ad328cc4a7f",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string>;
+                res = await this.rest.get<string>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update the status of an alert
+     * 
+     * @param {AlertInterfaces.AlertStateUpdate} stateUpdate - The new status of the alert
+     * @param {string} project - Project ID or project name
+     * @param {number} alertId - The ID of the alert
+     * @param {string} repository - The name or ID of the repository
+     */
+    public async updateAlert(
+        stateUpdate: AlertInterfaces.AlertStateUpdate,
+        project: string,
+        alertId: number,
+        repository: string
+        ): Promise<AlertInterfaces.Alert> {
+
+        return new Promise<AlertInterfaces.Alert>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                alertId: alertId,
+                repository: repository
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "e21b4630-b7d2-4031-99e3-3ad328cc4a7f",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<AlertInterfaces.Alert>;
+                res = await this.rest.update<AlertInterfaces.Alert>(url, stateUpdate, options);
+
+                let ret = this.formatResponse(res.result,
+                                              AlertInterfaces.TypeInfo.Alert,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {number} alertId
+     * @param {string} repository
+     * @param {string} ref
+     */
+    public async getAlertInstances(
+        project: string,
+        alertId: number,
+        repository: string,
+        ref?: string
+        ): Promise<AlertInterfaces.AlertAnalysisInstance[]> {
+
+        return new Promise<AlertInterfaces.AlertAnalysisInstance[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                alertId: alertId,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                ref: ref,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "f451ba96-0e95-458a-8dd5-3df894770a49",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<AlertInterfaces.AlertAnalysisInstance[]>;
+                res = await this.rest.get<AlertInterfaces.AlertAnalysisInstance[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              AlertInterfaces.TypeInfo.AlertAnalysisInstance,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Upload a Sarif containing security alerts
+     * 
+     * @param {NodeJS.ReadableStream} contentStream - Content to upload
+     * @param {string} project - Project ID or project name
+     * @param {string} repository - The name or ID of a repository
+     */
+    public async uploadSarif(
+        customHeaders: any,
+        contentStream: NodeJS.ReadableStream,
+        project: string,
+        repository: string
+        ): Promise<number> {
+
+        return new Promise<number>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            customHeaders = customHeaders || {};
+            customHeaders["Content-Type"] = "application/octet-stream";
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "2a141cae-a50d-4c22-b41b-13f77748d035",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json',
+                                                                                verData.apiVersion);
+                options.additionalHeaders = customHeaders;
+
+                let res: restm.IRestResponse<number>;
+                res = await this.rest.uploadStream<number>("POST", url, contentStream, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} project - Project ID or project name
+     * @param {string} repository
+     * @param {AlertInterfaces.AlertType} alertType
+     */
+    public async getUxFilters(
+        project: string,
+        repository: string,
+        alertType: AlertInterfaces.AlertType
+        ): Promise<AlertInterfaces.UxFilters> {
+        if (alertType == null) {
+            throw new TypeError('alertType can not be null or undefined');
+        }
+
+        return new Promise<AlertInterfaces.UxFilters>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                alertType: alertType,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "8f90675b-f794-434d-8f2c-cfae0a11c02a",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<AlertInterfaces.UxFilters>;
+                res = await this.rest.get<AlertInterfaces.UxFilters>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              AlertInterfaces.TypeInfo.UxFilters,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get the status of the Sarif processing job
+     * 
+     * @param {number} sarifId - Sarif ID returned when the Sarif was uploaded
+     */
+    public async getSarif(
+        sarifId: number
+        ): Promise<boolean> {
+
+        return new Promise<boolean>(async (resolve, reject) => {
+            let routeValues: any = {
+                sarifId: sarifId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Alert",
+                    "a04689e7-0f81-48a2-8d18-40654c47494c",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<boolean>;
+                res = await this.rest.get<boolean>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+}

--- a/api/ManagementApi.ts
+++ b/api/ManagementApi.ts
@@ -1,0 +1,772 @@
+﻿/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+// Licensed under the MIT license.  See LICENSE file in the project root for full license information.
+
+import * as restm from 'typed-rest-client/RestClient';
+import vsom = require('./VsoClient');
+import basem = require('./ClientApiBases');
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+import ManagementInterfaces = require("./interfaces/ManagementInterfaces");
+
+export interface IManagementApi extends basem.ClientApiBase {
+    deleteBillingInfo(organizationId: string): Promise<void>;
+    deleteMeterUsageHistory(organizationId: string): Promise<void>;
+    getBillingInfo(organizationId: string): Promise<ManagementInterfaces.BillingInfo>;
+    saveBillingInfo(billingInfo: ManagementInterfaces.BillingInfo, organizationId: string): Promise<void>;
+    getBillableCommitterDetails(billingDate?: Date): Promise<ManagementInterfaces.BillableCommitterDetails[]>;
+    getLastMeterUsage(): Promise<ManagementInterfaces.MeterUsage>;
+    getMeterUsage(billingDate?: Date): Promise<ManagementInterfaces.MeterUsage>;
+    setBillingSnapshot(meterUsage: ManagementInterfaces.MeterUsage): Promise<void>;
+    getOrgEnablementStatus(includeAllProperties?: boolean): Promise<ManagementInterfaces.AdvSecEnablementSettings>;
+    updateOrgEnablementStatus(savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementSettingsUpdate): Promise<void>;
+    getEstimatedOrgBillablePushers(): Promise<string[]>;
+    getProjectEnablementStatus(project: string, includeAllProperties?: boolean): Promise<ManagementInterfaces.AdvSecEnablementSettings>;
+    updateProjectEnablementStatus(savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementSettingsUpdate, project: string): Promise<void>;
+    getEstimatedProjectBillablePushers(project: string): Promise<string[]>;
+    getRepoEnablementStatus(project: string, repository: string, includeAllProperties?: boolean): Promise<ManagementInterfaces.AdvSecEnablementStatus>;
+    updateRepoAdvSecEnablementStatus(savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementStatusUpdate, project: string, repository: string): Promise<void>;
+    getEstimatedRepoBillableCommitters(project: string, repository: string): Promise<string[]>;
+}
+
+export class ManagementApi extends basem.ClientApiBase implements IManagementApi {
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
+        super(baseUrl, handlers, 'node-Management-api', options);
+    }
+
+    /**
+     * @param {string} organizationId
+     */
+    public async deleteBillingInfo(
+        organizationId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Default", 
+                organizationId: organizationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "de45fbc6-60fd-46e2-95ef-490ad08d656a",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {string} organizationId
+     */
+    public async deleteMeterUsageHistory(
+        organizationId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "MeterUsageHistory", 
+                organizationId: organizationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "de45fbc6-60fd-46e2-95ef-490ad08d656a",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.del<void>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get the billing info for an organization.
+     * 
+     * @param {string} organizationId - Organization ID to get billing info for.
+     */
+    public async getBillingInfo(
+        organizationId: string
+        ): Promise<ManagementInterfaces.BillingInfo> {
+
+        return new Promise<ManagementInterfaces.BillingInfo>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Default", 
+                organizationId: organizationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "de45fbc6-60fd-46e2-95ef-490ad08d656a",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.BillingInfo>;
+                res = await this.rest.get<ManagementInterfaces.BillingInfo>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.BillingInfo,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {ManagementInterfaces.BillingInfo} billingInfo
+     * @param {string} organizationId
+     */
+    public async saveBillingInfo(
+        billingInfo: ManagementInterfaces.BillingInfo,
+        organizationId: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Default", 
+                organizationId: organizationId
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "de45fbc6-60fd-46e2-95ef-490ad08d656a",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.create<void>(url, billingInfo, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get all billable committers details, including those not matched with a VSID.
+     * 
+     * @param {Date} billingDate - The date to query, or if not provided, today
+     */
+    public async getBillableCommitterDetails(
+        billingDate?: Date
+        ): Promise<ManagementInterfaces.BillableCommitterDetails[]> {
+
+        return new Promise<ManagementInterfaces.BillableCommitterDetails[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Details", 
+            };
+
+            let queryValues: any = {
+                billingDate: billingDate,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "e58d8091-3d07-48b1-9527-7d6295fd4081",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.BillableCommitterDetails[]>;
+                res = await this.rest.get<ManagementInterfaces.BillableCommitterDetails[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.BillableCommitterDetails,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     */
+    public async getLastMeterUsage(
+        ): Promise<ManagementInterfaces.MeterUsage> {
+
+        return new Promise<ManagementInterfaces.MeterUsage>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Last", 
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "e58d8091-3d07-48b1-9527-7d6295fd4081",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.MeterUsage>;
+                res = await this.rest.get<ManagementInterfaces.MeterUsage>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.MeterUsage,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get commiters used when calculating billing information.
+     * 
+     * @param {Date} billingDate - The date to query, or if not provided, today
+     */
+    public async getMeterUsage(
+        billingDate?: Date
+        ): Promise<ManagementInterfaces.MeterUsage> {
+
+        return new Promise<ManagementInterfaces.MeterUsage>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Default", 
+            };
+
+            let queryValues: any = {
+                billingDate: billingDate,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "e58d8091-3d07-48b1-9527-7d6295fd4081",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.MeterUsage>;
+                res = await this.rest.get<ManagementInterfaces.MeterUsage>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.MeterUsage,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * @param {ManagementInterfaces.MeterUsage} meterUsage
+     */
+    public async setBillingSnapshot(
+        meterUsage: ManagementInterfaces.MeterUsage
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                action: "Default", 
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "e58d8091-3d07-48b1-9527-7d6295fd4081",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.create<void>(url, meterUsage, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get the current status of Advanced Security for the organization
+     * 
+     * @param {boolean} includeAllProperties - When true, also determine if pushes are blocked if they contain secrets
+     */
+    public async getOrgEnablementStatus(
+        includeAllProperties?: boolean
+        ): Promise<ManagementInterfaces.AdvSecEnablementSettings> {
+
+        return new Promise<ManagementInterfaces.AdvSecEnablementSettings>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            let queryValues: any = {
+                includeAllProperties: includeAllProperties,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "d0c0450f-8882-46f4-a5a8-e48fea3095b0",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementSettings>;
+                res = await this.rest.get<ManagementInterfaces.AdvSecEnablementSettings>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.AdvSecEnablementSettings,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update the status of Advanced Security for the organization
+     * 
+     * @param {ManagementInterfaces.AdvSecEnablementSettingsUpdate} savedAdvSecEnablementStatus - The new status
+     */
+    public async updateOrgEnablementStatus(
+        savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementSettingsUpdate
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "d0c0450f-8882-46f4-a5a8-e48fea3095b0",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Estimate the committers that would be added to the customer's usage if Advanced Security was enabled for this organization.
+     * 
+     */
+    public async getEstimatedOrgBillablePushers(
+        ): Promise<string[]> {
+
+        return new Promise<string[]>(async (resolve, reject) => {
+            let routeValues: any = {
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "10a9e9c3-89bf-4312-92ed-139ddbcd2e28",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string[]>;
+                res = await this.rest.get<string[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Get the current status of Advanced Security for a project
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {boolean} includeAllProperties - When true, also determine if pushes are blocked if they contain secrets
+     */
+    public async getProjectEnablementStatus(
+        project: string,
+        includeAllProperties?: boolean
+        ): Promise<ManagementInterfaces.AdvSecEnablementSettings> {
+
+        return new Promise<ManagementInterfaces.AdvSecEnablementSettings>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            let queryValues: any = {
+                includeAllProperties: includeAllProperties,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "6b9a4b47-5f2d-40f3-8286-b0152079074d",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementSettings>;
+                res = await this.rest.get<ManagementInterfaces.AdvSecEnablementSettings>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.AdvSecEnablementSettings,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update the status of Advanced Security for the project
+     * 
+     * @param {ManagementInterfaces.AdvSecEnablementSettingsUpdate} savedAdvSecEnablementStatus - The new status
+     * @param {string} project - Project ID or project name
+     */
+    public async updateProjectEnablementStatus(
+        savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementSettingsUpdate,
+        project: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "6b9a4b47-5f2d-40f3-8286-b0152079074d",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Estimate the number of committers that would be added to the customer's usage if Advanced Security was enabled for this project.
+     * 
+     * @param {string} project - Project ID or project name
+     */
+    public async getEstimatedProjectBillablePushers(
+        project: string
+        ): Promise<string[]> {
+
+        return new Promise<string[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "bf09cb40-ecf4-4496-8cf7-9ec60c64fd3e",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string[]>;
+                res = await this.rest.get<string[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Determine if Advanced Security is enabled for a repository
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} repository - The name or ID of the repository
+     * @param {boolean} includeAllProperties - When true, will also determine if pushes are blocked when secrets are detected
+     */
+    public async getRepoEnablementStatus(
+        project: string,
+        repository: string,
+        includeAllProperties?: boolean
+        ): Promise<ManagementInterfaces.AdvSecEnablementStatus> {
+
+        return new Promise<ManagementInterfaces.AdvSecEnablementStatus>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            let queryValues: any = {
+                includeAllProperties: includeAllProperties,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "d11a1c2b-b904-43dc-b970-bf42486262db",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementStatus>;
+                res = await this.rest.get<ManagementInterfaces.AdvSecEnablementStatus>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              ManagementInterfaces.TypeInfo.AdvSecEnablementStatus,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Update the enablement of Advanced Security for a repository
+     * 
+     * @param {ManagementInterfaces.AdvSecEnablementStatusUpdate} savedAdvSecEnablementStatus - new status
+     * @param {string} project - Project ID or project name
+     * @param {string} repository - Name or ID of the repository
+     */
+    public async updateRepoAdvSecEnablementStatus(
+        savedAdvSecEnablementStatus: ManagementInterfaces.AdvSecEnablementStatusUpdate,
+        project: string,
+        repository: string
+        ): Promise<void> {
+
+        return new Promise<void>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "d11a1c2b-b904-43dc-b970-bf42486262db",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<void>;
+                res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Estimate the committers that would be added to the customer's usage if Advanced Security was enabled for this repository.
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} repository - The name or ID of the repository
+     */
+    public async getEstimatedRepoBillableCommitters(
+        project: string,
+        repository: string
+        ): Promise<string[]> {
+
+        return new Promise<string[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                repository: repository
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "Management",
+                    "b60f1ebf-ae77-4557-bd7f-ae3d5598dd1f",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<string[]>;
+                res = await this.rest.get<string[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+}

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -13,6 +13,7 @@ import filecontainerm = require('./FileContainerApi');
 import gallerym = require('./GalleryApi');
 import gitm = require('./GitApi');
 import locationsm = require('./LocationsApi');
+import managementm = require('./ManagementApi');
 import notificationm = require('./NotificationApi');
 import policym = require('./PolicyApi');
 import profilem = require('./ProfileApi');
@@ -261,6 +262,12 @@ export class WebApi {
         serverUrl = await serverUrl || this.serverUrl;
         handlers = handlers || [this.authHandler];
         return new locationsm.LocationsApi(serverUrl, handlers, optionsClone);
+    }
+
+    public async getManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<managementm.IManagementApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "f101720c-9790-45a6-9fb3-494a09fddeeb");
+        handlers = handlers || [this.authHandler];
+        return new managementm.ManagementApi(serverUrl, handlers, this.options);
     }
 
     public async getNotificationApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<notificationm.INotificationApi> {

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -3,6 +3,7 @@
 
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import basem = require('./ClientApiBases');
+import alertm = require('./AlertApi');
 import buildm = require('./BuildApi');
 import corem = require('./CoreApi');
 import dashboardm = require('./DashboardApi');
@@ -192,6 +193,13 @@ export class WebApi {
      * Each factory method can take a serverUrl and a list of handlers
      * if these aren't provided, the default url and auth handler given to the constructor for this class will be used
      */
+
+    public async getAlertApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<alertm.IAlertApi> {
+        serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "0f2ca920-f269-4545-b1f4-5b4173aa784e");
+        handlers = handlers || [this.authHandler];
+        return new alertm.AlertApi(serverUrl, handlers, this.options);
+    }
+
     public async getBuildApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<buildm.IBuildApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, buildm.BuildApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];

--- a/api/interfaces/AlertInterfaces.ts
+++ b/api/interfaces/AlertInterfaces.ts
@@ -1,0 +1,1070 @@
+﻿/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+"use strict";
+
+import VSSInterfaces = require("../interfaces/common/VSSInterfaces");
+
+
+export interface Alert {
+    /**
+     * Identifier for the alert. It is unqiue within Azure DevOps organization.
+     */
+    alertId?: number;
+    /**
+     * Type of the alert. E.g. secret, code, etc.
+     */
+    alertType?: AlertType;
+    /**
+     * Contains information for the dismissal of the alert if the alert has been dismissed.
+     */
+    dismissal?: Dismissal;
+    /**
+     * This value is computed and returned by the service. This value represents the first time the service has seen this issue reported in an analysis instance.
+     */
+    firstSeenDate?: Date;
+    /**
+     * This value is computed and returned by the service. If the issue is fixed, this value represents the time the service has seen this issue fixed in an analysis instance.
+     */
+    fixedDate?: Date;
+    /**
+     * Reference to a git object, e.g. branch ref.
+     */
+    gitRef?: string;
+    /**
+     * This value is computed and returned by the service. This value represents the first time the vulnerability was introduced.
+     */
+    introducedDate?: Date;
+    /**
+     * This value is computed and returned by the service. This value represents the last time the service has seen this issue reported in an analysis instance.
+     */
+    lastSeenDate?: Date;
+    /**
+     * Logical locations for the alert. This value is computed and returned by the service. It is a value based on the results from all analysis configurations. An example of a logical location is a component.
+     */
+    logicalLocations?: LogicalLocation[];
+    /**
+     * This value is computed and returned by the service. It is a value based on the results from all analysis configurations. An example of a physical location is a file location.
+     */
+    physicalLocations?: PhysicalLocation[];
+    /**
+     * Repository URL where the alert was detected.
+     */
+    repositoryUrl?: string;
+    /**
+     * Severity of the alert.
+     */
+    severity?: Severity;
+    /**
+     * This value is computed and returned by the service. It is a value based on the results from all analysis configurations.
+     */
+    state?: State;
+    /**
+     * Title will only be rendered as text and does not support markdown formatting. There is a maximum character limit of 256.
+     */
+    title?: string;
+    /**
+     * Tools that have detected this issue.
+     */
+    tools?: Tool[];
+    /**
+     * A truncated/obfuscated version of the secret pertaining to the alert (if applicable).
+     */
+    truncatedSecret?: string;
+    /**
+     * ValidationFingerprints for the secret liveness check. Only return on demanded
+     */
+    validationFingerprints?: ValidationFingerprint[];
+}
+
+/**
+ * Summary of the state of the alert for a given analysis configuration.
+ */
+export interface AlertAnalysisInstance {
+    /**
+     * Analysis configuration.
+     */
+    analysisConfiguration?: AnalysisConfiguration;
+    /**
+     * Analysis instance where the issue was first detected for a given analysis configuration.
+     */
+    firstSeen?: AnalysisInstance;
+    /**
+     * Analysis instance where the issue was fixed for a given analysis configuration.
+     */
+    fixedIn?: AnalysisInstance;
+    /**
+     * Analysis instance where the issue was last detected for a given analysis configuration.
+     */
+    lastSeen?: AnalysisInstance;
+    /**
+     * The most recent instatnce of the analysis.
+     */
+    recentAnalysisInstance?: AnalysisInstance;
+    /**
+     * Result state for a given analysis configuration.
+     */
+    state?: State;
+}
+
+export interface AlertStateUpdate {
+    dismissedComment?: string;
+    dismissedReason?: DismissalType;
+    state?: State;
+}
+
+export enum AlertType {
+    /**
+     * The code has an unspecified vulnerability type
+     */
+    Unknown = 0,
+    /**
+     * The code uses a dependency with a known vulnerability.
+     */
+    Dependency = 1,
+    /**
+     * The code contains a secret that has now been compromised and must be revoked.
+     */
+    Secret = 2,
+    /**
+     * The code contains a weakness determined by static analysis.
+     */
+    Code = 3,
+}
+
+/**
+ * AnalysisConfiguration class models a build definition.
+ */
+export interface AnalysisConfiguration {
+    /**
+     * Details for the configuration. Populated values depend on the type of configuration.
+     */
+    analysisConfigurationDetails?: AnalysisConfigurationDetails;
+    /**
+     * Identifier for the analysis configuration.
+     */
+    analysisConfigurationId?: number;
+    /**
+     * Type of the configuration.
+     */
+    analysisConfigurationType?: AnalysisConfigurationType;
+    /**
+     * Name of the tool that ran on this configuration.
+     */
+    toolName?: string;
+    /**
+     * The latest version of the tool that ran on this configuration.
+     */
+    toolVersion?: string;
+}
+
+export interface AnalysisConfigurationDetails {
+    /**
+     * Reference to a git object, e.g. branch ref.
+     */
+    gitRef?: string;
+    /**
+     * Is this the default branch?
+     */
+    isDefaultBranch?: boolean;
+    /**
+     * Phase ID of the pipeline.
+     */
+    phaseId?: string;
+    /**
+     * Phase name.
+     */
+    phaseName?: string;
+    /**
+     * AzureDevOps pipeline id.
+     */
+    pipelineId?: number;
+    /**
+     * Name of the pipeline.
+     */
+    pipelineName?: string;
+}
+
+export enum AnalysisConfigurationType {
+    /**
+     * Default analysis configuration that is not attached to any other configuration data
+     */
+    Default = 0,
+    /**
+     * Ado Pipeline, contains branch, pipeline, phase, and ADOPipelineId
+     */
+    AdoPipeline = 1,
+}
+
+/**
+ * AnalysisInstance class models a build.
+ */
+export interface AnalysisInstance {
+    /**
+     * CommitId is a commit id for that instance
+     */
+    commitId?: string;
+    /**
+     * Analysis configuration.
+     */
+    configuration?: AnalysisConfiguration;
+    /**
+     * Date when the analysis was created.
+     */
+    createdDate?: Date;
+    /**
+     * InstanceIdentifier is a key that uniquely establishes this instance
+     */
+    instanceIdentifier?: string;
+    /**
+     * Results that were reported by the analysis.
+     */
+    results?: AnalysisResult[];
+    /**
+     * Url is the permalink to the build.
+     */
+    url?: string;
+}
+
+export interface AnalysisResult {
+    analysisResultId?: number;
+    firstIntroducedInstanceId?: number;
+    fixedInstanceId?: number;
+    introducedInstanceId?: number;
+    lastSeenInstanceId?: number;
+    result?: Result;
+    state?: State;
+}
+
+export interface Branch {
+    branchId?: number;
+    deletedDate?: Date;
+    name?: string;
+}
+
+/**
+ * This enum defines the dependency components.
+ */
+export enum ComponentType {
+    Unknown = 0,
+    NuGet = 1,
+    /**
+     * Indicates the component is an Npm package.
+     */
+    Npm = 2,
+    /**
+     * Indicates the component is a Maven artifact.
+     */
+    Maven = 3,
+    /**
+     * Indicates the component is a Git repository.
+     */
+    Git = 4,
+    /**
+     * Indicates the component is not any of the supported component types by Governance.
+     */
+    Other = 5,
+    /**
+     * Indicates the component is a Ruby gem.
+     */
+    RubyGems = 6,
+    /**
+     * Indicates the component is a Cargo package.
+     */
+    Cargo = 7,
+    /**
+     * Indicates the component is a Pip package.
+     */
+    Pip = 8,
+    /**
+     * Indicates the component is a loose file. Not a package as understood by different package managers.
+     */
+    File = 9,
+    Go = 10,
+    /**
+     * Indicates the component is a Docker Image
+     */
+    DockerImage = 11,
+    /**
+     * Indicates the component is a CocoaPods pod.
+     */
+    Pod = 12,
+    /**
+     * Indicates the component is found in a linux environment. A package understood by linux based package managers like apt and rpm.
+     */
+    Linux = 13,
+    /**
+     * Indicates the component is a Conda package.
+     */
+    Conda = 14,
+    /**
+     * Indicates the component is a Docker Reference.
+     */
+    DockerReference = 15,
+    /**
+     * Indicates the component is a Vcpkg Package.
+     */
+    Vcpkg = 16,
+}
+
+/**
+ * Information about a vulnerable dependency
+ */
+export interface Dependency {
+    /**
+     * Dependency name
+     */
+    componentName?: string;
+    /**
+     * Source of the dependency
+     */
+    componentType?: ComponentType;
+    /**
+     * Version information
+     */
+    componentVersion?: string;
+    /**
+     * Unique ID for the dependency
+     */
+    dependencyId?: number;
+}
+
+/**
+ * An instance of a vulnerable dependency that was detected
+ */
+export interface DependencyResult {
+    /**
+     * Information about the vulnerable dependency that was found
+     */
+    dependency?: Dependency;
+    /**
+     * Unique ID for this dependency
+     */
+    dependencyResultId?: number;
+    /**
+     * ID for the Result that this instance belongs to
+     */
+    resultId?: number;
+    /**
+     * Heirarchal information when multiple instances are found
+     */
+    rootDependencyId?: number;
+    /**
+     * Information about where the dependency was found
+     */
+    versionControlFilePath?: VersionControlFilePath;
+}
+
+/**
+ * Information about an alert dismissal
+ */
+export interface Dismissal {
+    /**
+     * Unique ID for this dismissal
+     */
+    dismissalId?: number;
+    /**
+     * Reason for the dismissal
+     */
+    dismissalType?: DismissalType;
+    /**
+     * Informational message attached to the dismissal
+     */
+    message?: string;
+    requestedOn?: Date;
+    /**
+     * Identity that dismissed the alert
+     */
+    stateChangedBy?: string;
+    /**
+     * Identity that dismissed the alert
+     */
+    stateChangedByIdentity?: VSSInterfaces.IdentityRef;
+}
+
+export enum DismissalType {
+    /**
+     * Dismissal type unknown
+     */
+    Unknown = 0,
+    /**
+     * Dismissal indicating alert has been fixed
+     */
+    Fixed = 1,
+    /**
+     * Dismissal indicating user is accepting a risk for the alert
+     */
+    AcceptedRisk = 2,
+    /**
+     * Dismissal indicating alert is a false positive and will likely not be fixed.
+     */
+    FalsePositive = 3,
+}
+
+export enum ExpandOption {
+    /**
+     * No Expands.
+     */
+    None = 0,
+    /**
+     * Return validationFingerprints in Alert.
+     */
+    ValidationFingerprint = 1,
+}
+
+export interface LogicalLocation {
+    fullyQualifiedName?: string;
+    /**
+     * Possible values: "unknown" "rootDependency" and "vulnerableDependency"
+     */
+    kind?: string;
+}
+
+/**
+ * Location in the source control system where the issue was found
+ */
+export interface PhysicalLocation {
+    /**
+     * Path of the file where the issue was found
+     */
+    filePath?: string;
+    /**
+     * Details about the location where the issue was found including a snippet
+     */
+    region?: Region;
+    /**
+     * Source control system-specific information about the location
+     */
+    versionControl?: VersionControlDetails;
+}
+
+export interface Pipeline {
+    adoPipelineId?: number;
+    name?: string;
+    phase?: string;
+    phaseId?: string;
+}
+
+export interface Region {
+    /**
+     * The column where the code snippet ends
+     */
+    columnEnd?: number;
+    /**
+     * The column where the code snippet starts
+     */
+    columnStart?: number;
+    /**
+     * A subset of the code snippet highlighting the issue
+     */
+    highlightSnippet?: string;
+    /**
+     * The line number where the code snippet ends
+     */
+    lineEnd?: number;
+    /**
+     * The line number where the code snippet starts
+     */
+    lineStart?: number;
+    /**
+     * The full code snippet
+     */
+    snippet?: string;
+}
+
+export interface Result {
+    /**
+     * Additional information about the alert.  Valid when ResultType is Dependency
+     */
+    dependencyResult?: DependencyResult;
+    /**
+     * Full fingerprint of the Result.  This is used to detect duplicate instances of the same alert
+     */
+    fingerprint?: string;
+    /**
+     * Unique ID of the fingerprint of the Result
+     */
+    fingerprintId?: number;
+    /**
+     * Unique ID of the Result
+     */
+    resultId?: number;
+    /**
+     * This is the index into the SARIF Results array. If we have to do any tool specific insertions, we'll use this key to index back into the SARIF Results array.
+     */
+    resultIndex?: number;
+    /**
+     * Detailed description of the rule that triggered the alert
+     */
+    resultMessage?: string;
+    /**
+     * The type of rule that triggered the alert
+     */
+    resultType?: ResultType;
+    /**
+     * ID of the rule that the triggered the alert
+     */
+    ruleId?: number;
+    /**
+     * Short description of the rule that triggered the alert
+     */
+    ruleShortDescription?: string;
+    /**
+     * The severity of the alert
+     */
+    severity?: Severity;
+    /**
+     * Additional information about the alert.  Valid when ResultType is VersionControl
+     */
+    versionControlResult?: VersionControlResult;
+}
+
+/**
+ * This enum defines the different result types.
+ */
+export enum ResultType {
+    /**
+     * The result was found from an unspecified analysis type
+     */
+    Unknown = 0,
+    /**
+     * The result was found from dependency analysis
+     */
+    Dependency = 1,
+    /**
+     * The result was found from static code analysis
+     */
+    VersionControl = 2,
+}
+
+/**
+ * The analysis rule that caused the alert.
+ */
+export interface Rule {
+    /**
+     * Additional properties of this rule dependent on the rule type.  For example, dependency rules may include the CVE ID if it is available.
+     */
+    additionalProperties?: { [key: string] : any; };
+    /**
+     * Description of what this rule detects
+     */
+    description?: string;
+    /**
+     * Plain-text rule identifier
+     */
+    friendlyName?: string;
+    /**
+     * Additional information about this rule
+     */
+    helpMessage?: string;
+    /**
+     * Tool-specific rule identifier
+     */
+    opaqueId?: string;
+    /**
+     * Markdown-formatted list of resources to learn more about the Rule. In some cases, RuleInfo.AdditionalProperties.advisoryUrls is used instead.
+     */
+    resources?: string;
+    /**
+     * Classification tags for this rule
+     */
+    tags?: string[];
+}
+
+export interface SearchCriteria {
+    /**
+     * If provided, only return alerts of this type. Otherwise, return alerts of all types.
+     */
+    alertType?: AlertType;
+    /**
+     * If provided, only alerts for this dependency are returned. <br />Otherwise, return alerts for all dependencies. <br />In a sarif submission, a dependency (or a vulnerable component) is specified in result.RelatedLocations[].logicalLocation.
+     */
+    dependencyName?: string;
+    /**
+     * If provided, only return alerts last seen after this date. <br />Otherwise return all alerts.
+     */
+    fromDate?: Date;
+    /**
+     * If provided, only return alerts whose titles match this pattern.
+     */
+    keywords?: string;
+    /**
+     * If provided, only return alerts that were modified since this date. <br />Otherwise return all alerts.
+     */
+    modifiedSince?: Date;
+    /**
+     * If true, only return alerts found on the default branch of the repository. <br />If there have been no runs completed on the default branch, the last run is used instead regardless of the branch used for that run. <br />This option is ignored if ref is provided.
+     */
+    onlyDefaultBranchAlerts?: boolean;
+    /**
+     * If provided with pipelineName, only return alerts detected in this pipeline phase <br />Otherwise, return alerts detected in all phases.
+     */
+    phaseId?: string;
+    /**
+     * If provided with pipelineName, only return alerts detected in this pipeline phase <br />Otherwise, return alerts detected in all phases.
+     */
+    phaseName?: string;
+    /**
+     * If provided, only return alerts detected in this pipeline. <br />Otherwise, return alerts detected in all pipelines.
+     */
+    pipelineName?: string;
+    /**
+     * If provided, only include alerts for this ref. <br />If not provided and OnlyDefaultBranch is true, only include alerts found on the default branch or last run branch if there is no analysis configuration for the default branch. <br />Otherwise, include alerts from all branches.
+     */
+    ref?: string;
+    /**
+     * If provided, only return alerts for this rule. <br />Otherwise, return alerts of all rules.
+     */
+    ruleId?: string;
+    /**
+     * If provided, only return alerts for this rule. <br />Otherwise, return alerts for all rules.
+     */
+    ruleName?: string;
+    /**
+     * If provided, only return alerts at these severities. <br />Otherwise, return alerts at any serverity.
+     */
+    severities?: Severity[];
+    /**
+     * If provided, only return alerts in these states. <br />Otherwise, return alerts in any state.
+     */
+    states?: State[];
+    /**
+     * If provided, only return alerts last seen before this date. <br />Otherwise return all alerts.
+     */
+    toDate?: Date;
+    /**
+     * If provided with toolName, only return alerts detected by this tool. <br />Otherwise, return alerts detected by all tools.
+     */
+    toolName?: string;
+}
+
+export enum Severity {
+    Low = 0,
+    Medium = 1,
+    High = 2,
+    Critical = 3,
+    Note = 4,
+    Warning = 5,
+    Error = 6,
+}
+
+export enum State {
+    /**
+     * Alert is in an indeterminate state
+     */
+    Unknown = 0,
+    /**
+     * Alert has been detected in the code
+     */
+    Active = 1,
+    /**
+     * Alert was dismissed by a user
+     */
+    Dismissed = 2,
+    /**
+     * The issue is no longer detected in the code
+     */
+    Fixed = 4,
+    /**
+     * The tool has determined that the issue is no longer a risk
+     */
+    AutoDismissed = 8,
+}
+
+/**
+ * An Analysis tool that can generate security alerts
+ */
+export interface Tool {
+    /**
+     * Name of the tool
+     */
+    name?: string;
+    /**
+     * The rules that the tool defines
+     */
+    rules?: Rule[];
+}
+
+export interface UxFilters {
+    /**
+     * Branches to display alerts for.  If empty, show alerts from all branches
+     */
+    branches?: Branch[];
+    packages?: Dependency[];
+    /**
+     * Pipelines to show alerts for.  If empty, show alerts for all pipelines
+     */
+    pipelines?: Pipeline[];
+    progressPercentage?: number;
+    rules?: Rule[];
+    secretTypes?: string[];
+    /**
+     * Alert severities to show.  If empty show all alert servities
+     */
+    severities?: Severity[];
+    /**
+     * Alert states to show.  If empty show all alert states
+     */
+    states?: State[];
+    tools?: Tool[];
+}
+
+export interface ValidationFingerprint {
+    validationFingerprintHash?: string;
+    validationFingerprintJson?: string;
+}
+
+/**
+ * Information for locating files in a source control system
+ */
+export interface VersionControlDetails {
+    commitHash?: string;
+    itemUrl?: string;
+}
+
+export interface VersionControlFilePath {
+    /**
+     * Path of the file in the version control system
+     */
+    filePath?: string;
+    /**
+     * Hash of the file in the version control system
+     */
+    filePathHash?: number[];
+    /**
+     * Unique ID for the file in the version control system
+     */
+    versionControlFilePathId?: number;
+}
+
+export interface VersionControlResult {
+    /**
+     * The ID to associate this structure with the cooresponding Result
+     */
+    resultId?: number;
+    /**
+     * Information about the snippet where the Result was found
+     */
+    versionControlSnippet?: VersionControlSnippet;
+}
+
+export interface VersionControlSnippet {
+    /**
+     * column in the code file where the snippet ends
+     */
+    endColumn?: number;
+    /**
+     * line in the code file where the snippet ends
+     */
+    endLine?: number;
+    /**
+     * subset of the code snippet highlighting the alert issue
+     */
+    highlightSnippet?: string;
+    /**
+     * larger code snippet
+     */
+    snippet?: string;
+    /**
+     * column in the code file where the snippet starts
+     */
+    startColumn?: number;
+    /**
+     * line in the code file where the snippet starts
+     */
+    startLine?: number;
+    /**
+     * Version control system where the code was found
+     */
+    versionControl?: string;
+    /**
+     * path of the code file in the version control system
+     */
+    versionControlFilePath?: VersionControlFilePath;
+    /**
+     * Unique Id number for the file path
+     */
+    versionControlFilePathId?: number;
+    /**
+     * Unique Id number for this snippet
+     */
+    versionControlSnippetId?: number;
+}
+
+export var TypeInfo = {
+    Alert: <any>{
+    },
+    AlertAnalysisInstance: <any>{
+    },
+    AlertStateUpdate: <any>{
+    },
+    AlertType: {
+        enumValues: {
+            "unknown": 0,
+            "dependency": 1,
+            "secret": 2,
+            "code": 3
+        }
+    },
+    AnalysisConfiguration: <any>{
+    },
+    AnalysisConfigurationType: {
+        enumValues: {
+            "default": 0,
+            "adoPipeline": 1
+        }
+    },
+    AnalysisInstance: <any>{
+    },
+    AnalysisResult: <any>{
+    },
+    Branch: <any>{
+    },
+    ComponentType: {
+        enumValues: {
+            "unknown": 0,
+            "nuGet": 1,
+            "npm": 2,
+            "maven": 3,
+            "git": 4,
+            "other": 5,
+            "rubyGems": 6,
+            "cargo": 7,
+            "pip": 8,
+            "file": 9,
+            "go": 10,
+            "dockerImage": 11,
+            "pod": 12,
+            "linux": 13,
+            "conda": 14,
+            "dockerReference": 15,
+            "vcpkg": 16
+        }
+    },
+    Dependency: <any>{
+    },
+    DependencyResult: <any>{
+    },
+    Dismissal: <any>{
+    },
+    DismissalType: {
+        enumValues: {
+            "unknown": 0,
+            "fixed": 1,
+            "acceptedRisk": 2,
+            "falsePositive": 3
+        }
+    },
+    ExpandOption: {
+        enumValues: {
+            "none": 0,
+            "validationFingerprint": 1
+        }
+    },
+    Result: <any>{
+    },
+    ResultType: {
+        enumValues: {
+            "unknown": 0,
+            "dependency": 1,
+            "versionControl": 2
+        }
+    },
+    SearchCriteria: <any>{
+    },
+    Severity: {
+        enumValues: {
+            "low": 0,
+            "medium": 1,
+            "high": 2,
+            "critical": 3,
+            "note": 4,
+            "warning": 5,
+            "error": 6
+        }
+    },
+    State: {
+        enumValues: {
+            "unknown": 0,
+            "active": 1,
+            "dismissed": 2,
+            "fixed": 4,
+            "autoDismissed": 8
+        }
+    },
+    UxFilters: <any>{
+    },
+};
+
+TypeInfo.Alert.fields = {
+    alertType: {
+        enumType: TypeInfo.AlertType
+    },
+    dismissal: {
+        typeInfo: TypeInfo.Dismissal
+    },
+    firstSeenDate: {
+        isDate: true,
+    },
+    fixedDate: {
+        isDate: true,
+    },
+    introducedDate: {
+        isDate: true,
+    },
+    lastSeenDate: {
+        isDate: true,
+    },
+    severity: {
+        enumType: TypeInfo.Severity
+    },
+    state: {
+        enumType: TypeInfo.State
+    }
+};
+
+TypeInfo.AlertAnalysisInstance.fields = {
+    analysisConfiguration: {
+        typeInfo: TypeInfo.AnalysisConfiguration
+    },
+    firstSeen: {
+        typeInfo: TypeInfo.AnalysisInstance
+    },
+    fixedIn: {
+        typeInfo: TypeInfo.AnalysisInstance
+    },
+    lastSeen: {
+        typeInfo: TypeInfo.AnalysisInstance
+    },
+    recentAnalysisInstance: {
+        typeInfo: TypeInfo.AnalysisInstance
+    },
+    state: {
+        enumType: TypeInfo.State
+    }
+};
+
+TypeInfo.AlertStateUpdate.fields = {
+    dismissedReason: {
+        enumType: TypeInfo.DismissalType
+    },
+    state: {
+        enumType: TypeInfo.State
+    }
+};
+
+TypeInfo.AnalysisConfiguration.fields = {
+    analysisConfigurationType: {
+        enumType: TypeInfo.AnalysisConfigurationType
+    }
+};
+
+TypeInfo.AnalysisInstance.fields = {
+    configuration: {
+        typeInfo: TypeInfo.AnalysisConfiguration
+    },
+    createdDate: {
+        isDate: true,
+    },
+    results: {
+        isArray: true,
+        typeInfo: TypeInfo.AnalysisResult
+    }
+};
+
+TypeInfo.AnalysisResult.fields = {
+    result: {
+        typeInfo: TypeInfo.Result
+    },
+    state: {
+        enumType: TypeInfo.State
+    }
+};
+
+TypeInfo.Branch.fields = {
+    deletedDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.Dependency.fields = {
+    componentType: {
+        enumType: TypeInfo.ComponentType
+    }
+};
+
+TypeInfo.DependencyResult.fields = {
+    dependency: {
+        typeInfo: TypeInfo.Dependency
+    }
+};
+
+TypeInfo.Dismissal.fields = {
+    dismissalType: {
+        enumType: TypeInfo.DismissalType
+    },
+    requestedOn: {
+        isDate: true,
+    }
+};
+
+TypeInfo.Result.fields = {
+    dependencyResult: {
+        typeInfo: TypeInfo.DependencyResult
+    },
+    resultType: {
+        enumType: TypeInfo.ResultType
+    },
+    severity: {
+        enumType: TypeInfo.Severity
+    }
+};
+
+TypeInfo.SearchCriteria.fields = {
+    alertType: {
+        enumType: TypeInfo.AlertType
+    },
+    fromDate: {
+        isDate: true,
+    },
+    modifiedSince: {
+        isDate: true,
+    },
+    severities: {
+        isArray: true,
+        enumType: TypeInfo.Severity
+    },
+    states: {
+        isArray: true,
+        enumType: TypeInfo.State
+    },
+    toDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.UxFilters.fields = {
+    branches: {
+        isArray: true,
+        typeInfo: TypeInfo.Branch
+    },
+    packages: {
+        isArray: true,
+        typeInfo: TypeInfo.Dependency
+    },
+    severities: {
+        isArray: true,
+        enumType: TypeInfo.Severity
+    },
+    states: {
+        isArray: true,
+        enumType: TypeInfo.State
+    }
+};

--- a/api/interfaces/ManagementInterfaces.ts
+++ b/api/interfaces/ManagementInterfaces.ts
@@ -1,0 +1,239 @@
+﻿/*
+ * ---------------------------------------------------------
+ * Copyright(C) Microsoft Corporation. All rights reserved.
+ * ---------------------------------------------------------
+ *
+ * ---------------------------------------------------------
+ * Generated file, DO NOT EDIT
+ * ---------------------------------------------------------
+ */
+
+"use strict";
+
+
+
+export interface AdvSecEnablementSettings {
+    /**
+     * Automatically enable Advanced Security on newly created repositories.
+     */
+    enableOnCreate?: boolean;
+    reposEnablementStatus?: AdvSecEnablementStatus[];
+}
+
+export interface AdvSecEnablementSettingsUpdate extends AdvSecEnablementStatusUpdate {
+    /**
+     * Automatically enable Advanced Security on newly created repositories.
+     */
+    enableOnCreate?: boolean;
+}
+
+export interface AdvSecEnablementStatus extends AdvSecEnablementStatusUpdate {
+    /**
+     * The last time the status of Advanced Security for this repository was updated
+     */
+    advSecEnablementLastChangedDate?: Date;
+    projectId?: string;
+    repositoryId?: string;
+}
+
+export interface AdvSecEnablementStatusUpdate {
+    /**
+     * Enabled status False disabled, True enabled, Null never explicitly set.
+     */
+    advSecEnabled?: boolean;
+    /**
+     * When true, pushes containing secrets will be blocked. <br />When false, pushes are scanned for secrets and are not blocked. <br />If includeAllProperties in the request if false, this value will be null.
+     */
+    blockPushes?: boolean;
+}
+
+/**
+ * Billable Committers Details for Advanced Security Services
+ */
+export interface BillableCommitterDetails {
+    /**
+     * ID (SHA-1) of the commit.
+     */
+    commitId?: string;
+    /**
+     * Committer email address after parsing.
+     */
+    committerEmail?: string;
+    /**
+     * Time reported by the commit.
+     */
+    commitTime?: Date;
+    /**
+     * DisplayName of the Pusher.
+     */
+    displayName?: string;
+    /**
+     * MailNickName of the Pusher.
+     */
+    mailNickName?: string;
+    /**
+     * Project Id commit was pushed to.
+     */
+    projectId?: string;
+    /**
+     * Project name commit was pushed to.
+     */
+    projectName?: string;
+    /**
+     * Time of the push that contained the commit.
+     */
+    pushedTime?: Date;
+    /**
+     * Pusher Id for the push.
+     */
+    pusherId?: string;
+    /**
+     * Push Id that contained the commit.
+     */
+    pushId?: number;
+    /**
+     * RepositoryId commit was pushed to.
+     */
+    repoId?: string;
+    /**
+     * Repository name commit was pushed to.
+     */
+    repoName?: string;
+    /**
+     * SamAccountName of the Pusher.
+     */
+    samAccountName?: string;
+    /**
+     * Visual Studio ID /Team Foundation ID
+     */
+    vSID?: string;
+}
+
+/**
+ * BillingInfo contains an organization, its enablement status and the Azure Subscription for it.
+ */
+export interface BillingInfo {
+    advSecEnabled?: boolean;
+    /**
+     * The most recent time the enablement state was modified.
+     */
+    advSecEnabledChangedOnDate?: Date;
+    /**
+     * The first time the enablement state was modified.
+     */
+    advSecEnabledFirstChangedOnDate?: Date;
+    azureSubscriptionId?: string;
+    billingMode?: BillingMode;
+    organizationId?: string;
+    tenantId?: string;
+}
+
+export enum BillingMode {
+    /**
+     * None implies the organization is not billable because no Azure Subscription has been set.
+     */
+    None = 0,
+    /**
+     * When an organization is the only organization mapped to an Azure Subscription.
+     */
+    SingleOrg = 1,
+    /**
+     * When an organization is mapped to an Azure Subscription to which at least one other org is mapped.
+     */
+    MultiOrg = 2,
+}
+
+/**
+ * Information related to billing for Advanced Security services
+ */
+export interface MeterUsage {
+    /**
+     * The Azure DevOps account
+     */
+    accountId?: string;
+    azureSubscriptionId?: string;
+    /**
+     * A list of identifiers for the commiters to the repositories that have Advanced Security features enabled
+     */
+    billedCommitters?: string[];
+    /**
+     * The date this billing information pertains to
+     */
+    billingDate?: Date;
+    /**
+     * True when a bill is generated for Advanced Security feature usage in this organziation
+     */
+    isAdvSecBillable?: boolean;
+    /**
+     * True when Advanced Security features are enabled in this organization
+     */
+    isAdvSecEnabled?: boolean;
+    /**
+     * The Azure subscription
+     */
+    tenantId?: string;
+    /**
+     * The number of commiters to repositories that have Advanced Security features enabled
+     */
+    uniqueCommitterCount?: number;
+}
+
+export var TypeInfo = {
+    AdvSecEnablementSettings: <any>{
+    },
+    AdvSecEnablementStatus: <any>{
+    },
+    BillableCommitterDetails: <any>{
+    },
+    BillingInfo: <any>{
+    },
+    BillingMode: {
+        enumValues: {
+            "none": 0,
+            "singleOrg": 1,
+            "multiOrg": 2
+        }
+    },
+    MeterUsage: <any>{
+    },
+};
+
+TypeInfo.AdvSecEnablementSettings.fields = {
+    reposEnablementStatus: {
+        isArray: true,
+        typeInfo: TypeInfo.AdvSecEnablementStatus
+    }
+};
+
+TypeInfo.AdvSecEnablementStatus.fields = {
+    advSecEnablementLastChangedDate: {
+        isDate: true,
+    }
+};
+
+TypeInfo.BillableCommitterDetails.fields = {
+    commitTime: {
+        isDate: true,
+    },
+    pushedTime: {
+        isDate: true,
+    }
+};
+
+TypeInfo.BillingInfo.fields = {
+    advSecEnabledChangedOnDate: {
+        isDate: true,
+    },
+    advSecEnabledFirstChangedOnDate: {
+        isDate: true,
+    },
+    billingMode: {
+        enumType: TypeInfo.BillingMode
+    }
+};
+
+TypeInfo.MeterUsage.fields = {
+    billingDate: {
+        isDate: true,
+    }
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "12.2.0",
+    "version": "12.3.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "12.1.1",
+    "version": "12.2.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
In this change, we are introducing clients for [GitHub Advanced 
Security for Azure DevOps (GHAzDO)](https://azure.microsoft.com/en-us/products/devops/github-advanced-security).

Summary of the change is as follows:

  * Add `api/AlertApi.ts` and `api/ManagementApi.ts` and their
    respective interfaces to `api/interfaces`.
  * Update `README.md`
  * Update `api/WebApi.ts` to integrate the Advanced Security clients.
  * Update package version to `12.2.0`.