### PR TITLE
Add additional npm install step to fix package tests under node6

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,22 +5,31 @@ strategy:
   matrix:
     'Node 6':
       versionSpec: '6.x'
+      npmVersion: '5'
     'Node 8': 
       versionSpec: '8.x'
+      npmVersion: '6'
     'Node 10': 
       versionSpec: '10.x'
+      npmVersion: '6'
     'Node 12': 
       versionSpec: '12.x'
+      npmVersion: '6'
     'Node 14': 
       versionSpec: '14.x'
+      npmVersion: '6'
     'Node 16':
       versionSpec: '16.x'
+      npmVersion: '8'
 
 steps:
 - task: NodeTool@0
   inputs:
     versionSpec: $(versionSpec)
   displayName: Install node
+
+- script: npm install -g npm@$(npmVersion)
+  displayName: Upgrade npm
 
 # install dependencies
 - script: npm install


### PR DESCRIPTION
**Description**
Add the npm install step to fix package tests under node6.
The PR was tested via the pipeline. After the changes, the package tests started to work fine on node 6.