### PR TITLE
Update Advanced Security API clients

### DIFF
--- a/api/AlertApi.ts
+++ b/api/AlertApi.ts
@@ -25,7 +25,7 @@ export interface IAlertApi extends basem.ClientApiBase {
     getAlertInstances(project: string, alertId: number, repository: string, ref?: string): Promise<AlertInterfaces.AlertAnalysisInstance[]>;
     uploadSarif(customHeaders: any, contentStream: NodeJS.ReadableStream, project: string, repository: string): Promise<number>;
     getUxFilters(project: string, repository: string, alertType: AlertInterfaces.AlertType): Promise<AlertInterfaces.UxFilters>;
-    getSarif(sarifId: number): Promise<boolean>;
+    getSarif(sarifId: number): Promise<AlertInterfaces.SarifUploadStatus>;
 }
 
 export class AlertApi extends basem.ClientApiBase implements IAlertApi {
@@ -257,9 +257,11 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
     }
 
     /**
+     * Get instances of an alert.
+     * 
      * @param {string} project - Project ID or project name
-     * @param {number} alertId
-     * @param {string} repository
+     * @param {number} alertId - ID of alert to retrieve
+     * @param {string} repository - Name or id of a repository that alert is part of
      * @param {string} ref
      */
     public async getAlertInstances(
@@ -418,16 +420,16 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
      */
     public async getSarif(
         sarifId: number
-        ): Promise<boolean> {
+        ): Promise<AlertInterfaces.SarifUploadStatus> {
 
-        return new Promise<boolean>(async (resolve, reject) => {
+        return new Promise<AlertInterfaces.SarifUploadStatus>(async (resolve, reject) => {
             let routeValues: any = {
                 sarifId: sarifId
             };
 
             try {
                 let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
-                    "7.2-preview.1",
+                    "7.2-preview.2",
                     "Alert",
                     "a04689e7-0f81-48a2-8d18-40654c47494c",
                     routeValues);
@@ -436,11 +438,11 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
                                                                                 verData.apiVersion);
 
-                let res: restm.IRestResponse<boolean>;
-                res = await this.rest.get<boolean>(url, options);
+                let res: restm.IRestResponse<AlertInterfaces.SarifUploadStatus>;
+                res = await this.rest.get<AlertInterfaces.SarifUploadStatus>(url, options);
 
                 let ret = this.formatResponse(res.result,
-                                              null,
+                                              AlertInterfaces.TypeInfo.SarifUploadStatus,
                                               false);
 
                 resolve(ret);

--- a/api/ManagementApi.ts
+++ b/api/ManagementApi.ts
@@ -42,6 +42,8 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
     }
 
     /**
+     * Delete the billing info for an organization.
+     * 
      * @param {string} organizationId
      */
     public async deleteBillingInfo(
@@ -82,6 +84,8 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
     }
 
     /**
+     * Delete the meter usage history from Primary SU for an organization.
+     * 
      * @param {string} organizationId
      */
     public async deleteMeterUsageHistory(
@@ -164,6 +168,8 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
     }
 
     /**
+     * Save the billing info for an organization.
+     * 
      * @param {ManagementInterfaces.BillingInfo} billingInfo
      * @param {string} organizationId
      */

--- a/api/interfaces/AlertInterfaces.ts
+++ b/api/interfaces/AlertInterfaces.ts
@@ -79,7 +79,7 @@ export interface Alert {
      */
     truncatedSecret?: string;
     /**
-     * ValidationFingerprints for the secret liveness check. Only return on demanded
+     * ValidationFingerprints for the secret liveness check. Only returned on demand in Get API with Expand parameter set to be ValidationFingerprint (not returned in List API)
      */
     validationFingerprints?: ValidationFingerprint[];
 }
@@ -287,6 +287,9 @@ export enum ComponentType {
      * Indicates the component is a loose file. Not a package as understood by different package managers.
      */
     File = 9,
+    /**
+     * Indicates the component is a Go package.
+     */
     Go = 10,
     /**
      * Indicates the component is a Docker Image
@@ -576,6 +579,35 @@ export interface Rule {
      * Classification tags for this rule
      */
     tags?: string[];
+}
+
+export enum SarifJobStatus {
+    /**
+     * The job type when it is new
+     */
+    New = 0,
+    /**
+     * The job type when it is queued
+     */
+    Queued = 1,
+    /**
+     * The job type when it is completed
+     */
+    Completed = 2,
+    /**
+     * The job type when it fails
+     */
+    Failed = 3,
+}
+
+export interface SarifUploadStatus {
+    errors?: SarifValidationError[];
+    processingStatus?: SarifJobStatus;
+}
+
+export interface SarifValidationError {
+    nodePointer?: string;
+    validationError?: string;
 }
 
 export interface SearchCriteria {
@@ -877,6 +909,16 @@ export var TypeInfo = {
             "versionControl": 2
         }
     },
+    SarifJobStatus: {
+        enumValues: {
+            "new": 0,
+            "queued": 1,
+            "completed": 2,
+            "failed": 3
+        }
+    },
+    SarifUploadStatus: <any>{
+    },
     SearchCriteria: <any>{
     },
     Severity: {
@@ -1024,6 +1066,12 @@ TypeInfo.Result.fields = {
     },
     severity: {
         enumType: TypeInfo.Severity
+    }
+};
+
+TypeInfo.SarifUploadStatus.fields = {
+    processingStatus: {
+        enumType: TypeInfo.SarifJobStatus
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "12.3.0",
+    "version": "12.4.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
We are updating the Advanced Security API clients to make a recent change to the `GET /sarifs` endpoint available for consumption.