### PR TITLE
Use name instead of ID as a ref for sec files. 

### DIFF
--- a/api/interfaces/BuildInterfaces.ts
+++ b/api/interfaces/BuildInterfaces.ts
@@ -2615,9 +2615,9 @@ export interface ScheduleTrigger extends BuildTrigger {
  */
 export interface SecureFileReference extends ResourceReference {
     /**
-     * The ID of the secure file.
+     * The name of the secure file
      */
-    id?: string;
+    name?: string;
 }
 
 /**


### PR DESCRIPTION
# This PR is supposed to fix the following issue: https://github.com/microsoft/azure-pipelines-tasks/issues/6885

First of all I'm sorry if I broke any etiquette with this contribution.

In the classic pipelines the secure file reference was stored by the GUID of the secure file which was generated upon upload. The flow in this design was that the secure file has no option to update it's content.

When for example a config file has to be changed because of infrastructural changes then every classic pipeline using that secure file breaks because the newly uploaded secure file has a different GUID.

In the context of yaml pipelines this does not cause any issue because we store the secure file by name.