### PR TITLE
Bump typed-rest-client to fix vulnerability issue with the qs package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "azure-devops-node-api",
-    "version": "14.0.0",
+    "version": "14.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "13.0.0",
+            "version": "14.0.1",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",
-                "typed-rest-client": "^2.0.0"
+                "typed-rest-client": "^2.0.1"
             },
             "devDependencies": {
                 "@types/glob": "5.0.35",
@@ -22,6 +22,9 @@
                 "nock": "9.6.1",
                 "shelljs": "^0.8.5",
                 "typescript": "4.0.2"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
             }
         },
         "node_modules/@types/events": {
@@ -1471,13 +1474,13 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.0.tgz",
-            "integrity": "sha512-+yizhP/ax4D08n/zLvdvgJ62xbJB59Pf21lXLiTUM3uh8M5fq0UVkyjk0jULCyceu+KnCs+VubK0VlGFgKK+dg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.1.tgz",
+            "integrity": "sha512-LSfgVu+jKUbkceVBGJ6bdIMzzpvjhw6A+aKsVnGa2S7bT82QCALh/RAtq/fdV3aLXxHqsChuClrQ93fXMrIckA==",
             "dependencies": {
                 "des.js": "^1.1.0",
                 "js-md4": "^0.3.2",
-                "qs": "^6.9.7",
+                "qs": "^6.10.3",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
             },
@@ -2637,13 +2640,13 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.0.tgz",
-            "integrity": "sha512-+yizhP/ax4D08n/zLvdvgJ62xbJB59Pf21lXLiTUM3uh8M5fq0UVkyjk0jULCyceu+KnCs+VubK0VlGFgKK+dg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-2.0.1.tgz",
+            "integrity": "sha512-LSfgVu+jKUbkceVBGJ6bdIMzzpvjhw6A+aKsVnGa2S7bT82QCALh/RAtq/fdV3aLXxHqsChuClrQ93fXMrIckA==",
             "requires": {
                 "des.js": "^1.1.0",
                 "js-md4": "^0.3.2",
-                "qs": "^6.9.7",
+                "qs": "^6.10.3",
                 "tunnel": "0.0.6",
                 "underscore": "^1.12.1"
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "14.0.0",
+    "version": "14.0.1",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.0"
+        "typed-rest-client": "^2.0.1"
     },
     "devDependencies": {
         "@types/glob": "5.0.35",

--- a/samples/package-lock.json
+++ b/samples/package-lock.json
@@ -10,16 +10,15 @@
       "license": "MIT",
       "dependencies": {
         "azure-devops-node-api": "file:../_build"
-      },
-      "devDependencies": {}
+      }
     },
     "../_build": {
       "name": "azure-devops-node-api",
-      "version": "14.0.0",
+      "version": "14.0.1",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.0"
+        "typed-rest-client": "^2.0.1"
       },
       "devDependencies": {
         "@types/glob": "5.0.35",
@@ -197,7 +196,7 @@
         "nock": "9.6.1",
         "shelljs": "^0.8.5",
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.0",
+        "typed-rest-client": "^2.0.1",
         "typescript": "4.0.2"
       },
       "dependencies": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -15,11 +15,11 @@
     },
     "../_build": {
       "name": "azure-devops-node-api",
-      "version": "13.0.0",
+      "version": "14.0.1",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.0"
+        "typed-rest-client": "^2.0.1"
       },
       "devDependencies": {
         "@types/glob": "5.0.35",
@@ -31,6 +31,9 @@
         "nock": "9.6.1",
         "shelljs": "^0.8.5",
         "typescript": "4.0.2"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
       }
     },
     "../_build/node_modules/tunnel": {
@@ -120,7 +123,7 @@
         "nock": "9.6.1",
         "shelljs": "^0.8.5",
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.0",
+        "typed-rest-client": "^2.0.1",
         "typescript": "4.0.2"
       },
       "dependencies": {


### PR DESCRIPTION
In this PR I bumped the typed-rest-client version to fix vulnerability issue with the qs package
Please check related PR: https://github.com/microsoft/typed-rest-client/pull/371
https://nvd.nist.gov/vuln/detail/CVE-2022-24999