### PR TITLE
Mirror typed-rest-client options

### DIFF
--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -85,15 +85,20 @@ export interface IHttpClientResponse {
 }
 
 export interface IRequestOptions {
+    headers?: IHeaders;
     socketTimeout?: number;
     ignoreSslError?: boolean;
     proxy?: IProxyConfiguration;
     cert?: ICertConfiguration;
+    allowRedirects?: boolean;
+    allowRedirectDowngrade?: boolean;
+    maxRedirects?: number;
+    maxSockets?: number;
+    keepAlive?: boolean;
+    presignedUrlPatterns?: RegExp[];
+    // Allows retries only on Read operations (since writes may not be idempotent)
     allowRetries?: boolean;
     maxRetries?: number;
-    allowRedirects?: boolean;
-    maxRedirects?: number;
-    presignedUrlPatterns?: RegExp[];
 }
 
 export interface IProxyConfiguration {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "14.0.1",
+    "version": "14.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "14.0.1",
+    "version": "14.0.2",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
**Description**:
The PR mirroring [IRequestOptions ](https://github.com/microsoft/typed-rest-client/blob/master/lib/Interfaces.ts#L44)from typed-rest-client.
This is needed, because VsoBaseInterfaces.IRequestOptions uses with [WebApi](https://github.com/microsoft/azure-devops-node-api/blob/master/api/WebApi.ts#L169) and [ClientApiBases](https://github.com/microsoft/azure-devops-node-api/blob/master/api/ClientApiBases.ts#L23) which is, basically, wrappers for typed-rest-client's [HttpClient](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L125) and [RestClient](https://github.com/microsoft/typed-rest-client/blob/master/lib/RestClient.ts#L43).

_Also, this is potential fix for the problem with 5sec timeout._
Since node19 [http.GlobalAgent](https://nodejs.org/docs/latest/api/http.html#httpglobalagent) has 5 sec timeout which might be too short for Azure REST API.
By adding keppAlive request option we assign to request [own agent](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L524) with null timeout(as it was previously) instead of [global one](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L532) with 5sec timeout.
In case if proxy will be specified, the specific agent will be created as well without [timeout option.](https://github.com/microsoft/typed-rest-client/blob/master/lib/HttpClient.ts#L501)

**Related WI**: [AB#2194177](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2194177)

**Tested**: tested locally 