### PR TITLE
Updated PAT length

### DIFF
--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -49,6 +49,7 @@ import url = require('url');
 import path = require('path');
 
 const isBrowser: boolean = typeof window !== 'undefined';
+const personalAccessTokenRegex : RegExp = new RegExp('^.{76}AZDO.{4}$');
 /**
  * Methods to return handler objects (see handlers folder)
  */
@@ -70,7 +71,7 @@ export function getPersonalAccessTokenHandler(token: string, allowCrossOriginAut
 }
 
 export function getHandlerFromToken(token: string, allowCrossOriginAuthentication?: boolean): VsoBaseInterfaces.IRequestHandler {
-    if (token.length === 52) {
+    if (token.length === 52 || personalAccessTokenRegex.test(token)) {
         return getPersonalAccessTokenHandler(token, allowCrossOriginAuthentication);
     }
     else {


### PR DESCRIPTION
We have updated the PAT format and the length has changed from 52 characters to 84 characters: https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#changes-to-format

Before the rollout is fully complete and to prepare for the transition period between the new and old PAT formats, I would like to adjust this library to work with both of these formats/lengths.