### PR TITLE
Add `globalAgentOptions` property to `IRequestOptions` to mirror `typed-rest-client`

### DIFF
--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -84,6 +84,11 @@ export interface IHttpClientResponse {
     readBody(): Promise<string>;
 }
 
+export interface IHttpGlobalAgentOptions {
+    keepAlive?: boolean;
+    timeout?: number;
+}
+
 export interface IRequestOptions {
     headers?: IHeaders;
     socketTimeout?: number;
@@ -99,6 +104,7 @@ export interface IRequestOptions {
     // Allows retries only on Read operations (since writes may not be idempotent)
     allowRetries?: boolean;
     maxRetries?: number;
+    globalAgentOptions?: IHttpGlobalAgentOptions;
 }
 
 export interface IProxyConfiguration {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "azure-devops-node-api",
-    "version": "14.0.2",
+    "version": "14.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "14.0.2",
+            "version": "14.1.0",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",
-                "typed-rest-client": "^2.0.1"
+                "typed-rest-client": "2.1.0"
             },
             "devDependencies": {
                 "@types/glob": "5.0.35",
@@ -1652,9 +1652,9 @@
             }
         },
         "node_modules/typed-rest-client": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.0.2.tgz",
-            "integrity": "sha1-gtRRuaIZv4+miLaYslgTJ75Lkg0=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+            "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
             "license": "MIT",
             "dependencies": {
                 "des.js": "^1.1.0",
@@ -2858,9 +2858,9 @@
             "dev": true
         },
         "typed-rest-client": {
-            "version": "2.0.2",
-            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.0.2.tgz",
-            "integrity": "sha1-gtRRuaIZv4+miLaYslgTJ75Lkg0=",
+            "version": "2.1.0",
+            "resolved": "https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/PipelineTools_PublicPackages/npm/registry/typed-rest-client/-/typed-rest-client-2.1.0.tgz",
+            "integrity": "sha1-8Exs/KvGASwtA2uAbqrEVWBPFZg=",
             "requires": {
                 "des.js": "^1.1.0",
                 "js-md4": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "14.0.2",
+    "version": "14.1.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {
@@ -28,7 +28,7 @@
     },
     "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.1"
+        "typed-rest-client": "2.1.0"
     },
     "devDependencies": {
         "@types/glob": "5.0.35",


### PR DESCRIPTION
**WI**
[AB#2217825](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2217825)

**Description**
Include new `globalAgentOptions` property in `IRequestOptions` which was introduced to `typed-rest-client` in this PR: https://github.com/microsoft/typed-rest-client/pull/378