### PR TITLE
remove pipelines platform as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global rule:
-* @microsoft/azure-pipelines-tasks-and-agent    @microsoft/azure-pipelines-platform
+* @microsoft/azure-pipelines-tasks-and-agent


### PR DESCRIPTION
This repo is owned by Tasks & Agent team, it's not related with platform team at all and there are no commits from the platform team.