### PR TITLE
Add the prerelease publishing step in the CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,11 +85,20 @@ extends:
           workingDir: '_build'
           displayName: Get package name and version
         - task: Npm@1
-          displayName: Publish package as latest in Npmjs registry
+          displayName: Remove prerelease tag for azure-devops-node-api in Npm
           condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
           inputs:
             command: custom
             customCommand: dist-tag remove "$(npm_package)" prerelease
+            workingDir: '_build'
+            publishRegistry: useExternalRegistry
+            publishEndpoint: btt-npm-publish-token
+        - task: Npm@1
+          displayName: Add latest tag for azure-devops-node-api in Npm
+          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
+          inputs:
+            command: custom
+            customCommand: dist-tag add "$(npm_package)" latest
             workingDir: '_build'
             publishRegistry: useExternalRegistry
             publishEndpoint: btt-npm-publish-token

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,8 +60,36 @@ extends:
           displayName: Publish azure-devops-node-api to npm
           condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
           inputs:
-            command: publish
+            command: custom
+            customCommand: publish --tag prerelease
             workingDir: '_build'
             publishRegistry: useExternalRegistry
             publishEndpoint: btt-npm-publish-token
           continueOnError: true
+    - stage: Release
+      displayName: Release to Latest
+      trigger: manual
+      jobs:
+      - job: Release
+        displayName: Release to Latest
+        steps:
+        - checkout: self
+          clean: true
+        - task: NodeTool@0
+          inputs:
+            versionSpec: $(versionSpec)
+          displayName: Install node
+        - bash: |
+            package_name=$(npm pkg get name version | jq -r '"\(.name)@\(.version)"')
+            echo "##vso[task.setvariable variable=npm_package]$package_name"
+          workingDir: '_build'
+          displayName: Get package name and version
+        - task: Npm@1
+          displayName: Publish package as latest in Npmjs registry
+          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
+          inputs:
+            command: custom
+            customCommand: dist-tag remove "$(npm_package)" prerelease
+            workingDir: '_build'
+            publishRegistry: useExternalRegistry
+            publishEndpoint: btt-npm-publish-token

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,7 +82,7 @@ extends:
         - bash: |
             package_name=$(npm pkg get name version | jq -r '"\(.name)@\(.version)"')
             echo "##vso[task.setvariable variable=npm_package]$package_name"
-          workingDir: '_build'
+          workingDirectory: '_build'
           displayName: Get package name and version
         - task: Npm@1
           displayName: Remove prerelease tag for azure-devops-node-api in Npm


### PR DESCRIPTION
**Description:** Add the CI step for publishing a prerelease version of the package that can be manually invoked when needed.

**Related WI:** [AB#2278468](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2278468)