### PR TITLE
Publish the package for the Node16 only in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,7 @@ extends:
           displayName: Run unit tests
         - task: Npm@1
           displayName: Publish azure-devops-node-api to npm
-          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'), and(variables['npmVersion'], '8'))
+          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'), eq(variables['npmVersion'], '8'))
           inputs:
             command: custom
             customCommand: publish --tag prerelease


### PR DESCRIPTION
**Description**: The publishing step is triggered for every strategy item, so we need to check the variable npmVersion to be 8 to publish it only for Nodejs v16

**Related WI**: [AB#2279742](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2279742)