### PR TITLE
Add PredefinedQueries API and UserAgent configurability

### DIFF
--- a/api/AlertApi.ts
+++ b/api/AlertApi.ts
@@ -34,8 +34,8 @@ export interface IAlertApi extends basem.ClientApiBase {
 }
 
 export class AlertApi extends basem.ClientApiBase implements IAlertApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Alert-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Alert-api', options);
     }
 
     /**

--- a/api/BuildApi.ts
+++ b/api/BuildApi.ts
@@ -118,8 +118,8 @@ export interface IBuildApi extends basem.ClientApiBase {
 }
 
 export class BuildApi extends basem.ClientApiBase implements IBuildApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Build-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Build-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "965220d5-5bb9-42cf-8d67-9b146df2a5a4";

--- a/api/CIXApi.ts
+++ b/api/CIXApi.ts
@@ -25,8 +25,8 @@ export interface ICixApi extends basem.ClientApiBase {
 }
 
 export class CixApi extends basem.ClientApiBase implements ICixApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Pipelines-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Pipelines-api', options);
     }
 
     /**

--- a/api/CoreApi.ts
+++ b/api/CoreApi.ts
@@ -55,8 +55,8 @@ export interface ICoreApi extends basem.ClientApiBase {
 }
 
 export class CoreApi extends basem.ClientApiBase implements ICoreApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Core-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Core-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "79134c72-4a58-4b42-976c-04e7115f32bf";

--- a/api/DashboardApi.ts
+++ b/api/DashboardApi.ts
@@ -34,8 +34,8 @@ export interface IDashboardApi extends basem.ClientApiBase {
 }
 
 export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Dashboard-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Dashboard-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "31c84e0a-3ece-48fd-a29d-100849af99ba";

--- a/api/ExtensionManagementApi.ts
+++ b/api/ExtensionManagementApi.ts
@@ -46,8 +46,8 @@ export interface IExtensionManagementApi extends basem.ClientApiBase {
 }
 
 export class ExtensionManagementApi extends basem.ClientApiBase implements IExtensionManagementApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-ExtensionManagement-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-ExtensionManagement-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "6c2b0933-3600-42ae-bf8b-93d4f7e83594";

--- a/api/FeatureManagementApi.ts
+++ b/api/FeatureManagementApi.ts
@@ -29,8 +29,8 @@ export interface IFeatureManagementApi extends basem.ClientApiBase {
 }
 
 export class FeatureManagementApi extends basem.ClientApiBase implements IFeatureManagementApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-FeatureManagement-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-FeatureManagement-api', options);
     }
 
     /**

--- a/api/FileContainerApi.ts
+++ b/api/FileContainerApi.ts
@@ -25,8 +25,8 @@ export interface IFileContainerApi extends FileContainerApiBase.IFileContainerAp
 }
 
 export class FileContainerApi extends FileContainerApiBase.FileContainerApiBase implements IFileContainerApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, options, userAgent);
     }
 
     /**

--- a/api/FileContainerApiBase.ts
+++ b/api/FileContainerApiBase.ts
@@ -25,8 +25,8 @@ export interface IFileContainerApiBase extends basem.ClientApiBase {
 }
 
 export class FileContainerApiBase extends basem.ClientApiBase implements IFileContainerApiBase {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-FileContainer-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-FileContainer-api', options);
     }
 
     /**

--- a/api/GalleryApi.ts
+++ b/api/GalleryApi.ts
@@ -105,8 +105,8 @@ export interface IGalleryApi extends compatBase.GalleryCompatHttpClientBase {
 }
 
 export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implements IGalleryApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Gallery-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Gallery-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "69d21c00-f135-441b-b5ce-3626378e0819";

--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -175,8 +175,8 @@ export interface IGitApi extends basem.ClientApiBase {
 }
 
 export class GitApi extends basem.ClientApiBase implements IGitApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Git-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Git-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "4e080c62-fa21-4fbc-8fef-2a10a2b38049";

--- a/api/LocationsApi.ts
+++ b/api/LocationsApi.ts
@@ -31,8 +31,8 @@ export interface ILocationsApi extends basem.ClientApiBase {
 }
 
 export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Locations-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Locations-api', options);
     }
 
     /**

--- a/api/ManagementApi.ts
+++ b/api/ManagementApi.ts
@@ -49,8 +49,8 @@ export interface IManagementApi extends basem.ClientApiBase {
 }
 
 export class ManagementApi extends basem.ClientApiBase implements IManagementApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Management-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Management-api', options);
     }
 
     /**

--- a/api/NotificationApi.ts
+++ b/api/NotificationApi.ts
@@ -45,8 +45,8 @@ export interface INotificationApi extends basem.ClientApiBase {
 }
 
 export class NotificationApi extends basem.ClientApiBase implements INotificationApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Notification-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Notification-api', options);
     }
 
     /**

--- a/api/PipelinesApi.ts
+++ b/api/PipelinesApi.ts
@@ -30,8 +30,8 @@ export interface IPipelinesApi extends basem.ClientApiBase {
 }
 
 export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Pipelines-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Pipelines-api', options);
     }
 
     /**

--- a/api/PolicyApi.ts
+++ b/api/PolicyApi.ts
@@ -33,8 +33,8 @@ export interface IPolicyApi extends basem.ClientApiBase {
 }
 
 export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Policy-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Policy-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "fb13a388-40dd-4a04-b530-013a739c72ef";

--- a/api/ProfileApi.ts
+++ b/api/ProfileApi.ts
@@ -40,8 +40,8 @@ export interface IProfileApi extends basem.ClientApiBase {
 }
 
 export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Profile-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Profile-api', options);
     }
 
     /**

--- a/api/ProjectAnalysisApi.ts
+++ b/api/ProjectAnalysisApi.ts
@@ -24,8 +24,8 @@ export interface IProjectAnalysisApi extends basem.ClientApiBase {
 }
 
 export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectAnalysisApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-ProjectAnalysis-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-ProjectAnalysis-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "7658fa33-b1bf-4580-990f-fac5896773d3";

--- a/api/ReleaseApi.ts
+++ b/api/ReleaseApi.ts
@@ -110,8 +110,8 @@ export interface IReleaseApi extends basem.ClientApiBase {
 }
 
 export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Release-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Release-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "efc2f575-36ef-48e9-b672-0c6fb4a48ac5";

--- a/api/SecurityRolesApi.ts
+++ b/api/SecurityRolesApi.ts
@@ -28,8 +28,8 @@ export interface ISecurityRolesApi extends basem.ClientApiBase {
 }
 
 export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRolesApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-SecurityRoles-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-SecurityRoles-api', options);
     }
 
     /**

--- a/api/TaskAgentApi.ts
+++ b/api/TaskAgentApi.ts
@@ -16,8 +16,8 @@ export class TaskAgentApi extends taskagentbasem.TaskAgentApiBase implements ITa
     private _options: VsoBaseInterfaces.IRequestOptions;
     private _fallbackClient: TaskAgentApi;
 
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, options, userAgent);
 
         // hang on to the handlers in case we need to fall back to an account-level client
         this._handlers = handlers;

--- a/api/TaskAgentApiBase.ts
+++ b/api/TaskAgentApiBase.ts
@@ -177,8 +177,8 @@ export interface ITaskAgentApiBase extends basem.ClientApiBase {
 }
 
 export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentApiBase {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-TaskAgent-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-TaskAgent-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd";

--- a/api/TaskApi.ts
+++ b/api/TaskApi.ts
@@ -46,8 +46,8 @@ export interface ITaskApi extends basem.ClientApiBase {
 }
 
 export class TaskApi extends basem.ClientApiBase implements ITaskApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Task-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Task-api', options);
     }
 
     /**

--- a/api/TestApi.ts
+++ b/api/TestApi.ts
@@ -98,8 +98,8 @@ export interface ITestApi extends basem.ClientApiBase {
 }
 
 export class TestApi extends basem.ClientApiBase implements ITestApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Test-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Test-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e";

--- a/api/TestPlanApi.ts
+++ b/api/TestPlanApi.ts
@@ -68,8 +68,8 @@ export interface ITestPlanApi extends basem.ClientApiBase {
 }
 
 export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-TestPlan-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-TestPlan-api', options);
     }
 
     /**

--- a/api/TestResultsApi.ts
+++ b/api/TestResultsApi.ts
@@ -142,8 +142,8 @@ export interface ITestResultsApi extends basem.ClientApiBase {
 }
 
 export class TestResultsApi extends basem.ClientApiBase implements ITestResultsApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-testResults-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-testResults-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "c83eaf52-edf3-4034-ae11-17d38f25404c";

--- a/api/TfvcApi.ts
+++ b/api/TfvcApi.ts
@@ -45,8 +45,8 @@ export interface ITfvcApi extends basem.ClientApiBase {
 }
 
 export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Tfvc-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Tfvc-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "8aa40520-446d-40e6-89f6-9c9f9ce44c48";

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -81,7 +81,8 @@ export function getHandlerFromToken(token: string, allowCrossOriginAuthenticatio
 
 export interface IWebApiRequestSettings {
     productName: string,
-    productVersion: string
+    productVersion: string,
+    userAgent?: string
 };
 
 // ---------------------------------------------------------------------------
@@ -95,6 +96,7 @@ export class WebApi {
     public rest: rm.RestClient;
     public vsoClient: vsom.VsoClient;
     public options: VsoBaseInterfaces.IRequestOptions;
+    public userAgent?: string;
 
     private _resourceAreas: lim.ResourceAreaInfo[];
 
@@ -145,7 +147,10 @@ export class WebApi {
 
         let userAgent: string;
         const nodeApiName: string = 'azure-devops-node-api';
-        if(isBrowser) {
+        if(requestSettings && requestSettings.userAgent) {
+            userAgent = requestSettings.userAgent;
+            this.userAgent = requestSettings.userAgent;
+        } else if(isBrowser) {
             if(requestSettings) {
                 userAgent = `${requestSettings.productName}/${requestSettings.productVersion} (${nodeApiName}; ${window.navigator.userAgent})`
             } else {
@@ -202,60 +207,60 @@ export class WebApi {
     public async getAlertApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<alertm.IAlertApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "0f2ca920-f269-4545-b1f4-5b4173aa784e");
         handlers = handlers || [this.authHandler];
-        return new alertm.AlertApi(serverUrl, handlers, this.options);
+        return new alertm.AlertApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getBuildApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<buildm.IBuildApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, buildm.BuildApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
-        return new buildm.BuildApi(serverUrl, handlers, this.options);
+        return new buildm.BuildApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getCoreApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<corem.ICoreApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "79134c72-4a58-4b42-976c-04e7115f32bf");
         handlers = handlers || [this.authHandler];
-        return new corem.CoreApi(serverUrl, handlers, this.options);
+        return new corem.CoreApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getDashboardApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<dashboardm.IDashboardApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "31c84e0a-3ece-48fd-a29d-100849af99ba");
         handlers = handlers || [this.authHandler];
-        return new dashboardm.DashboardApi(serverUrl, handlers, this.options);
+        return new dashboardm.DashboardApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getExtensionManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<extmgmtm.IExtensionManagementApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "6c2b0933-3600-42ae-bf8b-93d4f7e83594");
         handlers = handlers || [this.authHandler];
-        return new extmgmtm.ExtensionManagementApi(serverUrl, handlers, this.options);
+        return new extmgmtm.ExtensionManagementApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getFeatureManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<featuremgmtm.IFeatureManagementApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
         handlers = handlers || [this.authHandler];
-        return new featuremgmtm.FeatureManagementApi(serverUrl, handlers, this.options);
+        return new featuremgmtm.FeatureManagementApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getFileContainerApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<filecontainerm.IFileContainerApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
         handlers = handlers || [this.authHandler];
-        return new filecontainerm.FileContainerApi(serverUrl, handlers, this.options);
+        return new filecontainerm.FileContainerApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getGalleryApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gallerym.IGalleryApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gallerym.GalleryApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
-        return new gallerym.GalleryApi(serverUrl, handlers, this.options);
+        return new gallerym.GalleryApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getGitApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<gitm.IGitApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, gitm.GitApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
-        return new gitm.GitApi(serverUrl, handlers, this.options);
+        return new gitm.GitApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     // TODO: Don't call resource area here? Will cause infinite loop?
@@ -265,145 +270,145 @@ export class WebApi {
         optionsClone.maxRetries = 5;
         serverUrl = await serverUrl || this.serverUrl;
         handlers = handlers || [this.authHandler];
-        return new locationsm.LocationsApi(serverUrl, handlers, optionsClone);
+        return new locationsm.LocationsApi(serverUrl, handlers, optionsClone, this.userAgent);
     }
 
     public async getManagementApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<managementm.IManagementApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "f101720c-9790-45a6-9fb3-494a09fddeeb");
         handlers = handlers || [this.authHandler];
-        return new managementm.ManagementApi(serverUrl, handlers, this.options);
+        return new managementm.ManagementApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getNotificationApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<notificationm.INotificationApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
         handlers = handlers || [this.authHandler];
-        return new notificationm.NotificationApi(serverUrl, handlers, this.options);
+        return new notificationm.NotificationApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getPolicyApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<policym.IPolicyApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "fb13a388-40dd-4a04-b530-013a739c72ef");
         handlers = handlers || [this.authHandler];
-        return new policym.PolicyApi(serverUrl, handlers, this.options);
+        return new policym.PolicyApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getProfileApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<profilem.IProfileApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8ccfef3d-2b87-4e99-8ccb-66e343d2daa8");
         handlers = handlers || [this.authHandler];
-        return new profilem.ProfileApi(serverUrl, handlers, this.options);
+        return new profilem.ProfileApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getProjectAnalysisApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<projectm.IProjectAnalysisApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "7658fa33-b1bf-4580-990f-fac5896773d3");
         handlers = handlers || [this.authHandler];
-        return new projectm.ProjectAnalysisApi(serverUrl, handlers, this.options);
+        return new projectm.ProjectAnalysisApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getSecurityRolesApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<securityrolesm.ISecurityRolesApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
         handlers = handlers || [this.authHandler];
-        return new securityrolesm.SecurityRolesApi(serverUrl, handlers, this.options);
+        return new securityrolesm.SecurityRolesApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getReleaseApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<releasem.IReleaseApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "efc2f575-36ef-48e9-b672-0c6fb4a48ac5");
         handlers = handlers || [this.authHandler];
-        return new releasem.ReleaseApi(serverUrl, handlers, this.options);
+        return new releasem.ReleaseApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTaskApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskm.ITaskApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "");
         handlers = handlers || [this.authHandler];
-        return new taskm.TaskApi(serverUrl, handlers, this.options);
+        return new taskm.TaskApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTaskAgentApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<taskagentm.ITaskAgentApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "a85b8835-c1a1-4aac-ae97-1c3d0ba72dbd");
         handlers = handlers || [this.authHandler];
-        return new taskagentm.TaskAgentApi(serverUrl, handlers, this.options);
+        return new taskagentm.TaskAgentApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTestApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testm.ITestApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c2aa639c-3ccc-4740-b3b6-ce2a1e1d984e");
         handlers = handlers || [this.authHandler];
-        return new testm.TestApi(serverUrl, handlers, this.options);
+        return new testm.TestApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTestPlanApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testplanm.ITestPlanApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "e4c27205-9d23-4c98-b958-d798bc3f9cd4");
         handlers = handlers || [this.authHandler];
-        return new testplanm.TestPlanApi(serverUrl, handlers, this.options);
+        return new testplanm.TestPlanApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTestResultsApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<testresultsm.ITestResultsApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "c83eaf52-edf3-4034-ae11-17d38f25404c");
         handlers = handlers || [this.authHandler];
-        return new testresultsm.TestResultsApi(serverUrl, handlers, this.options);
+        return new testresultsm.TestResultsApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getTfvcApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<tfvcm.ITfvcApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "8aa40520-446d-40e6-89f6-9c9f9ce44c48");
         handlers = handlers || [this.authHandler];
-        return new tfvcm.TfvcApi(serverUrl, handlers, this.options);
+        return new tfvcm.TfvcApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getWikiApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<wikim.IWikiApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3");
         handlers = handlers || [this.authHandler];
-        return new wikim.WikiApi(serverUrl, handlers, this.options);
+        return new wikim.WikiApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getWorkApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workm.IWorkApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9");
         handlers = handlers || [this.authHandler];
-        return new workm.WorkApi(serverUrl, handlers, this.options);
+        return new workm.WorkApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getWorkItemTrackingApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingm.IWorkItemTrackingApi> {
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, workitemtrackingm.WorkItemTrackingApi.RESOURCE_AREA_ID);
         handlers = handlers || [this.authHandler];
-        return new workitemtrackingm.WorkItemTrackingApi(serverUrl, handlers, this.options);
+        return new workitemtrackingm.WorkItemTrackingApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getWorkItemTrackingProcessApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessm.IWorkItemTrackingProcessApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
         handlers = handlers || [this.authHandler];
-        return new workitemtrackingprocessm.WorkItemTrackingProcessApi(serverUrl, handlers, this.options);
+        return new workitemtrackingprocessm.WorkItemTrackingProcessApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getWorkItemTrackingProcessDefinitionApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<workitemtrackingprocessdefinitionm.IWorkItemTrackingProcessDefinitionsApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
         handlers = handlers || [this.authHandler];
-        return new workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi(serverUrl, handlers, this.options);
+        return new workitemtrackingprocessdefinitionm.WorkItemTrackingProcessDefinitionsApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getPipelinesApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<pipelinesm.IPipelinesApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
         handlers = handlers || [this.authHandler];
-        return new pipelinesm.PipelinesApi(serverUrl, handlers, this.options);
+        return new pipelinesm.PipelinesApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     public async getCixApi(serverUrl?: string, handlers?: VsoBaseInterfaces.IRequestHandler[]): Promise<cixm.ICixApi> {
         // TODO: Load RESOURCE_AREA_ID correctly.
         serverUrl = await this._getResourceAreaUrl(serverUrl || this.serverUrl, "5264459e-e5e0-4bd8-b118-0985e68a4ec5");
         handlers = handlers || [this.authHandler];
-        return new cixm.CixApi(serverUrl, handlers, this.options);
+        return new cixm.CixApi(serverUrl, handlers, this.options, this.userAgent);
     }
 
     /**

--- a/api/WikiApi.ts
+++ b/api/WikiApi.ts
@@ -45,8 +45,8 @@ export interface IWikiApi extends basem.ClientApiBase {
 }
 
 export class WikiApi extends basem.ClientApiBase implements IWikiApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Wiki-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Wiki-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "bf7d82a0-8aa5-4613-94ef-6172a5ea01f3";

--- a/api/WorkApi.ts
+++ b/api/WorkApi.ts
@@ -59,6 +59,8 @@ export interface IWorkApi extends basem.ClientApiBase {
     getPlan(project: string, id: string): Promise<WorkInterfaces.Plan>;
     getPlans(project: string): Promise<WorkInterfaces.Plan[]>;
     updatePlan(updatedPlan: WorkInterfaces.UpdatePlan, project: string, id: string): Promise<WorkInterfaces.Plan>;
+    getPredefinedQueries(project: string): Promise<WorkInterfaces.PredefinedQuery[]>;
+    getPredefinedQueryResults(project: string, id: string, top?: number, includeCompleted?: boolean): Promise<WorkInterfaces.PredefinedQuery>;
     getProcessConfiguration(project: string): Promise<WorkInterfaces.ProcessConfiguration>;
     getBoardRows(teamContext: TfsCoreInterfaces.TeamContext, board: string): Promise<WorkInterfaces.BoardRow[]>;
     updateBoardRows(boardRows: WorkInterfaces.BoardRow[], teamContext: TfsCoreInterfaces.TeamContext, board: string): Promise<WorkInterfaces.BoardRow[]>;
@@ -2190,6 +2192,101 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
 
                 let ret = this.formatResponse(res.result,
                                               WorkInterfaces.TypeInfo.Plan,
+                                              false);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Retrieves the set of known queries
+     * 
+     * @param {string} project - Project ID or project name
+     */
+    public async getPredefinedQueries(
+        project: string
+        ): Promise<WorkInterfaces.PredefinedQuery[]> {
+
+        return new Promise<WorkInterfaces.PredefinedQuery[]>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project
+            };
+
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "work",
+                    "9cbba37c-6cc6-4f70-b903-709be86acbf0",
+                    routeValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.PredefinedQuery[]>;
+                res = await this.rest.get<WorkInterfaces.PredefinedQuery[]>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
+                                              true);
+
+                resolve(ret);
+                
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    /**
+     * Retrieves the specified predefined query including the query results
+     * 
+     * @param {string} project - Project ID or project name
+     * @param {string} id - Id of the query to run
+     * @param {number} top - The maximum number of items to return
+     * @param {boolean} includeCompleted - Whether or not to retrieve the 'completed' work items (work items in the 'completed' meta state)
+     */
+    public async getPredefinedQueryResults(
+        project: string,
+        id: string,
+        top?: number,
+        includeCompleted?: boolean
+        ): Promise<WorkInterfaces.PredefinedQuery> {
+
+        return new Promise<WorkInterfaces.PredefinedQuery>(async (resolve, reject) => {
+            let routeValues: any = {
+                project: project,
+                id: id
+            };
+
+            let queryValues: any = {
+                '$top': top,
+                includeCompleted: includeCompleted,
+            };
+            
+            try {
+                let verData: vsom.ClientVersioningData = await this.vsoClient.getVersioningData(
+                    "7.2-preview.1",
+                    "work",
+                    "9cbba37c-6cc6-4f70-b903-709be86acbf0",
+                    routeValues,
+                    queryValues);
+
+                let url: string = verData.requestUrl!;
+                let options: restm.IRequestOptions = this.createRequestOptions('application/json', 
+                                                                                verData.apiVersion);
+
+                let res: restm.IRestResponse<WorkInterfaces.PredefinedQuery>;
+                res = await this.rest.get<WorkInterfaces.PredefinedQuery>(url, options);
+
+                let ret = this.formatResponse(res.result,
+                                              null,
                                               false);
 
                 resolve(ret);

--- a/api/WorkApi.ts
+++ b/api/WorkApi.ts
@@ -80,8 +80,8 @@ export interface IWorkApi extends basem.ClientApiBase {
 }
 
 export class WorkApi extends basem.ClientApiBase implements IWorkApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-Work-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-Work-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "1d4f49f9-02b9-4e26-b826-2cdb6195f2a9";

--- a/api/WorkItemTrackingApi.ts
+++ b/api/WorkItemTrackingApi.ts
@@ -112,8 +112,8 @@ export interface IWorkItemTrackingApi extends basem.ClientApiBase {
 }
 
 export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkItemTrackingApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-WorkItemTracking-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-WorkItemTracking-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";

--- a/api/WorkItemTrackingProcessApi.ts
+++ b/api/WorkItemTrackingProcessApi.ts
@@ -77,8 +77,8 @@ export interface IWorkItemTrackingProcessApi extends basem.ClientApiBase {
 }
 
 export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements IWorkItemTrackingProcessApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-WorkItemTracking-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-WorkItemTracking-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";

--- a/api/WorkItemTrackingProcessDefinitionsApi.ts
+++ b/api/WorkItemTrackingProcessDefinitionsApi.ts
@@ -66,8 +66,8 @@ export interface IWorkItemTrackingProcessDefinitionsApi extends basem.ClientApiB
 }
 
 export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase implements IWorkItemTrackingProcessDefinitionsApi {
-    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions) {
-        super(baseUrl, handlers, 'node-WorkItemTracking-api', options);
+    constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], options?: VsoBaseInterfaces.IRequestOptions, userAgent?: string) {
+        super(baseUrl, handlers, userAgent || 'node-WorkItemTracking-api', options);
     }
 
     public static readonly RESOURCE_AREA_ID = "5264459e-e5e0-4bd8-b118-0985e68a4ec5";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.0.0",
+    "version": "15.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "15.0.0",
+            "version": "15.1.0",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.0.0",
+    "version": "15.1.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
This change contains two pieces necessary for library integration into another tool built currently internally:
1. new APIs that were published recently in the ADO product
2. ability to wire specific `User-Agent` header value to be able to trace all requests from a specific tool in server side telemetry