### PR TITLE
Fix node version in the latest version publishing CI stage

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ extends:
           clean: true
         - task: NodeTool@0
           inputs:
-            versionSpec: $(versionSpec)
+            versionSpec: 16.x
           displayName: Install node
         - bash: |
             package_name=$(npm pkg get name version | jq -r '"\(.name)@\(.version)"')


### PR DESCRIPTION
**Description:** The Nodejs version was copy-pasted from prerelease stage and versionSpec variable is missed in the latest version publishing CI stage.
Currently, the Nodejs is set to 16.*