### PR TITLE
Fix array-type query parameter handling

### DIFF
--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -195,7 +195,8 @@ export class VsoClient {
         let queryString: string = '';
 
         if (Array.isArray(queryParams)) {
-            const paramName = prefix.slice(0, -1); // Remove trailing '.'
+            // Remove trailing '.' from prefix if it exists, otherwise use the prefix as-is
+            const paramName = prefix.endsWith('.') ? prefix.slice(0, -1) : prefix;
             const values = queryParams.map(value => value.toString()).join(',');
             queryString += paramName + '=' + encodeURIComponent(values) + '&';
             return queryString;
@@ -216,9 +217,9 @@ export class VsoClient {
             // Need to specially call `toUTCString()` instead for such cases
             const queryValue = typeof queryParams === 'object' && 'toUTCString' in queryParams ? (queryParams as Date).toUTCString() : queryParams.toString();
 
-
-            // Will always need to chop period off of end of prefix
-            queryString = prefix.slice(0, -1) + '=' + encodeURIComponent(queryValue) + '&';
+            // Will always need to chop period off of end of prefix, if it exists
+            const paramName = prefix.endsWith('.') ? prefix.slice(0, -1) : prefix;
+            queryString = paramName + '=' + encodeURIComponent(queryValue) + '&';
         }
         return queryString;
     }

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -194,6 +194,15 @@ export class VsoClient {
         }
         let queryString: string = '';
 
+        if (Array.isArray(queryParams)) {
+            const paramName = prefix.slice(0, -1); // Remove trailing '.'
+            for (let i = 0; i < queryParams.length; i++) {
+                const value = queryParams[i];
+                queryString += paramName + '=' + encodeURIComponent(value.toString()) + '&';
+            }
+            return queryString;
+        }
+
         if (typeof (queryParams) !== 'string') {
             for (let property in queryParams) {
                 if (queryParams.hasOwnProperty(property)) {

--- a/api/VsoClient.ts
+++ b/api/VsoClient.ts
@@ -196,10 +196,8 @@ export class VsoClient {
 
         if (Array.isArray(queryParams)) {
             const paramName = prefix.slice(0, -1); // Remove trailing '.'
-            for (let i = 0; i < queryParams.length; i++) {
-                const value = queryParams[i];
-                queryString += paramName + '=' + encodeURIComponent(value.toString()) + '&';
-            }
+            const values = queryParams.map(value => value.toString()).join(',');
+            queryString += paramName + '=' + encodeURIComponent(values) + '&';
             return queryString;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.0",
+    "version": "15.1.1",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -163,6 +163,27 @@ describe('VSOClient Units', function () {
         assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?status.innerstatus=2&version=1&nestedObject.nestedField=value&nestedObject.innerNestedObject.key=val2');
     });
 
+    it('gets versioning data with array-typed query params', async () => {
+        //Arrange
+        nock('https://dev.azure.com/_apis/testArea5', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': 'testAgent'
+            }})
+            .options('')
+            .reply(200, {
+                value: [{id: 'testLocation', maxVersion: '1', releasedVersion: '1', routeTemplate: 'testTemplate', area: 'testArea5', resourceName: 'testName', resourceVersion: '1'}]
+        });
+
+        //Act
+        const queryParams = {states: ["active", "inactive"]};
+        const res: vsom.ClientVersioningData = await vsoClient.getVersioningData('1', 'testArea5', 'testLocation', {'testKey': 'testValue'}, queryParams);
+
+        //Assert
+        assert.equal(res.apiVersion, '1');
+        assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?states=active&states=inactive');
+    });
+
     it('gets versioning datafor dates', async () => {
         //Arrange
         nock('https://dev.azure.com/_apis/testArea5', {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -184,6 +184,41 @@ describe('VSOClient Units', function () {
         assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?states=active%2Cinactive');
     });
 
+    it('gets versioning data with mixed query parameter types', async () => {
+        //Arrange
+        nock('https://dev.azure.com/_apis/testArea9', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': 'testAgent'
+            }})
+            .options('')
+            .reply(200, {
+                value: [{id: 'testLocation', maxVersion: '1', releasedVersion: '1', routeTemplate: 'testTemplate', area: 'testArea9', resourceName: 'testName', resourceVersion: '1'}]
+        });
+
+        //Act
+        const queryParams = {
+            // Simple parameter
+            status: 'completed',
+            // Nested parameter
+            filter: { type: 'build' },
+            // Complex nested parameter
+            options: {
+                sorting: { field: 'date', order: 'desc' },
+                pagination: { limit: 50 }
+            },
+            // Array parameter
+            tags: ['important', 'release', 'verified'],
+            // Another array parameter
+            assignedTo: ['user1', 'user2']
+        };
+        const res: vsom.ClientVersioningData = await vsoClient.getVersioningData('1', 'testArea9', 'testLocation', {'testKey': 'testValue'}, queryParams);
+
+        //Assert
+        assert.equal(res.apiVersion, '1');
+        assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?status=completed&filter.type=build&options.sorting.field=date&options.sorting.order=desc&options.pagination.limit=50&tags=important%2Crelease%2Cverified&assignedTo=user1%2Cuser2');
+    });
+
     it('gets versioning datafor dates', async () => {
         //Arrange
         nock('https://dev.azure.com/_apis/testArea5', {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -181,7 +181,7 @@ describe('VSOClient Units', function () {
 
         //Assert
         assert.equal(res.apiVersion, '1');
-        assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?states=active&states=inactive');
+        assert.equal(res.requestUrl, 'https://dev.azure.com/testTemplate?states=active%2Cinactive');
     });
 
     it('gets versioning datafor dates', async () => {


### PR DESCRIPTION
In this change, a bug in the way `VsoClient.queryParamsToStringHelper`
handles array-typed query parameters values is fix. After this change,
a query parameter dictionary like `{states: ["active", "inactive"]}` 
will produce `states=active,inactive` instead of
`states.0=active&states.1=inactive`.

Fix #643