### PR TITLE
fix to return rate limit headers

### DIFF
--- a/api/ClientApiBases.ts
+++ b/api/ClientApiBases.ts
@@ -60,19 +60,19 @@ export class ClientApiBase {
             rateLimit.resource = headers['x-ratelimit-resource'];
         }
         if (headers['x-ratelimit-delay']) {
-            rateLimit.delay = headers['x-ratelimit-delay'];
+            rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
         }
         if (headers['x-ratelimit-limit']) {
-            rateLimit.limit = headers['x-ratelimit-limit'];
+            rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
         }
         if (headers['x-ratelimit-remaining']) {
-            rateLimit.remaining = headers['x-ratelimit-remaining'];
+            rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
         }
         if (headers['x-ratelimit-reset']) {
-            rateLimit.reset = headers['x-ratelimit-reset'];
+            rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
         }
         if (headers['retry-after']) {
-            rateLimit.retryAfter = headers['retry-after'];
+            rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
         }
         target.rateLimit = rateLimit;
     }

--- a/api/interfaces/common/VsoBaseInterfaces.ts
+++ b/api/interfaces/common/VsoBaseInterfaces.ts
@@ -123,27 +123,27 @@ export interface ICertConfiguration {
 
 export interface RateLimit {
     /**
-     * The resource bucket that was rate limited (e.g., "core", "search")
+     * Service and type of threshold reached. For display purposes only.
      */
     resource?: string;
     /**
-     * Delay in seconds before the next request (tarpit state)
+     * Request delay in seconds (tarpit state). Supports up to 3 decimal places.
      */
-    delay?: string;
+    delay?: number;
     /**
-     * Maximum number of requests allowed in the time window
+     * Total TSTUs allowed before delays are imposed.
      */
-    limit?: string;
+    limit?: number;
     /**
-     * Number of requests remaining in the current time window
+     * TSTUs remaining before delays start. 0 if already delayed or blocked.
      */
-    remaining?: string;
+    remaining?: number;
     /**
-     * UTC timestamp when the rate limit resets
+     * Unix epoch time (seconds) when usage resets to 0 TSTUs.
      */
-    reset?: string;
+    reset?: number;
     /**
-     * Number of seconds to wait before retrying (block state, HTTP 429)
+     * Seconds to wait before retrying (HTTP 429 block state).
      */
-    retryAfter?: string;
+    retryAfter?: number;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.1.1",
+    "version": "15.1.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "15.1.1",
+            "version": "15.1.2",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.1",
+    "version": "15.1.2",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
**Summary**
This PR adds support for extracting and exposing Azure DevOps rate limit headers in API responses and error objects, enabling clients to handle rate limiting gracefully.

**Changes**
Added RateLimit interface in VsoBaseInterfaces.ts to group all rate limit properties
Added extractRateLimitHeaders() method to ClientApiBase to parse rate limit headers from responses
All API responses now include a rateLimit property when rate limit headers are present
Supports all three Azure DevOps rate limit states:
Flag state: Warning headers (200 OK with x-ratelimit-* headers)
Tarpit state: Delayed responses (200 OK with x-ratelimit-delay)
Block state: Request blocked (HTTP 429 with retry-after)

**Rate Limit Headers Extracted**
x-ratelimit-resource - Resource bucket that was limited
x-ratelimit-delay - Delay in seconds (tarpit state)
x-ratelimit-limit - Maximum requests allowed
x-ratelimit-remaining - Requests remaining
x-ratelimit-reset - UTC timestamp when limit resets
retry-after - Seconds to wait before retrying (429 errors)