### PR TITLE
Updating the image for fixing s360 warnings

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -22,7 +22,7 @@ extends:
         enabled: false
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     pool:
       name: 1ES-ABTT-Shared-Pool

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ extends:
         enabled: false
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
-        image: abtt-windows-2022
+        image: abtt-windows-2025
         os: windows
     pool:
       name: 1ES-ABTT-Shared-Pool


### PR DESCRIPTION
Updated the deprecated images with latest images to resolve the error messages we are getting in this pipeline.

These are the error messages we get because of deprecated images and artifacts:
<img width="1964" height="715" alt="image" src="https://github.com/user-attachments/assets/6887e635-8a19-414f-a4de-a67db591fc49" />
Pipeline link: https://mseng.visualstudio.com/AzureDevOps/_build/results?buildId=30831201&view=results

After the changes we are not getting these error messages:
<img width="2004" height="713" alt="image" src="https://github.com/user-attachments/assets/8dfdb1d3-11c6-4b17-bc7a-202a9430d7e0" />
Pipeline link: https://mseng.visualstudio.com/AzureDevOps/_build/results?buildId=30861770&view=results

Note: We can see the warning messages because the pipeline is not triggered from master branch. We tested it using this working branch with dryRun parameter set to True


Work-item: [AB#2344099](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2344099)
