### PR TITLE
Update methods removed from Node24 to support Node24 migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.1.2",
+    "version": "15.1.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.2",
+    "version": "15.1.3",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {


### PR DESCRIPTION
# 🔐 Node 24 Support: Fix Deprecated Crypto APIs for Proxy Authentication

## Summary

Updates `azure-devops-node-api` to support Node.js 24 by replacing deprecated crypto APIs in the `_readTaskLibSecrets()` method. This is a **breaking change** that requires `azure-pipelines-task-lib` v5.2.4+ due to encryption format incompatibility.

---

## 🎯 Changes Made

 Replaced Deprecated `crypto.createDecipher()` with `crypto.createDecipheriv()`
---

**Tasks must update BOTH packages together:**
```json
{
  "dependencies": {
    "azure-pipelines-task-lib": "^5.2.4",
    "azure-devops-node-api": "^15.1.3"
  }
}
```
---

## ✅ Testing
Task fails with Node24 upgrade without any changes in task-lib and node-api
<img width="1823" height="321" alt="image" src="https://github.com/user-attachments/assets/d7cc4b42-9d7f-466f-9b45-72addbb55ed1" />


Task works with updated versions of task-lib and node-api:
https://dev.azure.com/sanjuyadav0415/checkout/_build/results?buildId=5103&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=8e89b867-42fb-5d71-0aab-590696aff14f