### PR TITLE
Example: Make Rate Limit Headers Usable

### DIFF
--- a/api/AdoHttpClientBases.ts
+++ b/api/AdoHttpClientBases.ts
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+
+import * as rm from 'typed-rest-client/RestClient';
+import * as hm from 'typed-rest-client/HttpClient';
+import { IHeaders, IHttpClientResponse } from 'typed-rest-client/Interfaces';
+
+/**
+ * Extracts rate limit headers from the provided headers and attaches them to the target object
+ * @param headers - source headers
+ * @param target - target object to attach rate limit info to
+ * @returns void
+ */
+function extractRateLimitHeaders(headers: any, target: any): void {
+    if (!headers || !target) {
+        return;
+    }
+
+    const rateLimit: VsoBaseInterfaces.RateLimit = {};
+
+    if (headers['x-ratelimit-resource']) {
+        rateLimit.resource = headers['x-ratelimit-resource'];
+    }
+    if (headers['x-ratelimit-delay']) {
+        rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
+    }
+    if (headers['x-ratelimit-limit']) {
+        rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
+    }
+    if (headers['x-ratelimit-remaining']) {
+        rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+    }
+    if (headers['x-ratelimit-reset']) {
+        rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
+    }
+    if (headers['retry-after']) {
+        rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
+    }
+    target.rateLimit = rateLimit;
+}
+
+/**
+ * AdoHttpClient that extracts rate limit headers and attaches them to the response object
+ */
+export class AdoHttpClient extends hm.HttpClient {
+    public async request(verb: string, requestUrl: string, data: string | NodeJS.ReadableStream, headers: IHeaders): Promise<IHttpClientResponse> {
+        const res = await super.request(verb, requestUrl, data, headers);
+
+        const resHeaders = res?.message?.headers;
+
+        extractRateLimitHeaders(resHeaders, res);
+        extractRateLimitHeaders(resHeaders, res?.message);
+
+        return res;
+    }
+}
+
+/**
+ * AdoRestClient that extracts rate limit headers and attaches them to the response/result objects
+ */
+export class AdoRestClient extends rm.RestClient {
+    protected async processResponse<T>(res: hm.HttpClientResponse, options: rm.IRequestOptions): Promise<rm.IRestResponse<T>> {
+        const headers = res?.message?.headers;
+
+        try {
+            const response = await super.processResponse(res, options);
+            if (response && response.result && typeof response.result === 'object') {
+                extractRateLimitHeaders(headers, response.result);
+            }
+            return response as rm.IRestResponse<T>;
+        } catch (err: any) {
+            if (err?.result && typeof err.result === 'object' && err.responseHeaders && typeof err.responseHeaders === 'object') {
+                extractRateLimitHeaders(err.responseHeaders, err.result);
+            }
+            return Promise.reject(err);
+        }
+    }
+}

--- a/api/ClientApiBases.ts
+++ b/api/ClientApiBases.ts
@@ -4,6 +4,7 @@
 import vsom = require('./VsoClient');
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import serm = require('./Serialization');
+import AdoHttpClientBases = require('./AdoHttpClientBases');
 import * as rm from 'typed-rest-client/RestClient';
 import * as hm from 'typed-rest-client/HttpClient';
 
@@ -20,15 +21,15 @@ export class ClientApiBase {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], userAgent: string, options?: VsoBaseInterfaces.IRequestOptions) {
         this.baseUrl = baseUrl;
 
-        this.http = new hm.HttpClient(userAgent, handlers, options);
-        this.rest = new rm.RestClient(userAgent, null, handlers, options);
+        this.http = new AdoHttpClientBases.AdoHttpClient(userAgent, handlers, options);
+        this.rest = new AdoHttpClientBases.AdoRestClient(userAgent, null, handlers, options);
 
         this.vsoClient = new vsom.VsoClient(baseUrl, this.rest);
         this.userAgent = userAgent;
     }
 
     public createAcceptHeader(type: string, apiVersion?: string): string {
-        return type + (apiVersion ? (';api-version=' + apiVersion) : '');
+        return type + (apiVersion ? ';api-version=' + apiVersion : '');
     }
 
     public createRequestOptions(type: string, apiVersion?: string) {
@@ -40,40 +41,9 @@ export class ClientApiBase {
     public formatResponse(data: any, responseTypeMetadata: any, isCollection: boolean): any {
         let serializationData = {
             responseTypeMetadata: responseTypeMetadata,
-            responseIsCollection: isCollection
+            responseIsCollection: isCollection,
         };
-        let deserializedResult = serm.ContractSerializer.deserialize(data,
-            serializationData.responseTypeMetadata,
-            false,
-            serializationData.responseIsCollection);
+        let deserializedResult = serm.ContractSerializer.deserialize(data, serializationData.responseTypeMetadata, false, serializationData.responseIsCollection);
         return deserializedResult;
-    }
-
-    public extractRateLimitHeaders(headers: any, target: any): void {
-        if (!headers || !target) {
-            return;
-        }
-
-        const rateLimit: VsoBaseInterfaces.RateLimit = {};
-
-        if (headers['x-ratelimit-resource']) {
-            rateLimit.resource = headers['x-ratelimit-resource'];
-        }
-        if (headers['x-ratelimit-delay']) {
-            rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
-        }
-        if (headers['x-ratelimit-limit']) {
-            rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
-        }
-        if (headers['x-ratelimit-remaining']) {
-            rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
-        }
-        if (headers['x-ratelimit-reset']) {
-            rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
-        }
-        if (headers['retry-after']) {
-            rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
-        }
-        target.rateLimit = rateLimit;
     }
 }

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -37,7 +37,7 @@ import basicm = require('./handlers/basiccreds');
 import bearm = require('./handlers/bearertoken');
 import ntlmm = require('./handlers/ntlm');
 import patm = require('./handlers/personalaccesstoken');
-
+import AdoHttpClientBases = require('./AdoHttpClientBases');
 import * as rm from 'typed-rest-client/RestClient';
 import vsom = require('./VsoClient');
 import lim = require("./interfaces/LocationsInterfaces");
@@ -172,7 +172,7 @@ export class WebApi {
                 userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
             }
         }
-        this.rest = new rm.RestClient(userAgent, null, [this.authHandler], this.options);
+        this.rest = new AdoHttpClientBases.AdoRestClient(userAgent, null, [this.authHandler], this.options);
         this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.1.3",
+    "version": "15.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "15.1.2",
+            "version": "15.1.4",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.3",
+    "version": "15.1.4",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -15,11 +15,11 @@
     },
     "../_build": {
       "name": "azure-devops-node-api",
-      "version": "14.0.2",
+      "version": "15.1.4",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.1"
+        "typed-rest-client": "2.1.0"
       },
       "devDependencies": {
         "@types/glob": "5.0.35",
@@ -59,7 +59,7 @@
         "nock": "9.6.1",
         "shelljs": "^0.8.5",
         "tunnel": "0.0.6",
-        "typed-rest-client": "^2.0.1",
+        "typed-rest-client": "2.1.0",
         "typescript": "4.0.2"
       },
       "dependencies": {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -4,18 +4,19 @@ import nock = require('nock');
 import os = require('os');
 import vsom = require('../../_build/VsoClient');
 import WebApi = require('../../_build/WebApi');
-import * as rm from 'typed-rest-client/RestClient';
-import { ApiResourceLocation } from '../../_build/interfaces/common/VsoBaseInterfaces';
+import { ApiResourceLocation, RateLimit } from '../../_build/interfaces/common/VsoBaseInterfaces';
 import semver = require('semver');
+import AdoHttpClientBases = require('../../_build/AdoHttpClientBases');
+import { IRestResponse, RestClient } from 'typed-rest-client';
 
 describe('VSOClient Units', function () {
-    let rest: rm.RestClient;
+    let rest: RestClient;
     let vsoClient: vsom.VsoClient
     const baseUrl: string = 'https://dev.azure.com/';
 
     before(() => {
         const userAgent: string = "testAgent";
-        rest = new rm.RestClient(userAgent, null, []);
+        rest = new AdoHttpClientBases.AdoRestClient(userAgent, null, []);
         vsoClient = new vsom.VsoClient(baseUrl, rest);
     });
 
@@ -31,7 +32,7 @@ describe('VSOClient Units', function () {
         //Arrange
         this.timeout(1000);
         const userAgent: string = "testAgent";
-        const rest: rm.RestClient = new rm.RestClient(userAgent, null, []);
+        const rest: AdoHttpClientBases.AdoRestClient = new AdoHttpClientBases.AdoRestClient(userAgent, null, []);
 
         //Act
         const vso: vsom.VsoClient = new vsom.VsoClient('https://microsoft.com', rest);
@@ -257,7 +258,7 @@ describe('VSOClient Units', function () {
         //Act
         vsoClient._setInitializationPromise(new Promise(resolve => {
             vsoClient.baseUrl = 'https://newbase.com';
-            resolve();
+            resolve(void 0);
         }));
         const res: vsom.ClientVersioningData = await vsoClient.getVersioningData('1', 'testArea6', 'testLocation', {'testKey': 'testValue'}, null);
 
@@ -314,6 +315,42 @@ describe('WebApi Units', function () {
                                                           undefined, {productName: 'name', productVersion: '1.2.3'});
         const userAgent: string = `name/1.2.3 (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
         assert.equal(userAgent, myWebApi.rest.client.userAgent, 'User agent should be: ' + userAgent);
+    });
+
+    it('AdoRestClient attaches rate limit headers to responses', async () => {
+        // Arrange
+        const userAgent: string = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+
+        nock('https://dev.azure.com', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': userAgent,
+            },
+        })
+            .defaultReplyHeaders({
+                'x-ratelimit-resource': 'core',
+                'x-ratelimit-delay': '0.5',
+                'x-ratelimit-limit': '1000',
+                'x-ratelimit-remaining': '999',
+                'x-ratelimit-reset': '1625078400',
+                'retry-after': '1',
+            })
+            .get('/test')
+            .reply(200, { success: true });
+        
+        const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com', WebApi.getBasicHandler('user', 'password'));
+
+        // Act
+        const response = (await myWebApi.rest.get<{ success: boolean, rateLimit?: RateLimit }>('https://dev.azure.com/test')) as IRestResponse<{ success: boolean, rateLimit?: RateLimit }>;
+        // Assert
+        assert(response.result?.success === true, 'Response body should indicate success');
+        assert(response.result?.rateLimit, 'Response should have rateLimit property');
+        assert.equal(response.result.rateLimit?.resource, 'core', 'Rate limit resource should be "core"');
+        assert.equal(response.result.rateLimit?.delay, 0.5, 'Rate limit delay should be 0.5');
+        assert.equal(response.result.rateLimit?.limit, 1000, 'Rate limit limit should be 1000');
+        assert.equal(response.result.rateLimit?.remaining, 999, 'Rate limit remaining should be 999');
+        assert.equal(response.result.rateLimit?.reset, 1625078400, 'Rate limit reset should be 1625078400');
+        assert.equal(response.result.rateLimit?.retryAfter, 1, 'Rate limit retryAfter should be 1');
     });
 
     it('sets the user agent correctly when request settings are not specified', async () => {


### PR DESCRIPTION
### Enable usage of Rate Limit Headers

Based on https://github.com/microsoft/azure-devops-node-api/pull/654

extractRateLimitHeaders and RateLimit type were added, but not used to add the rateLimit to responses.

The purpose of this pull request is to integrate the rate limit headers into the response objects from API responses.

Creating as draft as unsure of the feature that was to add this change and if future changes will be added to support the extractRateLimitHeaders across all the API responses.