### PR TITLE
Set continuationToken when returned in response headers

### DIFF
--- a/api/AlertApi.ts
+++ b/api/AlertApi.ts
@@ -82,7 +82,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.Alert>;
                 res = await this.rest.get<AlertInterfaces.Alert>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.Alert,
                                               false);
 
@@ -145,7 +145,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<AlertInterfaces.Alert>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<AlertInterfaces.Alert>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.Alert,
                                               true);
 
@@ -202,7 +202,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -251,7 +251,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.Alert>;
                 res = await this.rest.update<AlertInterfaces.Alert>(url, stateUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.Alert,
                                               false);
 
@@ -318,7 +318,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.Branch[]>;
                 res = await this.rest.get<AlertInterfaces.Branch[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.Branch,
                                               true);
 
@@ -371,7 +371,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.UxFilters>;
                 res = await this.rest.get<AlertInterfaces.UxFilters>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.UxFilters,
                                               false);
 
@@ -425,7 +425,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.AlertAnalysisInstance[]>;
                 res = await this.rest.get<AlertInterfaces.AlertAnalysisInstance[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.AlertAnalysisInstance,
                                               true);
 
@@ -482,7 +482,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.LegalReview>;
                 res = await this.rest.create<AlertInterfaces.LegalReview>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -528,7 +528,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.AlertMetadataChange[]>;
                 res = await this.rest.update<AlertInterfaces.AlertMetadataChange[]>(url, alertsMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.AlertMetadataChange,
                                               true);
 
@@ -583,7 +583,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.uploadStream<number>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -623,7 +623,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.SarifUploadStatus>;
                 res = await this.rest.get<AlertInterfaces.SarifUploadStatus>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.SarifUploadStatus,
                                               false);
 
@@ -670,7 +670,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.ValidationRequestInfo>;
                 res = await this.rest.get<AlertInterfaces.ValidationRequestInfo>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.ValidationRequestInfo,
                                               false);
 
@@ -717,7 +717,7 @@ export class AlertApi extends basem.ClientApiBase implements IAlertApi {
                 let res: restm.IRestResponse<AlertInterfaces.AlertValidationRequestStatus>;
                 res = await this.rest.create<AlertInterfaces.AlertValidationRequestStatus>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               AlertInterfaces.TypeInfo.AlertValidationRequestStatus,
                                               false);
 

--- a/api/BuildApi.ts
+++ b/api/BuildApi.ts
@@ -157,7 +157,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildArtifact>;
                 res = await this.rest.create<BuildInterfaces.BuildArtifact>(url, artifact, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -211,7 +211,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildArtifact>;
                 res = await this.rest.get<BuildInterfaces.BuildArtifact>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -301,7 +301,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildArtifact[]>;
                 res = await this.rest.get<BuildInterfaces.BuildArtifact[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -406,7 +406,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Attachment[]>;
                 res = await this.rest.get<BuildInterfaces.Attachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -495,7 +495,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.DefinitionResourceReference[]>;
                 res = await this.rest.update<BuildInterfaces.DefinitionResourceReference[]>(url, resources, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -544,7 +544,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.DefinitionResourceReference[]>;
                 res = await this.rest.get<BuildInterfaces.DefinitionResourceReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -595,7 +595,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -652,7 +652,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -706,7 +706,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildBadge>;
                 res = await this.rest.get<BuildInterfaces.BuildBadge>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -760,7 +760,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -804,7 +804,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease[]>;
                 res = await this.rest.get<BuildInterfaces.RetentionLease[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               true);
 
@@ -848,7 +848,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -899,7 +899,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Build>;
                 res = await this.rest.get<BuildInterfaces.Build>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               false);
 
@@ -1004,7 +1004,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<BuildInterfaces.Build>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<BuildInterfaces.Build>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               true);
 
@@ -1063,7 +1063,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Build>;
                 res = await this.rest.create<BuildInterfaces.Build>(url, build, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               false);
 
@@ -1116,7 +1116,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Build>;
                 res = await this.rest.update<BuildInterfaces.Build>(url, build, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               false);
 
@@ -1159,7 +1159,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Build[]>;
                 res = await this.rest.update<BuildInterfaces.Build[]>(url, builds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               true);
 
@@ -1216,7 +1216,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<BuildInterfaces.Change>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<BuildInterfaces.Change>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Change,
                                               true);
 
@@ -1270,7 +1270,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Change[]>;
                 res = await this.rest.get<BuildInterfaces.Change[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Change,
                                               true);
 
@@ -1311,7 +1311,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildController>;
                 res = await this.rest.get<BuildInterfaces.BuildController>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildController,
                                               false);
 
@@ -1356,7 +1356,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildController[]>;
                 res = await this.rest.get<BuildInterfaces.BuildController[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildController,
                                               true);
 
@@ -1409,7 +1409,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinition>;
                 res = await this.rest.create<BuildInterfaces.BuildDefinition>(url, definition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinition,
                                               false);
 
@@ -1453,7 +1453,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1513,7 +1513,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinition>;
                 res = await this.rest.get<BuildInterfaces.BuildDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinition,
                                               false);
 
@@ -1606,7 +1606,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<BuildInterfaces.BuildDefinitionReference>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<BuildInterfaces.BuildDefinitionReference>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinitionReference,
                                               true);
 
@@ -1660,7 +1660,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinition>;
                 res = await this.rest.update<BuildInterfaces.BuildDefinition>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinition,
                                               false);
 
@@ -1716,7 +1716,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinition>;
                 res = await this.rest.replace<BuildInterfaces.BuildDefinition>(url, definition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinition,
                                               false);
 
@@ -1821,7 +1821,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Folder>;
                 res = await this.rest.replace<BuildInterfaces.Folder>(url, folder, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Folder,
                                               false);
 
@@ -1872,7 +1872,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1923,7 +1923,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Folder[]>;
                 res = await this.rest.get<BuildInterfaces.Folder[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Folder,
                                               true);
 
@@ -1976,7 +1976,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Folder>;
                 res = await this.rest.create<BuildInterfaces.Folder>(url, folder, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Folder,
                                               false);
 
@@ -2017,7 +2017,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.PipelineGeneralSettings>;
                 res = await this.rest.get<BuildInterfaces.PipelineGeneralSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2060,7 +2060,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.PipelineGeneralSettings>;
                 res = await this.rest.update<BuildInterfaces.PipelineGeneralSettings>(url, newSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2105,7 +2105,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildRetentionHistory>;
                 res = await this.rest.get<BuildInterfaces.BuildRetentionHistory>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildRetentionHistory,
                                               false);
 
@@ -2156,7 +2156,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Build>;
                 res = await this.rest.get<BuildInterfaces.Build>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Build,
                                               false);
 
@@ -2199,7 +2199,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease[]>;
                 res = await this.rest.create<BuildInterfaces.RetentionLease[]>(url, newLeases, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               true);
 
@@ -2250,7 +2250,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2294,7 +2294,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease>;
                 res = await this.rest.get<BuildInterfaces.RetentionLease>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               false);
 
@@ -2345,7 +2345,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease[]>;
                 res = await this.rest.get<BuildInterfaces.RetentionLease[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               true);
 
@@ -2399,7 +2399,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease[]>;
                 res = await this.rest.get<BuildInterfaces.RetentionLease[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               true);
 
@@ -2456,7 +2456,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease[]>;
                 res = await this.rest.get<BuildInterfaces.RetentionLease[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               true);
 
@@ -2502,7 +2502,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RetentionLease>;
                 res = await this.rest.update<BuildInterfaces.RetentionLease>(url, leaseUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RetentionLease,
                                               false);
 
@@ -2608,7 +2608,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2652,7 +2652,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildLog[]>;
                 res = await this.rest.get<BuildInterfaces.BuildLog[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildLog,
                                               true);
 
@@ -2788,7 +2788,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildMetric[]>;
                 res = await this.rest.get<BuildInterfaces.BuildMetric[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildMetric,
                                               true);
 
@@ -2839,7 +2839,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildMetric[]>;
                 res = await this.rest.get<BuildInterfaces.BuildMetric[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildMetric,
                                               true);
 
@@ -2880,7 +2880,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildOptionDefinition[]>;
                 res = await this.rest.get<BuildInterfaces.BuildOptionDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildOptionDefinition,
                                               true);
 
@@ -2940,7 +2940,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.SourceRepositoryItem[]>;
                 res = await this.rest.get<BuildInterfaces.SourceRepositoryItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2991,7 +2991,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3042,7 +3042,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.update<any>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3093,7 +3093,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3144,7 +3144,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.update<any>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3201,7 +3201,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.PullRequest>;
                 res = await this.rest.get<BuildInterfaces.PullRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3252,7 +3252,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildReportMetadata>;
                 res = await this.rest.get<BuildInterfaces.BuildReportMetadata>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3358,7 +3358,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.SourceRepositories>;
                 res = await this.rest.get<BuildInterfaces.SourceRepositories>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3402,7 +3402,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.DefinitionResourceReference[]>;
                 res = await this.rest.update<BuildInterfaces.DefinitionResourceReference[]>(url, resources, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3444,7 +3444,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.DefinitionResourceReference[]>;
                 res = await this.rest.get<BuildInterfaces.DefinitionResourceReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3482,7 +3482,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildResourceUsage>;
                 res = await this.rest.get<BuildInterfaces.BuildResourceUsage>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3523,7 +3523,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.ProjectRetentionSetting>;
                 res = await this.rest.get<BuildInterfaces.ProjectRetentionSetting>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3566,7 +3566,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.ProjectRetentionSetting>;
                 res = await this.rest.update<BuildInterfaces.ProjectRetentionSetting>(url, updateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3610,7 +3610,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinitionRevision[]>;
                 res = await this.rest.get<BuildInterfaces.BuildDefinitionRevision[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinitionRevision,
                                               true);
 
@@ -3651,7 +3651,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildSettings>;
                 res = await this.rest.get<BuildInterfaces.BuildSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3694,7 +3694,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildSettings>;
                 res = await this.rest.update<BuildInterfaces.BuildSettings>(url, settings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3735,7 +3735,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.SourceProviderAttributes[]>;
                 res = await this.rest.get<BuildInterfaces.SourceProviderAttributes[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.SourceProviderAttributes,
                                               true);
 
@@ -3784,7 +3784,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3847,7 +3847,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3894,7 +3894,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.replace<string[]>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3940,7 +3940,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, tags, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3987,7 +3987,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.del<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4031,7 +4031,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4077,7 +4077,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.update<string[]>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4124,7 +4124,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.replace<string[]>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4170,7 +4170,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, tags, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4217,7 +4217,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.del<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4268,7 +4268,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4314,7 +4314,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.update<string[]>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4358,7 +4358,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.del<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4399,7 +4399,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4443,7 +4443,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4487,7 +4487,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinitionTemplate>;
                 res = await this.rest.get<BuildInterfaces.BuildDefinitionTemplate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinitionTemplate,
                                               false);
 
@@ -4528,7 +4528,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinitionTemplate[]>;
                 res = await this.rest.get<BuildInterfaces.BuildDefinitionTemplate[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinitionTemplate,
                                               true);
 
@@ -4574,7 +4574,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.BuildDefinitionTemplate>;
                 res = await this.rest.replace<BuildInterfaces.BuildDefinitionTemplate>(url, template, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.BuildDefinitionTemplate,
                                               false);
 
@@ -4631,7 +4631,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.Timeline>;
                 res = await this.rest.get<BuildInterfaces.Timeline>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.Timeline,
                                               false);
 
@@ -4687,7 +4687,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, triggerTypes, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4741,7 +4741,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.RepositoryWebhook[]>;
                 res = await this.rest.get<BuildInterfaces.RepositoryWebhook[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               BuildInterfaces.TypeInfo.RepositoryWebhook,
                                               true);
 
@@ -4792,7 +4792,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.ResourceRef[]>;
                 res = await this.rest.get<VSSInterfaces.ResourceRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4845,7 +4845,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.ResourceRef[]>;
                 res = await this.rest.create<VSSInterfaces.ResourceRef[]>(url, commitIds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4905,7 +4905,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<VSSInterfaces.ResourceRef[]>;
                 res = await this.rest.get<VSSInterfaces.ResourceRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4965,7 +4965,7 @@ export class BuildApi extends basem.ClientApiBase implements IBuildApi {
                 let res: restm.IRestResponse<BuildInterfaces.YamlBuild>;
                 res = await this.rest.get<BuildInterfaces.YamlBuild>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/CIXApi.ts
+++ b/api/CIXApi.ts
@@ -73,7 +73,7 @@ export class CixApi extends basem.ClientApiBase implements ICixApi {
                 let res: restm.IRestResponse<CIXInterfaces.ConfigurationFile[]>;
                 res = await this.rest.get<CIXInterfaces.ConfigurationFile[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -123,7 +123,7 @@ export class CixApi extends basem.ClientApiBase implements ICixApi {
                 let res: restm.IRestResponse<CIXInterfaces.PipelineConnection>;
                 res = await this.rest.create<CIXInterfaces.PipelineConnection>(url, createConnectionInputs, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -183,7 +183,7 @@ export class CixApi extends basem.ClientApiBase implements ICixApi {
                 let res: restm.IRestResponse<CIXInterfaces.DetectedBuildFramework[]>;
                 res = await this.rest.get<CIXInterfaces.DetectedBuildFramework[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -224,7 +224,7 @@ export class CixApi extends basem.ClientApiBase implements ICixApi {
                 let res: restm.IRestResponse<CIXInterfaces.CreatedResources>;
                 res = await this.rest.create<CIXInterfaces.CreatedResources>(url, creationParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/ClientApiBases.ts
+++ b/api/ClientApiBases.ts
@@ -37,15 +37,20 @@ export class ClientApiBase {
         return options;
     }
 
-    public formatResponse(data: any, responseTypeMetadata: any, isCollection: boolean): any {
+    public formatResponse<T>(response: rm.IRestResponse<T>, responseTypeMetadata: any, isCollection: boolean): T {
         let serializationData = {
             responseTypeMetadata: responseTypeMetadata,
             responseIsCollection: isCollection
         };
-        let deserializedResult = serm.ContractSerializer.deserialize(data,
+        let deserializedResult = serm.ContractSerializer.deserialize(response.result,
+
             serializationData.responseTypeMetadata,
             false,
             serializationData.responseIsCollection);
+
+        if (response.headers['x-ms-continuationtoken']) {
+            deserializedResult.continuationToken = response.headers['x-ms-continuationtoken'];
+        }
         return deserializedResult;
     }
 

--- a/api/ClientApiBases.ts
+++ b/api/ClientApiBases.ts
@@ -48,8 +48,8 @@ export class ClientApiBase {
             false,
             serializationData.responseIsCollection);
 
-        if (response.headers['x-ms-continuationtoken']) {
-            deserializedResult.continuationToken = response.headers['x-ms-continuationtoken'];
+        if (isCollection && response.headers['x-ms-continuationtoken']) {
+            (deserializedResult as any).continuationToken = response.headers['x-ms-continuationtoken'];
         }
         return deserializedResult;
     }

--- a/api/CoreApi.ts
+++ b/api/CoreApi.ts
@@ -89,7 +89,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse<void>(res,
                                               null,
                                               false);
 
@@ -132,7 +132,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, avatarBlob, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -186,7 +186,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.CategorizedWebApiTeams>;
                 res = await this.rest.get<CoreInterfaces.CategorizedWebApiTeams>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -227,7 +227,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiConnectedService>;
                 res = await this.rest.create<CoreInterfaces.WebApiConnectedService>(url, connectedServiceCreationData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.WebApiConnectedService,
                                               false);
 
@@ -269,7 +269,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiConnectedServiceDetails>;
                 res = await this.rest.get<CoreInterfaces.WebApiConnectedServiceDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.WebApiConnectedServiceDetails,
                                               false);
 
@@ -315,7 +315,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiConnectedService[]>;
                 res = await this.rest.get<CoreInterfaces.WebApiConnectedService[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.WebApiConnectedService,
                                               true);
 
@@ -356,7 +356,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, mruData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -397,7 +397,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -436,7 +436,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
                 res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -477,7 +477,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, mruData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -531,7 +531,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<VSSInterfaces.TeamMember[]>;
                 res = await this.rest.get<VSSInterfaces.TeamMember[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -572,7 +572,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.Process>;
                 res = await this.rest.get<CoreInterfaces.Process>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.Process,
                                               false);
 
@@ -610,7 +610,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.Process[]>;
                 res = await this.rest.get<CoreInterfaces.Process[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.Process,
                                               true);
 
@@ -651,7 +651,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.TeamProjectCollection>;
                 res = await this.rest.get<CoreInterfaces.TeamProjectCollection>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.TeamProjectCollection,
                                               false);
 
@@ -699,7 +699,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.TeamProjectCollectionReference[]>;
                 res = await this.rest.get<CoreInterfaces.TeamProjectCollectionReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -744,7 +744,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.ProjectInfo[]>;
                 res = await this.rest.get<CoreInterfaces.ProjectInfo[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.ProjectInfo,
                                               true);
 
@@ -795,7 +795,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.TeamProject>;
                 res = await this.rest.get<CoreInterfaces.TeamProject>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.TeamProject,
                                               false);
 
@@ -852,7 +852,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<CoreInterfaces.TeamProjectReference>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<CoreInterfaces.TeamProjectReference>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               CoreInterfaces.TypeInfo.TeamProjectReference,
                                               true);
 
@@ -892,7 +892,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<OperationsInterfaces.OperationReference>;
                 res = await this.rest.create<OperationsInterfaces.OperationReference>(url, projectToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               OperationsInterfaces.TypeInfo.OperationReference,
                                               false);
 
@@ -933,7 +933,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<OperationsInterfaces.OperationReference>;
                 res = await this.rest.del<OperationsInterfaces.OperationReference>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               OperationsInterfaces.TypeInfo.OperationReference,
                                               false);
 
@@ -976,7 +976,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<OperationsInterfaces.OperationReference>;
                 res = await this.rest.update<OperationsInterfaces.OperationReference>(url, projectUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               OperationsInterfaces.TypeInfo.OperationReference,
                                               false);
 
@@ -1027,7 +1027,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.ProjectProperties[]>;
                 res = await this.rest.get<CoreInterfaces.ProjectProperties[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1075,7 +1075,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.ProjectProperty[]>;
                 res = await this.rest.get<CoreInterfaces.ProjectProperty[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1123,7 +1123,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, patchDocument, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1161,7 +1161,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.Proxy>;
                 res = await this.rest.replace<CoreInterfaces.Proxy>(url, proxy, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1210,7 +1210,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1253,7 +1253,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.Proxy[]>;
                 res = await this.rest.get<CoreInterfaces.Proxy[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1307,7 +1307,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiTeam[]>;
                 res = await this.rest.get<CoreInterfaces.WebApiTeam[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1350,7 +1350,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiTeam>;
                 res = await this.rest.create<CoreInterfaces.WebApiTeam>(url, team, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1394,7 +1394,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1445,7 +1445,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiTeam>;
                 res = await this.rest.get<CoreInterfaces.WebApiTeam>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1502,7 +1502,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiTeam[]>;
                 res = await this.rest.get<CoreInterfaces.WebApiTeam[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1548,7 +1548,7 @@ export class CoreApi extends basem.ClientApiBase implements ICoreApi {
                 let res: restm.IRestResponse<CoreInterfaces.WebApiTeam>;
                 res = await this.rest.update<CoreInterfaces.WebApiTeam>(url, teamData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/DashboardApi.ts
+++ b/api/DashboardApi.ts
@@ -78,7 +78,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Dashboard>;
                 res = await this.rest.create<DashboardInterfaces.Dashboard>(url, dashboard, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Dashboard,
                                               false);
 
@@ -130,7 +130,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -182,7 +182,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Dashboard>;
                 res = await this.rest.get<DashboardInterfaces.Dashboard>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Dashboard,
                                               false);
 
@@ -231,7 +231,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Dashboard[]>;
                 res = await this.rest.get<DashboardInterfaces.Dashboard[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Dashboard,
                                               true);
 
@@ -285,7 +285,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Dashboard>;
                 res = await this.rest.replace<DashboardInterfaces.Dashboard>(url, dashboard, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Dashboard,
                                               false);
 
@@ -336,7 +336,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.DashboardGroup>;
                 res = await this.rest.replace<DashboardInterfaces.DashboardGroup>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.DashboardGroup,
                                               false);
 
@@ -390,7 +390,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Widget>;
                 res = await this.rest.create<DashboardInterfaces.Widget>(url, widget, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Widget,
                                               false);
 
@@ -445,7 +445,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Dashboard>;
                 res = await this.rest.del<DashboardInterfaces.Dashboard>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Dashboard,
                                               false);
 
@@ -500,7 +500,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Widget>;
                 res = await this.rest.get<DashboardInterfaces.Widget>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Widget,
                                               false);
 
@@ -557,7 +557,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Widget>;
                 res = await this.rest.replace<DashboardInterfaces.Widget>(url, widget, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Widget,
                                               false);
 
@@ -614,7 +614,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.Widget>;
                 res = await this.rest.update<DashboardInterfaces.Widget>(url, widget, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.Widget,
                                               false);
 
@@ -658,7 +658,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.WidgetMetadataResponse>;
                 res = await this.rest.get<DashboardInterfaces.WidgetMetadataResponse>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.WidgetMetadataResponse,
                                               false);
 
@@ -709,7 +709,7 @@ export class DashboardApi extends basem.ClientApiBase implements IDashboardApi {
                 let res: restm.IRestResponse<DashboardInterfaces.WidgetTypesResponse>;
                 res = await this.rest.get<DashboardInterfaces.WidgetTypesResponse>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               DashboardInterfaces.TypeInfo.WidgetTypesResponse,
                                               false);
 

--- a/api/ExtensionManagementApi.ts
+++ b/api/ExtensionManagementApi.ts
@@ -105,7 +105,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.AcquisitionOptions>;
                 res = await this.rest.get<ExtensionManagementInterfaces.AcquisitionOptions>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.AcquisitionOptions,
                                               false);
 
@@ -143,7 +143,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.ExtensionAcquisitionRequest>;
                 res = await this.rest.create<ExtensionManagementInterfaces.ExtensionAcquisitionRequest>(url, acquisitionRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.ExtensionAcquisitionRequest,
                                               false);
 
@@ -185,7 +185,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.ExtensionAuditLog>;
                 res = await this.rest.get<ExtensionManagementInterfaces.ExtensionAuditLog>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.ExtensionAuditLog,
                                               false);
 
@@ -230,7 +230,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.ExtensionAuthorization>;
                 res = await this.rest.replace<ExtensionManagementInterfaces.ExtensionAuthorization>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -283,7 +283,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.create<any>(url, doc, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -337,7 +337,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -391,7 +391,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -442,7 +442,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<any[]>;
                 res = await this.rest.get<any[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -495,7 +495,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.replace<any>(url, doc, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -548,7 +548,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.update<any>(url, doc, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -594,7 +594,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.ExtensionDataCollection[]>;
                 res = await this.rest.create<ExtensionManagementInterfaces.ExtensionDataCollection[]>(url, collectionQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -648,7 +648,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.ExtensionState[]>;
                 res = await this.rest.get<ExtensionManagementInterfaces.ExtensionState[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.ExtensionState,
                                               true);
 
@@ -686,7 +686,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.InstalledExtension[]>;
                 res = await this.rest.create<ExtensionManagementInterfaces.InstalledExtension[]>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.InstalledExtension,
                                               true);
 
@@ -740,7 +740,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.InstalledExtension[]>;
                 res = await this.rest.get<ExtensionManagementInterfaces.InstalledExtension[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.InstalledExtension,
                                               true);
 
@@ -780,7 +780,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.InstalledExtension>;
                 res = await this.rest.update<ExtensionManagementInterfaces.InstalledExtension>(url, extension, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.InstalledExtension,
                                               false);
 
@@ -831,7 +831,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.InstalledExtension>;
                 res = await this.rest.get<ExtensionManagementInterfaces.InstalledExtension>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.InstalledExtension,
                                               false);
 
@@ -878,7 +878,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.InstalledExtension>;
                 res = await this.rest.create<ExtensionManagementInterfaces.InstalledExtension>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.InstalledExtension,
                                               false);
 
@@ -932,7 +932,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -971,7 +971,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<GalleryInterfaces.UserExtensionPolicy>;
                 res = await this.rest.get<GalleryInterfaces.UserExtensionPolicy>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.UserExtensionPolicy,
                                               false);
 
@@ -1028,7 +1028,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.update<number>(url, rejectMessage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1064,7 +1064,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.RequestedExtension[]>;
                 res = await this.rest.get<ExtensionManagementInterfaces.RequestedExtension[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.RequestedExtension,
                                               true);
 
@@ -1118,7 +1118,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.update<number>(url, rejectMessage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1160,7 +1160,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1204,7 +1204,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<ExtensionManagementInterfaces.RequestedExtension>;
                 res = await this.rest.create<ExtensionManagementInterfaces.RequestedExtension>(url, requestMessage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ExtensionManagementInterfaces.TypeInfo.RequestedExtension,
                                               false);
 
@@ -1240,7 +1240,7 @@ export class ExtensionManagementApi extends basem.ClientApiBase implements IExte
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/FeatureManagementApi.ts
+++ b/api/FeatureManagementApi.ts
@@ -61,7 +61,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeature>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeature>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -106,7 +106,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeature[]>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeature[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -150,7 +150,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeatureState>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
                                               false);
 
@@ -206,7 +206,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.update<FeatureManagementInterfaces.ContributedFeatureState>(url, feature, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
                                               false);
 
@@ -256,7 +256,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.get<FeatureManagementInterfaces.ContributedFeatureState>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
                                               false);
 
@@ -318,7 +318,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureState>;
                 res = await this.rest.update<FeatureManagementInterfaces.ContributedFeatureState>(url, feature, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureState,
                                               false);
 
@@ -358,7 +358,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
                                               false);
 
@@ -401,7 +401,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
                                               false);
 
@@ -450,7 +450,7 @@ export class FeatureManagementApi extends basem.ClientApiBase implements IFeatur
                 let res: restm.IRestResponse<FeatureManagementInterfaces.ContributedFeatureStateQuery>;
                 res = await this.rest.create<FeatureManagementInterfaces.ContributedFeatureStateQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FeatureManagementInterfaces.TypeInfo.ContributedFeatureStateQuery,
                                               false);
 

--- a/api/FileContainerApi.ts
+++ b/api/FileContainerApi.ts
@@ -162,7 +162,7 @@ export class FileContainerApi extends FileContainerApiBase.FileContainerApiBase 
                 options.additionalHeaders = customHeaders;
                 this.rest.uploadStream<FileContainerInterfaces.FileContainerItem>('PUT', url, contentStream, options)
                     .then((res: restm.IRestResponse<FileContainerInterfaces.FileContainerItem>) => {
-                        let ret = this.formatResponse(res.result,
+                        let ret = this.formatResponse(res,
                             FileContainerInterfaces.TypeInfo.FileContainerItem,
                             false);
                         onResult(null, res.statusCode, ret);

--- a/api/FileContainerApiBase.ts
+++ b/api/FileContainerApiBase.ts
@@ -66,7 +66,7 @@ export class FileContainerApiBase extends basem.ClientApiBase implements IFileCo
                 let res: restm.IRestResponse<FileContainerInterfaces.FileContainerItem[]>;
                 res = await this.rest.create<FileContainerInterfaces.FileContainerItem[]>(url, items, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FileContainerInterfaces.TypeInfo.FileContainerItem,
                                               true);
 
@@ -120,7 +120,7 @@ export class FileContainerApiBase extends basem.ClientApiBase implements IFileCo
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -168,7 +168,7 @@ export class FileContainerApiBase extends basem.ClientApiBase implements IFileCo
                 let res: restm.IRestResponse<FileContainerInterfaces.FileContainer[]>;
                 res = await this.rest.get<FileContainerInterfaces.FileContainer[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FileContainerInterfaces.TypeInfo.FileContainer,
                                               true);
 
@@ -246,7 +246,7 @@ export class FileContainerApiBase extends basem.ClientApiBase implements IFileCo
                 let res: restm.IRestResponse<FileContainerInterfaces.FileContainerItem[]>;
                 res = await this.rest.get<FileContainerInterfaces.FileContainerItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               FileContainerInterfaces.TypeInfo.FileContainerItem,
                                               true);
 

--- a/api/GalleryApi.ts
+++ b/api/GalleryApi.ts
@@ -140,7 +140,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -182,7 +182,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -227,7 +227,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -272,7 +272,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -327,7 +327,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.AcquisitionOptions>;
                 res = await this.rest.get<GalleryInterfaces.AcquisitionOptions>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.AcquisitionOptions,
                                               false);
 
@@ -365,7 +365,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionAcquisitionRequest>;
                 res = await this.rest.create<GalleryInterfaces.ExtensionAcquisitionRequest>(url, acquisitionRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionAcquisitionRequest,
                                               false);
 
@@ -576,7 +576,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.AzurePublisher>;
                 res = await this.rest.replace<GalleryInterfaces.AzurePublisher>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -615,7 +615,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.AzurePublisher>;
                 res = await this.rest.get<GalleryInterfaces.AzurePublisher>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -658,7 +658,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -707,7 +707,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.CategoriesResult>;
                 res = await this.rest.get<GalleryInterfaces.CategoriesResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -771,7 +771,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ProductCategory>;
                 res = await this.rest.get<GalleryInterfaces.ProductCategory>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -829,7 +829,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ProductCategoriesResult>;
                 res = await this.rest.get<GalleryInterfaces.ProductCategoriesResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -904,7 +904,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, customerSupportRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -946,7 +946,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.create<GalleryInterfaces.ExtensionDraft>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -993,7 +993,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.update<GalleryInterfaces.ExtensionDraft>(url, draftPatch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -1049,7 +1049,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.uploadStream<GalleryInterfaces.ExtensionDraft>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -1104,7 +1104,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraftAsset>;
                 res = await this.rest.uploadStream<GalleryInterfaces.ExtensionDraftAsset>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1156,7 +1156,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.uploadStream<GalleryInterfaces.ExtensionDraft>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -1199,7 +1199,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.update<GalleryInterfaces.ExtensionDraft>(url, draftPatch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -1252,7 +1252,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraft>;
                 res = await this.rest.uploadStream<GalleryInterfaces.ExtensionDraft>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDraft,
                                               false);
 
@@ -1304,7 +1304,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDraftAsset>;
                 res = await this.rest.uploadStream<GalleryInterfaces.ExtensionDraftAsset>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1447,7 +1447,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionEvents>;
                 res = await this.rest.get<GalleryInterfaces.ExtensionEvents>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionEvents,
                                               false);
 
@@ -1487,7 +1487,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, extensionEvents, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1539,7 +1539,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionQueryResult>;
                 res = await this.rest.create<GalleryInterfaces.ExtensionQueryResult>(url, extensionQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionQueryResult,
                                               false);
 
@@ -1593,7 +1593,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.uploadStream<GalleryInterfaces.PublishedExtension>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -1638,7 +1638,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1687,7 +1687,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.get<GalleryInterfaces.PublishedExtension>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -1733,7 +1733,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.replace<GalleryInterfaces.PublishedExtension>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -1790,7 +1790,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.uploadStream<GalleryInterfaces.PublishedExtension>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -1838,7 +1838,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1900,7 +1900,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.get<GalleryInterfaces.PublishedExtension>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -1965,7 +1965,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.uploadStream<GalleryInterfaces.PublishedExtension>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -2016,7 +2016,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.update<GalleryInterfaces.PublishedExtension>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -2064,7 +2064,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2112,7 +2112,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2152,7 +2152,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, azureRestApiRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2192,7 +2192,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, notificationData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2354,7 +2354,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2453,7 +2453,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<{ [key: string] : string; }>;
                 res = await this.rest.uploadStream<{ [key: string] : string; }>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2491,7 +2491,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2530,7 +2530,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2568,7 +2568,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublisherQueryResult>;
                 res = await this.rest.create<GalleryInterfaces.PublisherQueryResult>(url, publisherQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublisherQueryResult,
                                               false);
 
@@ -2606,7 +2606,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Publisher>;
                 res = await this.rest.create<GalleryInterfaces.Publisher>(url, publisher, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Publisher,
                                               false);
 
@@ -2645,7 +2645,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2691,7 +2691,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Publisher>;
                 res = await this.rest.get<GalleryInterfaces.Publisher>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Publisher,
                                               false);
 
@@ -2732,7 +2732,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Publisher>;
                 res = await this.rest.replace<GalleryInterfaces.Publisher>(url, publisher, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Publisher,
                                               false);
 
@@ -2782,7 +2782,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublisherRoleAssignment[]>;
                 res = await this.rest.create<GalleryInterfaces.PublisherRoleAssignment[]>(url, roleAssignments, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublisherRoleAssignment,
                                               true);
 
@@ -2845,7 +2845,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.uploadStream<GalleryInterfaces.PublishedExtension>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -2883,7 +2883,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Publisher>;
                 res = await this.rest.get<GalleryInterfaces.Publisher>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Publisher,
                                               false);
 
@@ -2940,7 +2940,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.QuestionsResult>;
                 res = await this.rest.get<GalleryInterfaces.QuestionsResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.QuestionsResult,
                                               false);
 
@@ -2989,7 +2989,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Concern>;
                 res = await this.rest.create<GalleryInterfaces.Concern>(url, concern, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Concern,
                                               false);
 
@@ -3035,7 +3035,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Question>;
                 res = await this.rest.create<GalleryInterfaces.Question>(url, question, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Question,
                                               false);
 
@@ -3082,7 +3082,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3131,7 +3131,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Question>;
                 res = await this.rest.update<GalleryInterfaces.Question>(url, question, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Question,
                                               false);
 
@@ -3180,7 +3180,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Response>;
                 res = await this.rest.create<GalleryInterfaces.Response>(url, response, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Response,
                                               false);
 
@@ -3230,7 +3230,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3282,7 +3282,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Response>;
                 res = await this.rest.update<GalleryInterfaces.Response>(url, response, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Response,
                                               false);
 
@@ -3339,7 +3339,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3399,7 +3399,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ReviewsResult>;
                 res = await this.rest.get<GalleryInterfaces.ReviewsResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ReviewsResult,
                                               false);
 
@@ -3453,7 +3453,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ReviewSummary>;
                 res = await this.rest.get<GalleryInterfaces.ReviewSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3499,7 +3499,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.Review>;
                 res = await this.rest.create<GalleryInterfaces.Review>(url, review, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.Review,
                                               false);
 
@@ -3546,7 +3546,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3595,7 +3595,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ReviewPatch>;
                 res = await this.rest.update<GalleryInterfaces.ReviewPatch>(url, reviewPatch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ReviewPatch,
                                               false);
 
@@ -3633,7 +3633,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionCategory>;
                 res = await this.rest.create<GalleryInterfaces.ExtensionCategory>(url, category, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3677,7 +3677,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<{ [key: string] : any; }>;
                 res = await this.rest.get<{ [key: string] : any; }>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3720,7 +3720,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, entries, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3766,7 +3766,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3805,7 +3805,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3849,7 +3849,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, extensionStatisticsUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3904,7 +3904,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDailyStats>;
                 res = await this.rest.get<GalleryInterfaces.ExtensionDailyStats>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDailyStats,
                                               false);
 
@@ -3951,7 +3951,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.ExtensionDailyStats>;
                 res = await this.rest.get<GalleryInterfaces.ExtensionDailyStats>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.ExtensionDailyStats,
                                               false);
 
@@ -4011,7 +4011,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4099,7 +4099,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.get<GalleryInterfaces.PublishedExtension>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GalleryInterfaces.TypeInfo.PublishedExtension,
                                               false);
 
@@ -4144,7 +4144,7 @@ export class GalleryApi extends compatBase.GalleryCompatHttpClientBase implement
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/GalleryCompatHttpClientBase.ts
+++ b/api/GalleryCompatHttpClientBase.ts
@@ -53,7 +53,7 @@ export class GalleryCompatHttpClientBase extends basem.ClientApiBase implements 
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.create<GalleryInterfaces.PublishedExtension>(url, extensionPackage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     GalleryInterfaces.TypeInfo.PublishedExtension,
                     false);
 
@@ -93,7 +93,7 @@ export class GalleryCompatHttpClientBase extends basem.ClientApiBase implements 
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.replace<GalleryInterfaces.PublishedExtension>(url, extensionPackage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     GalleryInterfaces.TypeInfo.PublishedExtension,
                     false);
 
@@ -133,7 +133,7 @@ export class GalleryCompatHttpClientBase extends basem.ClientApiBase implements 
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.create<GalleryInterfaces.PublishedExtension>(url, extensionPackage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     GalleryInterfaces.TypeInfo.PublishedExtension,
                     false);
 
@@ -176,7 +176,7 @@ export class GalleryCompatHttpClientBase extends basem.ClientApiBase implements 
                 let res: restm.IRestResponse<GalleryInterfaces.PublishedExtension>;
                 res = await this.rest.replace<GalleryInterfaces.PublishedExtension>(url, extensionPackage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     GalleryInterfaces.TypeInfo.PublishedExtension,
                     false);
 

--- a/api/GitApi.ts
+++ b/api/GitApi.ts
@@ -222,7 +222,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -276,7 +276,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.AdvSecEnablementStatus[]>;
                 res = await this.rest.get<GitInterfaces.AdvSecEnablementStatus[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.AdvSecEnablementStatus,
                                               true);
 
@@ -322,7 +322,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.get<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -368,7 +368,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.get<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -414,7 +414,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -466,7 +466,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -506,7 +506,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, enablementUpdates, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -544,7 +544,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.BillablePusher[]>;
                 res = await this.rest.get<GitInterfaces.BillablePusher[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -585,7 +585,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.BillablePusher[]>;
                 res = await this.rest.get<GitInterfaces.BillablePusher[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -629,7 +629,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.BillableCommitter[]>;
                 res = await this.rest.get<GitInterfaces.BillableCommitter[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -680,7 +680,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.get<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -726,7 +726,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitAnnotatedTag>;
                 res = await this.rest.create<GitInterfaces.GitAnnotatedTag>(url, tagObject, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitAnnotatedTag,
                                               false);
 
@@ -773,7 +773,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitAnnotatedTag>;
                 res = await this.rest.get<GitInterfaces.GitAnnotatedTag>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitAnnotatedTag,
                                               false);
 
@@ -827,7 +827,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.BillableCommitter[]>;
                 res = await this.rest.get<GitInterfaces.BillableCommitter[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -881,7 +881,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.BillableCommitterDetail[]>;
                 res = await this.rest.get<GitInterfaces.BillableCommitterDetail[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.BillableCommitterDetail,
                                               true);
 
@@ -941,7 +941,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitBlobRef>;
                 res = await this.rest.get<GitInterfaces.GitBlobRef>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1147,7 +1147,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitBranchStats>;
                 res = await this.rest.get<GitInterfaces.GitBranchStats>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitBranchStats,
                                               false);
 
@@ -1198,7 +1198,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitBranchStats[]>;
                 res = await this.rest.get<GitInterfaces.GitBranchStats[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitBranchStats,
                                               true);
 
@@ -1244,7 +1244,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitBranchStats[]>;
                 res = await this.rest.create<GitInterfaces.GitBranchStats[]>(url, searchCriteria, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitBranchStats,
                                               true);
 
@@ -1301,7 +1301,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitChanges>;
                 res = await this.rest.get<GitInterfaces.GitCommitChanges>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitChanges,
                                               false);
 
@@ -1351,7 +1351,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.get<GitInterfaces.GitConflict>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -1417,7 +1417,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<GitInterfaces.GitConflict>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<GitInterfaces.GitConflict>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               true);
 
@@ -1469,7 +1469,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.update<GitInterfaces.GitConflict>(url, conflict, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -1518,7 +1518,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflictUpdateResult[]>;
                 res = await this.rest.update<GitInterfaces.GitConflictUpdateResult[]>(url, conflictUpdates, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflictUpdateResult,
                                               true);
 
@@ -1572,7 +1572,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.get<GitInterfaces.GitCommitRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -1618,7 +1618,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCherryPick>;
                 res = await this.rest.create<GitInterfaces.GitCherryPick>(url, cherryPickToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCherryPick,
                                               false);
 
@@ -1665,7 +1665,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCherryPick>;
                 res = await this.rest.get<GitInterfaces.GitCherryPick>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCherryPick,
                                               false);
 
@@ -1719,7 +1719,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCherryPick>;
                 res = await this.rest.get<GitInterfaces.GitCherryPick>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCherryPick,
                                               false);
 
@@ -1790,7 +1790,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitDiffs>;
                 res = await this.rest.get<GitInterfaces.GitCommitDiffs>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitDiffs,
                                               false);
 
@@ -1844,7 +1844,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommit>;
                 res = await this.rest.get<GitInterfaces.GitCommit>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommit,
                                               false);
 
@@ -1904,7 +1904,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.get<GitInterfaces.GitCommitRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -1967,7 +1967,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.get<GitInterfaces.GitCommitRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -2026,7 +2026,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.create<GitInterfaces.GitCommitRef[]>(url, searchCriteria, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -2067,7 +2067,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitDeletedRepository[]>;
                 res = await this.rest.get<GitInterfaces.GitDeletedRepository[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitDeletedRepository,
                                               true);
 
@@ -2113,7 +2113,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.FileDiff[]>;
                 res = await this.rest.create<GitInterfaces.FileDiff[]>(url, fileDiffsCriteria, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.FileDiff,
                                               true);
 
@@ -2167,7 +2167,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepositoryRef[]>;
                 res = await this.rest.get<GitInterfaces.GitRepositoryRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepositoryRef,
                                               true);
 
@@ -2220,7 +2220,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitForkSyncRequest>;
                 res = await this.rest.create<GitInterfaces.GitForkSyncRequest>(url, syncParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitForkSyncRequest,
                                               false);
 
@@ -2274,7 +2274,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitForkSyncRequest>;
                 res = await this.rest.get<GitInterfaces.GitForkSyncRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitForkSyncRequest,
                                               false);
 
@@ -2328,7 +2328,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitForkSyncRequest[]>;
                 res = await this.rest.get<GitInterfaces.GitForkSyncRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitForkSyncRequest,
                                               true);
 
@@ -2409,7 +2409,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitItem>;
                 res = await this.rest.get<GitInterfaces.GitItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitItem,
                                               false);
 
@@ -2554,7 +2554,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitItem[]>;
                 res = await this.rest.get<GitInterfaces.GitItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitItem,
                                               true);
 
@@ -2746,7 +2746,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitImportRequest>;
                 res = await this.rest.create<GitInterfaces.GitImportRequest>(url, importRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitImportRequest,
                                               false);
 
@@ -2793,7 +2793,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitImportRequest>;
                 res = await this.rest.get<GitInterfaces.GitImportRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitImportRequest,
                                               false);
 
@@ -2844,7 +2844,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitImportRequest[]>;
                 res = await this.rest.get<GitInterfaces.GitImportRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitImportRequest,
                                               true);
 
@@ -2893,7 +2893,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitImportRequest>;
                 res = await this.rest.update<GitInterfaces.GitImportRequest>(url, importRequestToUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitImportRequest,
                                               false);
 
@@ -2974,7 +2974,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitItem>;
                 res = await this.rest.get<GitInterfaces.GitItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitItem,
                                               false);
 
@@ -3119,7 +3119,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitItem[]>;
                 res = await this.rest.get<GitInterfaces.GitItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitItem,
                                               true);
 
@@ -3311,7 +3311,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitItem[][]>;
                 res = await this.rest.create<GitInterfaces.GitItem[][]>(url, requestData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitItem,
                                               true);
 
@@ -3374,7 +3374,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.get<GitInterfaces.GitCommitRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -3427,7 +3427,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitMerge>;
                 res = await this.rest.create<GitInterfaces.GitMerge>(url, mergeParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitMerge,
                                               false);
 
@@ -3481,7 +3481,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitMerge>;
                 res = await this.rest.get<GitInterfaces.GitMerge>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitMerge,
                                               false);
 
@@ -3539,7 +3539,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Attachment>;
                 res = await this.rest.uploadStream<GitInterfaces.Attachment>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Attachment,
                                               false);
 
@@ -3588,7 +3588,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3677,7 +3677,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Attachment[]>;
                 res = await this.rest.get<GitInterfaces.Attachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Attachment,
                                               true);
 
@@ -3772,7 +3772,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3825,7 +3825,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3878,7 +3878,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
                 res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3938,7 +3938,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitCommitRef[]>;
                 res = await this.rest.get<GitInterfaces.GitCommitRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -3985,7 +3985,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<GitInterfaces.GitCommitRef>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<GitInterfaces.GitCommitRef>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitCommitRef,
                                               true);
 
@@ -4035,7 +4035,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.get<GitInterfaces.GitConflict>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -4101,7 +4101,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict[]>;
                 res = await this.rest.get<GitInterfaces.GitConflict[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               true);
 
@@ -4153,7 +4153,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.update<GitInterfaces.GitConflict>(url, conflict, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -4202,7 +4202,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflictUpdateResult[]>;
                 res = await this.rest.update<GitInterfaces.GitConflictUpdateResult[]>(url, conflictUpdates, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflictUpdateResult,
                                               true);
 
@@ -4265,7 +4265,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestIterationChanges>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestIterationChanges>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestIterationChanges,
                                               false);
 
@@ -4315,7 +4315,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestIteration>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestIteration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestIteration,
                                               false);
 
@@ -4369,7 +4369,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestIteration[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestIteration[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestIteration,
                                               true);
 
@@ -4421,7 +4421,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus>;
                 res = await this.rest.create<GitInterfaces.GitPullRequestStatus>(url, status, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               false);
 
@@ -4474,7 +4474,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4527,7 +4527,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestStatus>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               false);
 
@@ -4577,7 +4577,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestStatus[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               true);
 
@@ -4634,7 +4634,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, patchDocument, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4690,7 +4690,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<TfsCoreInterfaces.WebApiTagDefinition>;
                 res = await this.rest.create<TfsCoreInterfaces.WebApiTagDefinition>(url, label, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4747,7 +4747,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4804,7 +4804,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<TfsCoreInterfaces.WebApiTagDefinition>;
                 res = await this.rest.get<TfsCoreInterfaces.WebApiTagDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4858,7 +4858,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<TfsCoreInterfaces.WebApiTagDefinition[]>;
                 res = await this.rest.get<TfsCoreInterfaces.WebApiTagDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4905,7 +4905,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4959,7 +4959,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.update<any>(url, patchDocument, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5005,7 +5005,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestQuery>;
                 res = await this.rest.create<GitInterfaces.GitPullRequestQuery>(url, queries, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestQuery,
                                               false);
 
@@ -5057,7 +5057,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote>;
                 res = await this.rest.replace<GitInterfaces.IdentityRefWithVote>(url, reviewer, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5106,7 +5106,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote[]>;
                 res = await this.rest.create<GitInterfaces.IdentityRefWithVote[]>(url, reviewers, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5155,7 +5155,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote>;
                 res = await this.rest.replace<GitInterfaces.IdentityRefWithVote>(url, reviewer, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5205,7 +5205,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5255,7 +5255,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote>;
                 res = await this.rest.get<GitInterfaces.IdentityRefWithVote>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5302,7 +5302,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote[]>;
                 res = await this.rest.get<GitInterfaces.IdentityRefWithVote[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5354,7 +5354,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.IdentityRefWithVote>;
                 res = await this.rest.update<GitInterfaces.IdentityRefWithVote>(url, reviewer, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5403,7 +5403,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, patchVotes, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5447,7 +5447,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest>;
                 res = await this.rest.get<GitInterfaces.GitPullRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               false);
 
@@ -5507,7 +5507,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               true);
 
@@ -5560,7 +5560,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest>;
                 res = await this.rest.create<GitInterfaces.GitPullRequest>(url, gitPullRequestToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               false);
 
@@ -5626,7 +5626,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest>;
                 res = await this.rest.get<GitInterfaces.GitPullRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               false);
 
@@ -5689,7 +5689,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               true);
 
@@ -5738,7 +5738,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequest>;
                 res = await this.rest.update<GitInterfaces.GitPullRequest>(url, gitPullRequestToUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequest,
                                               false);
 
@@ -5787,7 +5787,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, userMessage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5836,7 +5836,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus>;
                 res = await this.rest.create<GitInterfaces.GitPullRequestStatus>(url, status, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               false);
 
@@ -5886,7 +5886,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5936,7 +5936,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestStatus>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               false);
 
@@ -5983,7 +5983,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestStatus[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestStatus[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestStatus,
                                               true);
 
@@ -6037,7 +6037,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, patchDocument, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6089,7 +6089,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Comment>;
                 res = await this.rest.create<GitInterfaces.Comment>(url, comment, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -6142,7 +6142,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6195,7 +6195,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Comment>;
                 res = await this.rest.get<GitInterfaces.Comment>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -6245,7 +6245,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Comment[]>;
                 res = await this.rest.get<GitInterfaces.Comment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Comment,
                                               true);
 
@@ -6300,7 +6300,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.Comment>;
                 res = await this.rest.update<GitInterfaces.Comment>(url, comment, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -6349,7 +6349,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestCommentThread>;
                 res = await this.rest.create<GitInterfaces.GitPullRequestCommentThread>(url, commentThread, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestCommentThread,
                                               false);
 
@@ -6409,7 +6409,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestCommentThread>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestCommentThread>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestCommentThread,
                                               false);
 
@@ -6466,7 +6466,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestCommentThread[]>;
                 res = await this.rest.get<GitInterfaces.GitPullRequestCommentThread[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestCommentThread,
                                               true);
 
@@ -6518,7 +6518,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPullRequestCommentThread>;
                 res = await this.rest.update<GitInterfaces.GitPullRequestCommentThread>(url, commentThread, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPullRequestCommentThread,
                                               false);
 
@@ -6565,7 +6565,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.ResourceRef[]>;
                 res = await this.rest.get<VSSInterfaces.ResourceRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -6611,7 +6611,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPush>;
                 res = await this.rest.create<GitInterfaces.GitPush>(url, push, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPush,
                                               false);
 
@@ -6668,7 +6668,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPush>;
                 res = await this.rest.get<GitInterfaces.GitPush>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPush,
                                               false);
 
@@ -6725,7 +6725,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitPush[]>;
                 res = await this.rest.get<GitInterfaces.GitPush[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitPush,
                                               true);
 
@@ -6769,7 +6769,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6810,7 +6810,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitDeletedRepository[]>;
                 res = await this.rest.get<GitInterfaces.GitDeletedRepository[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitDeletedRepository,
                                               true);
 
@@ -6856,7 +6856,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository>;
                 res = await this.rest.update<GitInterfaces.GitRepository>(url, repositoryDetails, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               false);
 
@@ -6925,7 +6925,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<GitInterfaces.GitRef>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<GitInterfaces.GitRef>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRef,
                                               true);
 
@@ -6984,7 +6984,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRef>;
                 res = await this.rest.update<GitInterfaces.GitRef>(url, newRefInfo, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRef,
                                               false);
 
@@ -7037,7 +7037,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRefUpdateResult[]>;
                 res = await this.rest.create<GitInterfaces.GitRefUpdateResult[]>(url, refUpdates, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRefUpdateResult,
                                               true);
 
@@ -7080,7 +7080,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRefFavorite>;
                 res = await this.rest.create<GitInterfaces.GitRefFavorite>(url, favorite, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRefFavorite,
                                               false);
 
@@ -7124,7 +7124,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -7168,7 +7168,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRefFavorite>;
                 res = await this.rest.get<GitInterfaces.GitRefFavorite>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRefFavorite,
                                               false);
 
@@ -7219,7 +7219,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRefFavorite[]>;
                 res = await this.rest.get<GitInterfaces.GitRefFavorite[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRefFavorite,
                                               true);
 
@@ -7265,7 +7265,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRefFavorite[]>;
                 res = await this.rest.get<GitInterfaces.GitRefFavorite[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRefFavorite,
                                               true);
 
@@ -7315,7 +7315,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository>;
                 res = await this.rest.create<GitInterfaces.GitRepository>(url, gitRepositoryToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               false);
 
@@ -7359,7 +7359,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -7413,7 +7413,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository[]>;
                 res = await this.rest.get<GitInterfaces.GitRepository[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               true);
 
@@ -7457,7 +7457,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository>;
                 res = await this.rest.get<GitInterfaces.GitRepository>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               false);
 
@@ -7511,7 +7511,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository>;
                 res = await this.rest.get<GitInterfaces.GitRepository>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               false);
 
@@ -7557,7 +7557,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRepository>;
                 res = await this.rest.update<GitInterfaces.GitRepository>(url, newRepositoryInfo, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               false);
 
@@ -7620,7 +7620,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<GitInterfaces.GitRepository>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<GitInterfaces.GitRepository>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRepository,
                                               true);
 
@@ -7670,7 +7670,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.get<GitInterfaces.GitConflict>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -7736,7 +7736,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<GitInterfaces.GitConflict>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<GitInterfaces.GitConflict>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               true);
 
@@ -7788,7 +7788,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflict>;
                 res = await this.rest.update<GitInterfaces.GitConflict>(url, conflict, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflict,
                                               false);
 
@@ -7837,7 +7837,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitConflictUpdateResult[]>;
                 res = await this.rest.update<GitInterfaces.GitConflictUpdateResult[]>(url, conflictUpdates, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitConflictUpdateResult,
                                               true);
 
@@ -7883,7 +7883,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRevert>;
                 res = await this.rest.create<GitInterfaces.GitRevert>(url, revertToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRevert,
                                               false);
 
@@ -7930,7 +7930,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRevert>;
                 res = await this.rest.get<GitInterfaces.GitRevert>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRevert,
                                               false);
 
@@ -7984,7 +7984,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitRevert>;
                 res = await this.rest.get<GitInterfaces.GitRevert>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitRevert,
                                               false);
 
@@ -8033,7 +8033,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitStatus>;
                 res = await this.rest.create<GitInterfaces.GitStatus>(url, gitCommitStatusToCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitStatus,
                                               false);
 
@@ -8093,7 +8093,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitStatus[]>;
                 res = await this.rest.get<GitInterfaces.GitStatus[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitStatus,
                                               true);
 
@@ -8144,7 +8144,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitSuggestion[]>;
                 res = await this.rest.get<GitInterfaces.GitSuggestion[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -8204,7 +8204,7 @@ export class GitApi extends basem.ClientApiBase implements IGitApi {
                 let res: restm.IRestResponse<GitInterfaces.GitTreeRef>;
                 res = await this.rest.get<GitInterfaces.GitTreeRef>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               GitInterfaces.TypeInfo.GitTreeRef,
                                               false);
 

--- a/api/LocationsApi.ts
+++ b/api/LocationsApi.ts
@@ -73,7 +73,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ConnectionData>;
                 res = await this.rest.get<LocationsInterfaces.ConnectionData>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               LocationsInterfaces.TypeInfo.ConnectionData,
                                               false);
 
@@ -125,7 +125,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ResourceAreaInfo>;
                 res = await this.rest.get<LocationsInterfaces.ResourceAreaInfo>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -177,7 +177,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ResourceAreaInfo>;
                 res = await this.rest.get<LocationsInterfaces.ResourceAreaInfo>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -232,7 +232,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ResourceAreaInfo>;
                 res = await this.rest.get<LocationsInterfaces.ResourceAreaInfo>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -278,7 +278,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ResourceAreaInfo[]>;
                 res = await this.rest.get<LocationsInterfaces.ResourceAreaInfo[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -324,7 +324,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ResourceAreaInfo[]>;
                 res = await this.rest.get<LocationsInterfaces.ResourceAreaInfo[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -366,7 +366,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -420,7 +420,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ServiceDefinition>;
                 res = await this.rest.get<LocationsInterfaces.ServiceDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               LocationsInterfaces.TypeInfo.ServiceDefinition,
                                               false);
 
@@ -459,7 +459,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<LocationsInterfaces.ServiceDefinition[]>;
                 res = await this.rest.get<LocationsInterfaces.ServiceDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               LocationsInterfaces.TypeInfo.ServiceDefinition,
                                               true);
 
@@ -497,7 +497,7 @@ export class LocationsApi extends basem.ClientApiBase implements ILocationsApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, serviceDefinitions, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/ManagementApi.ts
+++ b/api/ManagementApi.ts
@@ -91,7 +91,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.RepoEnablementSettings>;
                 res = await this.rest.get<ManagementInterfaces.RepoEnablementSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.RepoEnablementSettings,
                                               false);
 
@@ -137,7 +137,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -178,7 +178,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, meterUsage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -224,7 +224,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.BillableCommitterDetails[]>;
                 res = await this.rest.get<ManagementInterfaces.BillableCommitterDetails[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.BillableCommitterDetails,
                                               true);
 
@@ -261,7 +261,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsage>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsage>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.MeterUsage,
                                               false);
 
@@ -307,7 +307,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsage>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsage>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.MeterUsage,
                                               false);
 
@@ -358,7 +358,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, meterUsage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -410,7 +410,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.BillableCommitterDetails[]>;
                 res = await this.rest.get<ManagementInterfaces.BillableCommitterDetails[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.BillableCommitterDetails,
                                               true);
 
@@ -457,7 +457,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsageForPlan>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsageForPlan>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.MeterUsageForPlan,
                                               false);
 
@@ -509,7 +509,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsageForPlan>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsageForPlan>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.MeterUsageForPlan,
                                               false);
 
@@ -554,7 +554,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementSettings>;
                 res = await this.rest.get<ManagementInterfaces.AdvSecEnablementSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.AdvSecEnablementSettings,
                                               false);
 
@@ -594,7 +594,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -639,7 +639,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.OrgEnablementSettings>;
                 res = await this.rest.get<ManagementInterfaces.OrgEnablementSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.OrgEnablementSettings,
                                               false);
 
@@ -679,7 +679,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, orgEnablementSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -718,7 +718,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.BilledCommitter[]>;
                 res = await this.rest.get<ManagementInterfaces.BilledCommitter[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -757,7 +757,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -806,7 +806,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsageEstimate>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsageEstimate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -854,7 +854,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementSettings>;
                 res = await this.rest.get<ManagementInterfaces.AdvSecEnablementSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.AdvSecEnablementSettings,
                                               false);
 
@@ -897,7 +897,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -945,7 +945,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.ProjectEnablementSettings>;
                 res = await this.rest.get<ManagementInterfaces.ProjectEnablementSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.ProjectEnablementSettings,
                                               false);
 
@@ -988,7 +988,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, projectEnablementSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1030,7 +1030,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.BilledCommitter[]>;
                 res = await this.rest.get<ManagementInterfaces.BilledCommitter[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1072,7 +1072,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1121,7 +1121,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsageEstimate>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsageEstimate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1172,7 +1172,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.AdvSecEnablementStatus>;
                 res = await this.rest.get<ManagementInterfaces.AdvSecEnablementStatus>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ManagementInterfaces.TypeInfo.AdvSecEnablementStatus,
                                               false);
 
@@ -1218,7 +1218,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, savedAdvSecEnablementStatus, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1263,7 +1263,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.BilledCommitter[]>;
                 res = await this.rest.get<ManagementInterfaces.BilledCommitter[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1308,7 +1308,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1360,7 +1360,7 @@ export class ManagementApi extends basem.ClientApiBase implements IManagementApi
                 let res: restm.IRestResponse<ManagementInterfaces.MeterUsageEstimate>;
                 res = await this.rest.get<ManagementInterfaces.MeterUsageEstimate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/NotificationApi.ts
+++ b/api/NotificationApi.ts
@@ -74,7 +74,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, operation, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -128,7 +128,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.INotificationDiagnosticLog[]>;
                 res = await this.rest.get<NotificationInterfaces.INotificationDiagnosticLog[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.INotificationDiagnosticLog,
                                               true);
 
@@ -169,7 +169,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
                 res = await this.rest.get<NotificationInterfaces.SubscriptionDiagnostics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
                                               false);
 
@@ -212,7 +212,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionDiagnostics>;
                 res = await this.rest.replace<NotificationInterfaces.SubscriptionDiagnostics>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.SubscriptionDiagnostics,
                                               false);
 
@@ -252,7 +252,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<VSSInterfaces.VssNotificationEvent>;
                 res = await this.rest.create<VSSInterfaces.VssNotificationEvent>(url, notificationEvent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               VSSInterfaces.TypeInfo.VssNotificationEvent,
                                               false);
 
@@ -292,7 +292,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.EventTransformResult>;
                 res = await this.rest.create<NotificationInterfaces.EventTransformResult>(url, transformRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -333,7 +333,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventField[]>;
                 res = await this.rest.create<NotificationInterfaces.NotificationEventField[]>(url, inputValuesQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationEventField,
                                               true);
 
@@ -374,7 +374,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventType>;
                 res = await this.rest.get<NotificationInterfaces.NotificationEventType>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationEventType,
                                               false);
 
@@ -419,7 +419,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationEventType[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationEventType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationEventType,
                                               true);
 
@@ -458,7 +458,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationReason>;
                 res = await this.rest.get<NotificationInterfaces.NotificationReason>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationReason,
                                               false);
 
@@ -501,7 +501,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationReason[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationReason[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationReason,
                                               true);
 
@@ -537,7 +537,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
                 res = await this.rest.get<NotificationInterfaces.NotificationAdminSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationAdminSettings,
                                               false);
 
@@ -575,7 +575,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationAdminSettings>;
                 res = await this.rest.update<NotificationInterfaces.NotificationAdminSettings>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationAdminSettings,
                                               false);
 
@@ -616,7 +616,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriber>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscriber>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscriber,
                                               false);
 
@@ -659,7 +659,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriber>;
                 res = await this.rest.update<NotificationInterfaces.NotificationSubscriber>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscriber,
                                               false);
 
@@ -699,7 +699,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription[]>;
                 res = await this.rest.create<NotificationInterfaces.NotificationSubscription[]>(url, subscriptionQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscription,
                                               true);
 
@@ -739,7 +739,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.create<NotificationInterfaces.NotificationSubscription>(url, createParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscription,
                                               false);
 
@@ -780,7 +780,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -828,7 +828,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscription>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscription,
                                               false);
 
@@ -879,7 +879,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscription[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscription,
                                               true);
 
@@ -922,7 +922,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscription>;
                 res = await this.rest.update<NotificationInterfaces.NotificationSubscription>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscription,
                                               false);
 
@@ -960,7 +960,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.NotificationSubscriptionTemplate[]>;
                 res = await this.rest.get<NotificationInterfaces.NotificationSubscriptionTemplate[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               NotificationInterfaces.TypeInfo.NotificationSubscriptionTemplate,
                                               true);
 
@@ -1000,7 +1000,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<VSSInterfaces.VssNotificationEvent>;
                 res = await this.rest.create<VSSInterfaces.VssNotificationEvent>(url, notificationEvent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               VSSInterfaces.TypeInfo.VssNotificationEvent,
                                               false);
 
@@ -1046,7 +1046,7 @@ export class NotificationApi extends basem.ClientApiBase implements INotificatio
                 let res: restm.IRestResponse<NotificationInterfaces.SubscriptionUserSettings>;
                 res = await this.rest.replace<NotificationInterfaces.SubscriptionUserSettings>(url, userSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/PipelinesApi.ts
+++ b/api/PipelinesApi.ts
@@ -81,7 +81,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Artifact>;
                 res = await this.rest.get<PipelinesInterfaces.Artifact>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Artifact,
                                               false);
 
@@ -138,7 +138,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Log>;
                 res = await this.rest.get<PipelinesInterfaces.Log>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Log,
                                               false);
 
@@ -192,7 +192,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.LogCollection>;
                 res = await this.rest.get<PipelinesInterfaces.LogCollection>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.LogCollection,
                                               false);
 
@@ -235,7 +235,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Pipeline>;
                 res = await this.rest.create<PipelinesInterfaces.Pipeline>(url, inputParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Pipeline,
                                               false);
 
@@ -286,7 +286,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Pipeline>;
                 res = await this.rest.get<PipelinesInterfaces.Pipeline>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Pipeline,
                                               false);
 
@@ -340,7 +340,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Pipeline[]>;
                 res = await this.rest.get<PipelinesInterfaces.Pipeline[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Pipeline,
                                               true);
 
@@ -393,7 +393,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.PreviewRun>;
                 res = await this.rest.create<PipelinesInterfaces.PreviewRun>(url, runParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -440,7 +440,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Run>;
                 res = await this.rest.get<PipelinesInterfaces.Run>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Run,
                                               false);
 
@@ -484,7 +484,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Run[]>;
                 res = await this.rest.get<PipelinesInterfaces.Run[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Run,
                                               true);
 
@@ -537,7 +537,7 @@ export class PipelinesApi extends basem.ClientApiBase implements IPipelinesApi {
                 let res: restm.IRestResponse<PipelinesInterfaces.Run>;
                 res = await this.rest.create<PipelinesInterfaces.Run>(url, runParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PipelinesInterfaces.TypeInfo.Run,
                                               false);
 

--- a/api/PolicyApi.ts
+++ b/api/PolicyApi.ts
@@ -69,7 +69,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyConfiguration>;
                 res = await this.rest.create<PolicyInterfaces.PolicyConfiguration>(url, configuration, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               false);
 
@@ -113,7 +113,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -157,7 +157,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyConfiguration>;
                 res = await this.rest.get<PolicyInterfaces.PolicyConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               false);
 
@@ -208,7 +208,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<PolicyInterfaces.PolicyConfiguration>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<PolicyInterfaces.PolicyConfiguration>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               true);
 
@@ -254,7 +254,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyConfiguration>;
                 res = await this.rest.replace<PolicyInterfaces.PolicyConfiguration>(url, configuration, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               false);
 
@@ -298,7 +298,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyEvaluationRecord>;
                 res = await this.rest.get<PolicyInterfaces.PolicyEvaluationRecord>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyEvaluationRecord,
                                               false);
 
@@ -342,7 +342,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyEvaluationRecord>;
                 res = await this.rest.update<PolicyInterfaces.PolicyEvaluationRecord>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyEvaluationRecord,
                                               false);
 
@@ -402,7 +402,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyEvaluationRecord[]>;
                 res = await this.rest.get<PolicyInterfaces.PolicyEvaluationRecord[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyEvaluationRecord,
                                               true);
 
@@ -449,7 +449,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyConfiguration>;
                 res = await this.rest.get<PolicyInterfaces.PolicyConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               false);
 
@@ -503,7 +503,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyConfiguration[]>;
                 res = await this.rest.get<PolicyInterfaces.PolicyConfiguration[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               PolicyInterfaces.TypeInfo.PolicyConfiguration,
                                               true);
 
@@ -547,7 +547,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyType>;
                 res = await this.rest.get<PolicyInterfaces.PolicyType>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -588,7 +588,7 @@ export class PolicyApi extends basem.ClientApiBase implements IPolicyApi {
                 let res: restm.IRestResponse<PolicyInterfaces.PolicyType[]>;
                 res = await this.rest.get<PolicyInterfaces.PolicyType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 

--- a/api/ProfileApi.ts
+++ b/api/ProfileApi.ts
@@ -76,7 +76,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -121,7 +121,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.ProfileAttribute>;
                 res = await this.rest.get<ProfileInterfaces.ProfileAttribute>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.ProfileAttribute,
                     false);
 
@@ -178,7 +178,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.ProfileAttribute[]>;
                 res = await this.rest.get<ProfileInterfaces.ProfileAttribute[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.ProfileAttribute,
                     true);
 
@@ -225,7 +225,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, container, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -265,7 +265,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, attributesCollection, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -313,7 +313,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Avatar>;
                 res = await this.rest.get<ProfileInterfaces.Avatar>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Avatar,
                     false);
 
@@ -366,7 +366,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Avatar>;
                 res = await this.rest.create<ProfileInterfaces.Avatar>(url, container, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Avatar,
                     false);
 
@@ -404,7 +404,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -444,7 +444,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, container, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -488,7 +488,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.GeoRegion>;
                 res = await this.rest.get<ProfileInterfaces.GeoRegion>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -534,7 +534,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Profile>;
                 res = await this.rest.create<ProfileInterfaces.Profile>(url, createProfileContext, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Profile,
                     false);
 
@@ -591,7 +591,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Profile>;
                 res = await this.rest.get<ProfileInterfaces.Profile>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Profile,
                     false);
 
@@ -633,7 +633,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, profile, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -668,7 +668,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.ProfileRegions>;
                 res = await this.rest.get<ProfileInterfaces.ProfileRegions>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -703,7 +703,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     true);
 
@@ -745,7 +745,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Profile>;
                 res = await this.rest.get<ProfileInterfaces.Profile>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Profile,
                     false);
 
@@ -783,7 +783,7 @@ export class ProfileApi extends basem.ClientApiBase implements IProfileApi {
                 let res: restm.IRestResponse<ProfileInterfaces.Profile>;
                 res = await this.rest.replace<ProfileInterfaces.Profile>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     ProfileInterfaces.TypeInfo.Profile,
                     false);
 

--- a/api/ProjectAnalysisApi.ts
+++ b/api/ProjectAnalysisApi.ts
@@ -56,7 +56,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
                 let res: restm.IRestResponse<ProjectAnalysisInterfaces.ProjectLanguageAnalytics>;
                 res = await this.rest.get<ProjectAnalysisInterfaces.ProjectLanguageAnalytics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ProjectAnalysisInterfaces.TypeInfo.ProjectLanguageAnalytics,
                                               false);
 
@@ -111,7 +111,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
                 let res: restm.IRestResponse<ProjectAnalysisInterfaces.ProjectActivityMetrics>;
                 res = await this.rest.get<ProjectAnalysisInterfaces.ProjectActivityMetrics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ProjectAnalysisInterfaces.TypeInfo.ProjectActivityMetrics,
                                               false);
 
@@ -180,7 +180,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
                 let res: restm.IRestResponse<ProjectAnalysisInterfaces.RepositoryActivityMetrics[]>;
                 res = await this.rest.get<ProjectAnalysisInterfaces.RepositoryActivityMetrics[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ProjectAnalysisInterfaces.TypeInfo.RepositoryActivityMetrics,
                                               true);
 
@@ -238,7 +238,7 @@ export class ProjectAnalysisApi extends basem.ClientApiBase implements IProjectA
                 let res: restm.IRestResponse<ProjectAnalysisInterfaces.RepositoryActivityMetrics>;
                 res = await this.rest.get<ProjectAnalysisInterfaces.RepositoryActivityMetrics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ProjectAnalysisInterfaces.TypeInfo.RepositoryActivityMetrics,
                                               false);
 

--- a/api/ReleaseApi.ts
+++ b/api/ReleaseApi.ts
@@ -147,7 +147,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.AgentArtifactDefinition[]>;
                 res = await this.rest.get<ReleaseInterfaces.AgentArtifactDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.AgentArtifactDefinition,
                                               true);
 
@@ -216,7 +216,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<ReleaseInterfaces.ReleaseApproval>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<ReleaseInterfaces.ReleaseApproval>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseApproval,
                                               true);
 
@@ -260,7 +260,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseApproval>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseApproval>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseApproval,
                                               false);
 
@@ -311,7 +311,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseApproval>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseApproval>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseApproval,
                                               false);
 
@@ -357,7 +357,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseApproval>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseApproval>(url, approval, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseApproval,
                                               false);
 
@@ -398,7 +398,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseApproval[]>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseApproval[]>(url, approvals, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseApproval,
                                               true);
 
@@ -565,7 +565,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTaskAttachment[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseTaskAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseTaskAttachment,
                                               true);
 
@@ -621,7 +621,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTaskAttachment[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseTaskAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseTaskAttachment,
                                               true);
 
@@ -682,7 +682,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.AutoTriggerIssue[]>;
                 res = await this.rest.get<ReleaseInterfaces.AutoTriggerIssue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.AutoTriggerIssue,
                                               true);
 
@@ -732,7 +732,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -787,7 +787,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Change[]>;
                 res = await this.rest.get<ReleaseInterfaces.Change[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Change,
                                               true);
 
@@ -836,7 +836,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.DefinitionEnvironmentReference[]>;
                 res = await this.rest.get<ReleaseInterfaces.DefinitionEnvironmentReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -879,7 +879,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinition>;
                 res = await this.rest.create<ReleaseInterfaces.ReleaseDefinition>(url, releaseDefinition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinition,
                                               false);
 
@@ -933,7 +933,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -987,7 +987,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinition>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinition,
                                               false);
 
@@ -1120,7 +1120,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<ReleaseInterfaces.ReleaseDefinition>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<ReleaseInterfaces.ReleaseDefinition>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinition,
                                               true);
 
@@ -1166,7 +1166,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinition>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseDefinition>(url, releaseDefinitionUndeleteParameter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinition,
                                               false);
 
@@ -1216,7 +1216,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinition>;
                 res = await this.rest.replace<ReleaseInterfaces.ReleaseDefinition>(url, releaseDefinition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinition,
                                               false);
 
@@ -1306,7 +1306,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<ReleaseInterfaces.Deployment>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<ReleaseInterfaces.Deployment>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Deployment,
                                               true);
 
@@ -1347,7 +1347,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Deployment[]>;
                 res = await this.rest.create<ReleaseInterfaces.Deployment[]>(url, queryParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Deployment,
                                               true);
 
@@ -1401,7 +1401,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseEnvironment>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseEnvironment>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseEnvironment,
                                               false);
 
@@ -1450,7 +1450,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseEnvironment>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseEnvironment>(url, environmentUpdateData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseEnvironment,
                                               false);
 
@@ -1493,7 +1493,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>;
                 res = await this.rest.create<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>(url, template, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionEnvironmentTemplate,
                                               false);
 
@@ -1544,7 +1544,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1595,7 +1595,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionEnvironmentTemplate,
                                               false);
 
@@ -1643,7 +1643,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionEnvironmentTemplate,
                                               true);
 
@@ -1694,7 +1694,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseDefinitionEnvironmentTemplate>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionEnvironmentTemplate,
                                               false);
 
@@ -1745,7 +1745,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.FavoriteItem[]>;
                 res = await this.rest.create<ReleaseInterfaces.FavoriteItem[]>(url, favoriteItems, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1797,7 +1797,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1846,7 +1846,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.FavoriteItem[]>;
                 res = await this.rest.get<ReleaseInterfaces.FavoriteItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1889,7 +1889,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1935,7 +1935,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Folder>;
                 res = await this.rest.create<ReleaseInterfaces.Folder>(url, folder, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Folder,
                                               false);
 
@@ -1979,7 +1979,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2030,7 +2030,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Folder[]>;
                 res = await this.rest.get<ReleaseInterfaces.Folder[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Folder,
                                               true);
 
@@ -2076,7 +2076,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Folder>;
                 res = await this.rest.update<ReleaseInterfaces.Folder>(url, folder, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Folder,
                                               false);
 
@@ -2122,7 +2122,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseGates>;
                 res = await this.rest.update<ReleaseInterfaces.ReleaseGates>(url, gateUpdateMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseGates,
                                               false);
 
@@ -2164,7 +2164,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseRevision[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseRevision[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseRevision,
                                               true);
 
@@ -2205,7 +2205,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<FormInputInterfaces.InputValuesQuery>;
                 res = await this.rest.create<FormInputInterfaces.InputValuesQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2254,7 +2254,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.AutoTriggerIssue[]>;
                 res = await this.rest.get<ReleaseInterfaces.AutoTriggerIssue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.AutoTriggerIssue,
                                               true);
 
@@ -2544,7 +2544,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ManualIntervention>;
                 res = await this.rest.get<ReleaseInterfaces.ManualIntervention>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ManualIntervention,
                                               false);
 
@@ -2588,7 +2588,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ManualIntervention[]>;
                 res = await this.rest.get<ReleaseInterfaces.ManualIntervention[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ManualIntervention,
                                               true);
 
@@ -2637,7 +2637,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ManualIntervention>;
                 res = await this.rest.update<ReleaseInterfaces.ManualIntervention>(url, manualInterventionUpdateMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ManualIntervention,
                                               false);
 
@@ -2683,7 +2683,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Metric[]>;
                 res = await this.rest.get<ReleaseInterfaces.Metric[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2721,7 +2721,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.OrgPipelineReleaseSettings>;
                 res = await this.rest.get<ReleaseInterfaces.OrgPipelineReleaseSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2761,7 +2761,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.OrgPipelineReleaseSettings>;
                 res = await this.rest.update<ReleaseInterfaces.OrgPipelineReleaseSettings>(url, newSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2802,7 +2802,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ProjectPipelineReleaseSettings>;
                 res = await this.rest.get<ReleaseInterfaces.ProjectPipelineReleaseSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2845,7 +2845,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ProjectPipelineReleaseSettings>;
                 res = await this.rest.update<ReleaseInterfaces.ProjectPipelineReleaseSettings>(url, newSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2897,7 +2897,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ProjectReference[]>;
                 res = await this.rest.get<ReleaseInterfaces.ProjectReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3005,7 +3005,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Release[]>;
                 res = await this.rest.get<ReleaseInterfaces.Release[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Release,
                                               true);
 
@@ -3048,7 +3048,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Release>;
                 res = await this.rest.create<ReleaseInterfaces.Release>(url, releaseStartMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Release,
                                               false);
 
@@ -3099,7 +3099,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3162,7 +3162,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Release>;
                 res = await this.rest.get<ReleaseInterfaces.Release>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Release,
                                               false);
 
@@ -3225,7 +3225,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionSummary>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseDefinitionSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionSummary,
                                               false);
 
@@ -3325,7 +3325,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3371,7 +3371,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Release>;
                 res = await this.rest.replace<ReleaseInterfaces.Release>(url, release, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Release,
                                               false);
 
@@ -3417,7 +3417,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.Release>;
                 res = await this.rest.update<ReleaseInterfaces.Release>(url, releaseUpdateMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.Release,
                                               false);
 
@@ -3458,7 +3458,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseSettings>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3501,7 +3501,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseSettings>;
                 res = await this.rest.replace<ReleaseInterfaces.ReleaseSettings>(url, releaseSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3584,7 +3584,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseDefinitionRevision[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseDefinitionRevision[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseDefinitionRevision,
                                               true);
 
@@ -3626,7 +3626,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.SummaryMailSection[]>;
                 res = await this.rest.get<ReleaseInterfaces.SummaryMailSection[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.SummaryMailSection,
                                               true);
 
@@ -3670,7 +3670,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, mailMessage, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3712,7 +3712,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3759,7 +3759,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.update<string[]>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3805,7 +3805,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, tags, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3852,7 +3852,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.del<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3896,7 +3896,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3943,7 +3943,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.update<string[]>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3989,7 +3989,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, tags, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4036,7 +4036,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.del<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4080,7 +4080,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4119,7 +4119,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4167,7 +4167,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTask[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseTask[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseTask,
                                               true);
 
@@ -4218,7 +4218,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTask[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseTask[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseTask,
                                               true);
 
@@ -4270,7 +4270,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseTask[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseTask[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ReleaseTask,
                                               true);
 
@@ -4309,7 +4309,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ArtifactTypeDefinition[]>;
                 res = await this.rest.get<ReleaseInterfaces.ArtifactTypeDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ArtifactTypeDefinition,
                                               true);
 
@@ -4358,7 +4358,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ArtifactVersionQueryResult>;
                 res = await this.rest.get<ReleaseInterfaces.ArtifactVersionQueryResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ArtifactVersionQueryResult,
                                               false);
 
@@ -4399,7 +4399,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ArtifactVersionQueryResult>;
                 res = await this.rest.create<ReleaseInterfaces.ArtifactVersionQueryResult>(url, artifacts, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               ReleaseInterfaces.TypeInfo.ArtifactVersionQueryResult,
                                               false);
 
@@ -4454,7 +4454,7 @@ export class ReleaseApi extends basem.ClientApiBase implements IReleaseApi {
                 let res: restm.IRestResponse<ReleaseInterfaces.ReleaseWorkItemRef[]>;
                 res = await this.rest.get<ReleaseInterfaces.ReleaseWorkItemRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 

--- a/api/SecurityRolesApi.ts
+++ b/api/SecurityRolesApi.ts
@@ -61,7 +61,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<SecurityRolesInterfaces.RoleAssignment[]>;
                 res = await this.rest.get<SecurityRolesInterfaces.RoleAssignment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     SecurityRolesInterfaces.TypeInfo.RoleAssignment,
                     true);
 
@@ -106,7 +106,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -150,7 +150,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, identityIds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     false);
 
@@ -197,7 +197,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<SecurityRolesInterfaces.RoleAssignment>;
                 res = await this.rest.replace<SecurityRolesInterfaces.RoleAssignment>(url, roleAssignment, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     SecurityRolesInterfaces.TypeInfo.RoleAssignment,
                     false);
 
@@ -241,7 +241,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<SecurityRolesInterfaces.RoleAssignment[]>;
                 res = await this.rest.replace<SecurityRolesInterfaces.RoleAssignment[]>(url, roleAssignments, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     SecurityRolesInterfaces.TypeInfo.RoleAssignment,
                     true);
 
@@ -280,7 +280,7 @@ export class SecurityRolesApi extends basem.ClientApiBase implements ISecurityRo
                 let res: restm.IRestResponse<SecurityRolesInterfaces.SecurityRole[]>;
                 res = await this.rest.get<SecurityRolesInterfaces.SecurityRole[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                     null,
                     true);
 

--- a/api/Serialization.ts
+++ b/api/Serialization.ts
@@ -81,19 +81,19 @@ export module ContractSerializer {
      * @param preserveOriginal If true, don't modify the original object. False modifies the original object (the return value points to the data argument).
      * @param unwrapWrappedCollections If true check for wrapped arrays (REST apis will not return arrays directly as the root result but will instead wrap them in a { values: [], count: 0 } object.
      */
-    export function deserialize(data: any, contractMetadata: ContractMetadata, preserveOriginal: boolean, unwrapWrappedCollections: boolean) {
+    export function deserialize<T>(data: T, contractMetadata: ContractMetadata, preserveOriginal: boolean, unwrapWrappedCollections: boolean) {
         if (data) {
-            if (unwrapWrappedCollections && Array.isArray((<IWebApiArrayResult>data).value)) {
+            if (unwrapWrappedCollections && Array.isArray((data as unknown as IWebApiArrayResult).value)) {
                 // Wrapped json array - unwrap it and send the array as the result
-                data = (<IWebApiArrayResult>data).value;
+                data = (data as unknown as IWebApiArrayResult).value as unknown as T;
             }
 
             if (contractMetadata) {
                 if (Array.isArray(data)) {
-                    data = _getTranslatedArray(data, contractMetadata, false, preserveOriginal);
+                    data = _getTranslatedArray(data, contractMetadata, false, preserveOriginal) as unknown as T;
                 }
                 else {
-                    data = _getTranslatedObject(data, contractMetadata, false, preserveOriginal);
+                    data = _getTranslatedObject(data, contractMetadata, false, preserveOriginal) as unknown as T;
                 }
             }
         }

--- a/api/TaskAgentApiBase.ts
+++ b/api/TaskAgentApiBase.ts
@@ -208,7 +208,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentCloud>(url, agentCloud, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -247,7 +247,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
                 res = await this.rest.del<TaskAgentInterfaces.TaskAgentCloud>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -286,7 +286,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloud>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -322,7 +322,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloud[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -363,7 +363,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloud>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentCloud>(url, updatedCloud, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -401,7 +401,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloudType[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloudType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentCloudType,
                                               true);
 
@@ -456,7 +456,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.TaskAgentJobRequest>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.TaskAgentJobRequest>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -500,7 +500,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               false);
 
@@ -543,7 +543,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -587,7 +587,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -647,7 +647,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgent>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -710,7 +710,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgent[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               true);
 
@@ -756,7 +756,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -802,7 +802,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgent>(url, agent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -840,7 +840,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.AzureManagementGroupQueryResult>;
                 res = await this.rest.get<TaskAgentInterfaces.AzureManagementGroupQueryResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -878,7 +878,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.AzureSubscriptionQueryResult>;
                 res = await this.rest.get<TaskAgentInterfaces.AzureSubscriptionQueryResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -922,7 +922,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -965,7 +965,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentGroup>(url, deploymentGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentGroup,
                                               false);
 
@@ -1009,7 +1009,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1063,7 +1063,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentGroup,
                                               false);
 
@@ -1126,7 +1126,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentGroup>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentGroup>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentGroup,
                                               true);
 
@@ -1172,7 +1172,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentGroup>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentGroup>(url, deploymentGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentGroup,
                                               false);
 
@@ -1226,7 +1226,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentGroupMetrics>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentGroupMetrics>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentGroupMetrics,
                                               true);
 
@@ -1281,7 +1281,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -1333,7 +1333,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -1375,7 +1375,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1416,7 +1416,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1467,7 +1467,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentPoolSummary[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentPoolSummary[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentPoolSummary,
                                               true);
 
@@ -1524,7 +1524,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -1584,7 +1584,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -1628,7 +1628,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1668,7 +1668,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.create<string[]>(url, endpoint, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1722,7 +1722,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.EnvironmentDeploymentExecutionRecord>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.EnvironmentDeploymentExecutionRecord>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.EnvironmentDeploymentExecutionRecord,
                                               true);
 
@@ -1765,7 +1765,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.EnvironmentInstance>;
                 res = await this.rest.create<TaskAgentInterfaces.EnvironmentInstance>(url, environmentCreateParameter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.EnvironmentInstance,
                                               false);
 
@@ -1809,7 +1809,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1860,7 +1860,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.EnvironmentInstance>;
                 res = await this.rest.get<TaskAgentInterfaces.EnvironmentInstance>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.EnvironmentInstance,
                                               false);
 
@@ -1914,7 +1914,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.EnvironmentInstance>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.EnvironmentInstance>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.EnvironmentInstance,
                                               true);
 
@@ -1960,7 +1960,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.EnvironmentInstance>;
                 res = await this.rest.update<TaskAgentInterfaces.EnvironmentInstance>(url, environmentUpdateParameter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.EnvironmentInstance,
                                               false);
 
@@ -2009,7 +2009,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskHubLicenseDetails>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskHubLicenseDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2050,7 +2050,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskHubLicenseDetails>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskHubLicenseDetails>(url, taskHubLicenseDetails, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2088,7 +2088,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.InputValidationRequest>;
                 res = await this.rest.create<TaskAgentInterfaces.InputValidationRequest>(url, inputValidationRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2146,7 +2146,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2195,7 +2195,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               false);
 
@@ -2247,7 +2247,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.TaskAgentJobRequest>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.TaskAgentJobRequest>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -2299,7 +2299,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -2348,7 +2348,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -2400,7 +2400,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJobRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               true);
 
@@ -2441,7 +2441,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               false);
 
@@ -2498,7 +2498,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJobRequest>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentJobRequest>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJobRequest,
                                               false);
 
@@ -2542,7 +2542,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.KubernetesResource>;
                 res = await this.rest.create<TaskAgentInterfaces.KubernetesResource>(url, createParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.KubernetesResource,
                                               false);
 
@@ -2587,7 +2587,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2632,7 +2632,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.KubernetesResource>;
                 res = await this.rest.get<TaskAgentInterfaces.KubernetesResource>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.KubernetesResource,
                                               false);
 
@@ -2674,7 +2674,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2715,7 +2715,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentMachineGroup>(url, machineGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
                                               false);
 
@@ -2757,7 +2757,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2806,7 +2806,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachineGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
                                               false);
 
@@ -2855,7 +2855,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachineGroup[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
                                               true);
 
@@ -2899,7 +2899,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachineGroup>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachineGroup>(url, machineGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachineGroup,
                                               false);
 
@@ -2948,7 +2948,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -2992,7 +2992,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, deploymentMachines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -3036,7 +3036,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -3081,7 +3081,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3133,7 +3133,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -3188,7 +3188,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -3235,7 +3235,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.replace<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -3282,7 +3282,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -3326,7 +3326,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, machines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -3367,7 +3367,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, definition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
                                               false);
 
@@ -3409,7 +3409,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3451,7 +3451,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
                                               false);
 
@@ -3490,7 +3490,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
                                               true);
 
@@ -3534,7 +3534,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgentPoolMaintenanceDefinition>(url, definition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceDefinition,
                                               false);
 
@@ -3576,7 +3576,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3618,7 +3618,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
                                               false);
 
@@ -3698,7 +3698,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
                                               true);
 
@@ -3739,7 +3739,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, job, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
                                               false);
 
@@ -3783,7 +3783,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentPoolMaintenanceJob>(url, job, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPoolMaintenanceJob,
                                               false);
 
@@ -3835,7 +3835,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3887,7 +3887,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentMessage>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentMessage>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3936,7 +3936,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3975,7 +3975,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4026,7 +4026,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, message, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4071,7 +4071,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.PackageMetadata>;
                 res = await this.rest.get<TaskAgentInterfaces.PackageMetadata>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.PackageMetadata,
                                               false);
 
@@ -4120,7 +4120,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.PackageMetadata[]>;
                 res = await this.rest.get<TaskAgentInterfaces.PackageMetadata[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.PackageMetadata,
                                               true);
 
@@ -4197,7 +4197,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, agentPoolMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4241,7 +4241,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.get<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4281,7 +4281,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentPool>(url, pool, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPool,
                                               false);
 
@@ -4322,7 +4322,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4373,7 +4373,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPool>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPool,
                                               false);
 
@@ -4427,7 +4427,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPool[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPool,
                                               true);
 
@@ -4478,7 +4478,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentPool[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPool,
                                               true);
 
@@ -4521,7 +4521,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentPool>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskAgentPool>(url, pool, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentPool,
                                               false);
 
@@ -4571,7 +4571,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentQueue>(url, queue, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               false);
 
@@ -4612,7 +4612,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4656,7 +4656,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4707,7 +4707,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               false);
 
@@ -4758,7 +4758,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               true);
 
@@ -4812,7 +4812,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               true);
 
@@ -4866,7 +4866,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               true);
 
@@ -4920,7 +4920,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentQueue[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentQueue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentQueue,
                                               true);
 
@@ -4959,7 +4959,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentCloudRequest[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentCloudRequest[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentCloudRequest,
                                               true);
 
@@ -4995,7 +4995,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.ResourceLimit[]>;
                 res = await this.rest.get<TaskAgentInterfaces.ResourceLimit[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5044,7 +5044,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.ResourceUsage>;
                 res = await this.rest.get<TaskAgentInterfaces.ResourceUsage>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.ResourceUsage,
                                               false);
 
@@ -5086,7 +5086,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroupRevision[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskGroupRevision[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroupRevision,
                                               true);
 
@@ -5130,7 +5130,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5233,7 +5233,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               false);
 
@@ -5287,7 +5287,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               true);
 
@@ -5344,7 +5344,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               true);
 
@@ -5401,7 +5401,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.get<TaskAgentInterfaces.SecureFile[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               true);
 
@@ -5451,7 +5451,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.create<TaskAgentInterfaces.SecureFile[]>(url, condition, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               true);
 
@@ -5497,7 +5497,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.update<TaskAgentInterfaces.SecureFile>(url, secureFile, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               false);
 
@@ -5540,7 +5540,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile[]>;
                 res = await this.rest.update<TaskAgentInterfaces.SecureFile[]>(url, secureFiles, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               true);
 
@@ -5602,7 +5602,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.SecureFile>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.SecureFile>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.SecureFile,
                                               false);
 
@@ -5642,7 +5642,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentSession>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskAgentSession>(url, session, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentSession,
                                               false);
 
@@ -5684,7 +5684,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5730,7 +5730,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.create<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -5777,7 +5777,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5831,7 +5831,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.get<TaskAgentInterfaces.DeploymentMachine>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -5909,7 +5909,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentMachine>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.DeploymentMachine>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -5958,7 +5958,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.replace<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -6007,7 +6007,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine>(url, machine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               false);
 
@@ -6053,7 +6053,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.DeploymentMachine[]>;
                 res = await this.rest.update<TaskAgentInterfaces.DeploymentMachine[]>(url, machines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.DeploymentMachine,
                                               true);
 
@@ -6096,7 +6096,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskGroup>(url, taskGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               false);
 
@@ -6147,7 +6147,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6204,7 +6204,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               false);
 
@@ -6314,7 +6314,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskGroup[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               true);
 
@@ -6365,7 +6365,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskGroup[]>(url, taskGroupMetadata, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               true);
 
@@ -6406,7 +6406,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskGroup[]>(url, taskGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               true);
 
@@ -6452,7 +6452,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskGroup>(url, taskGroup, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               false);
 
@@ -6503,7 +6503,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskGroup[]>;
                 res = await this.rest.update<TaskAgentInterfaces.TaskGroup[]>(url, taskGroupUpdateProperties, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskGroup,
                                               true);
 
@@ -6542,7 +6542,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6644,7 +6644,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskDefinition>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskDefinition,
                                               false);
 
@@ -6696,7 +6696,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskDefinition[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskDefinition,
                                               true);
 
@@ -6748,7 +6748,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -6792,7 +6792,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgent>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAgent>(url, userCapabilities, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgent,
                                               false);
 
@@ -6832,7 +6832,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.VariableGroup>(url, variableGroupParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VariableGroup,
                                               false);
 
@@ -6883,7 +6883,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6933,7 +6933,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, variableGroupProjectReferences, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6976,7 +6976,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.replace<TaskAgentInterfaces.VariableGroup>(url, variableGroupParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VariableGroup,
                                               false);
 
@@ -7020,7 +7020,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VariableGroup,
                                               false);
 
@@ -7080,7 +7080,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VariableGroup,
                                               true);
 
@@ -7134,7 +7134,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VariableGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.VariableGroup[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VariableGroup,
                                               true);
 
@@ -7178,7 +7178,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VirtualMachineGroup>;
                 res = await this.rest.create<TaskAgentInterfaces.VirtualMachineGroup>(url, createParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VirtualMachineGroup,
                                               false);
 
@@ -7223,7 +7223,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -7268,7 +7268,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VirtualMachineGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.VirtualMachineGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VirtualMachineGroup,
                                               false);
 
@@ -7312,7 +7312,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VirtualMachineGroup>;
                 res = await this.rest.update<TaskAgentInterfaces.VirtualMachineGroup>(url, resource, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VirtualMachineGroup,
                                               false);
 
@@ -7376,7 +7376,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TaskAgentInterfaces.VirtualMachine>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TaskAgentInterfaces.VirtualMachine>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VirtualMachine,
                                               true);
 
@@ -7423,7 +7423,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<TaskAgentInterfaces.VirtualMachine[]>;
                 res = await this.rest.update<TaskAgentInterfaces.VirtualMachine[]>(url, machines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.VirtualMachine,
                                               true);
 
@@ -7484,7 +7484,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.create<string>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -7520,7 +7520,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -7565,7 +7565,7 @@ export class TaskAgentApiBase extends basem.ClientApiBase implements ITaskAgentA
                 let res: restm.IRestResponse<any>;
                 res = await this.rest.get<any>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/TaskApi.ts
+++ b/api/TaskApi.ts
@@ -85,7 +85,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAttachment,
                                               true);
 
@@ -150,7 +150,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskAttachment>("PUT", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAttachment,
                                               false);
 
@@ -222,7 +222,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.replace<TaskAgentInterfaces.TaskAttachment>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAttachment,
                                               false);
 
@@ -279,7 +279,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAttachment,
                                               false);
 
@@ -382,7 +382,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAttachment[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAttachment,
                                               true);
 
@@ -437,7 +437,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, lines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -507,7 +507,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper>;
                 res = await this.rest.get<TaskAgentInterfaces.TimelineRecordFeedLinesWrapper>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -552,7 +552,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskAgentJob>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskAgentJob>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskAgentJob,
                                               false);
 
@@ -610,7 +610,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.uploadStream<TaskAgentInterfaces.TaskLog>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskLog,
                                               false);
 
@@ -673,7 +673,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskLog>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskLog,
                                               false);
 
@@ -722,7 +722,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskLog>(url, log, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskLog,
                                               false);
 
@@ -780,7 +780,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<string[]>;
                 res = await this.rest.get<string[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -825,7 +825,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskLog[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskLog[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskLog,
                                               true);
 
@@ -867,7 +867,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlanGroupsQueueMetrics[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlanGroupsQueueMetrics,
                                               true);
 
@@ -924,7 +924,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskHubOidcToken>;
                 res = await this.rest.create<TaskAgentInterfaces.TaskHubOidcToken>(url, claims, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -976,7 +976,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
                                               true);
 
@@ -1021,7 +1021,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationQueuedPlanGroup>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskOrchestrationQueuedPlanGroup,
                                               false);
 
@@ -1066,7 +1066,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TaskOrchestrationPlan>;
                 res = await this.rest.get<TaskAgentInterfaces.TaskOrchestrationPlan>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TaskOrchestrationPlan,
                                               false);
 
@@ -1121,7 +1121,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.get<TaskAgentInterfaces.TimelineRecord[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TimelineRecord,
                                               true);
 
@@ -1173,7 +1173,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.TimelineRecord[]>;
                 res = await this.rest.update<TaskAgentInterfaces.TimelineRecord[]>(url, records, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.TimelineRecord,
                                               true);
 
@@ -1220,7 +1220,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.create<TaskAgentInterfaces.Timeline>(url, timeline, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.Timeline,
                                               false);
 
@@ -1268,7 +1268,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1326,7 +1326,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.Timeline,
                                               false);
 
@@ -1371,7 +1371,7 @@ export class TaskApi extends basem.ClientApiBase implements ITaskApi {
                 let res: restm.IRestResponse<TaskAgentInterfaces.Timeline[]>;
                 res = await this.rest.get<TaskAgentInterfaces.Timeline[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TaskAgentInterfaces.TypeInfo.Timeline,
                                               true);
 

--- a/api/TestApi.ts
+++ b/api/TestApi.ts
@@ -153,7 +153,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachmentReference>;
                 res = await this.rest.create<TestInterfaces.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -202,7 +202,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachmentReference>;
                 res = await this.rest.create<TestInterfaces.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -261,7 +261,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachmentReference>;
                 res = await this.rest.create<TestInterfaces.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -350,7 +350,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachment[]>;
                 res = await this.rest.get<TestInterfaces.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestAttachment,
                                               true);
 
@@ -501,7 +501,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachment[]>;
                 res = await this.rest.get<TestInterfaces.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestAttachment,
                                               true);
 
@@ -599,7 +599,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachmentReference>;
                 res = await this.rest.create<TestInterfaces.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -682,7 +682,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestAttachment[]>;
                 res = await this.rest.get<TestInterfaces.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestAttachment,
                                               true);
 
@@ -766,7 +766,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.WorkItemReference[]>;
                 res = await this.rest.get<TestInterfaces.WorkItemReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -823,7 +823,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.BuildCoverage[]>;
                 res = await this.rest.get<TestInterfaces.BuildCoverage[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.BuildCoverage,
                                               true);
 
@@ -877,7 +877,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.CodeCoverageSummary>;
                 res = await this.rest.get<TestInterfaces.CodeCoverageSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.CodeCoverageSummary,
                                               false);
 
@@ -930,7 +930,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, coverageData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -984,7 +984,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRunCoverage[]>;
                 res = await this.rest.get<TestInterfaces.TestRunCoverage[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1025,7 +1025,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.CustomTestFieldDefinition[]>;
                 res = await this.rest.create<TestInterfaces.CustomTestFieldDefinition[]>(url, newFields, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.CustomTestFieldDefinition,
                                               true);
 
@@ -1074,7 +1074,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.CustomTestFieldDefinition[]>;
                 res = await this.rest.get<TestInterfaces.CustomTestFieldDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.CustomTestFieldDefinition,
                                               true);
 
@@ -1115,7 +1115,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultHistory>;
                 res = await this.rest.create<TestInterfaces.TestResultHistory>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultHistory,
                                               false);
 
@@ -1172,7 +1172,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestIterationDetailsModel>;
                 res = await this.rest.get<TestInterfaces.TestIterationDetailsModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestIterationDetailsModel,
                                               false);
 
@@ -1226,7 +1226,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestIterationDetailsModel[]>;
                 res = await this.rest.get<TestInterfaces.TestIterationDetailsModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestIterationDetailsModel,
                                               true);
 
@@ -1267,7 +1267,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.LinkedWorkItemsQueryResult[]>;
                 res = await this.rest.create<TestInterfaces.LinkedWorkItemsQueryResult[]>(url, workItemQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1311,7 +1311,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestMessageLogDetails[]>;
                 res = await this.rest.get<TestInterfaces.TestMessageLogDetails[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestMessageLogDetails,
                                               true);
 
@@ -1368,7 +1368,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestPoint>;
                 res = await this.rest.get<TestInterfaces.TestPoint>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestPoint,
                                               false);
 
@@ -1440,7 +1440,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestPoint[]>;
                 res = await this.rest.get<TestInterfaces.TestPoint[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestPoint,
                                               true);
 
@@ -1492,7 +1492,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestPoint[]>;
                 res = await this.rest.update<TestInterfaces.TestPoint[]>(url, pointUpdateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestPoint,
                                               true);
 
@@ -1545,7 +1545,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestPointsQuery>;
                 res = await this.rest.create<TestInterfaces.TestPointsQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestPointsQuery,
                                               false);
 
@@ -1612,7 +1612,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultsDetails>;
                 res = await this.rest.get<TestInterfaces.TestResultsDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultsDetails,
                                               false);
 
@@ -1685,7 +1685,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultsDetails>;
                 res = await this.rest.get<TestInterfaces.TestResultsDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultsDetails,
                                               false);
 
@@ -1729,7 +1729,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultDocument>;
                 res = await this.rest.create<TestInterfaces.TestResultDocument>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1790,7 +1790,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestInterfaces.FieldDetailsForTestResults>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestInterfaces.FieldDetailsForTestResults>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1854,7 +1854,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestInterfaces.FieldDetailsForTestResults>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestInterfaces.FieldDetailsForTestResults>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1897,7 +1897,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultMetaData[]>;
                 res = await this.rest.create<TestInterfaces.TestResultMetaData[]>(url, testReferenceIds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1938,7 +1938,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.ResultRetentionSettings>;
                 res = await this.rest.get<TestInterfaces.ResultRetentionSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.ResultRetentionSettings,
                                               false);
 
@@ -1981,7 +1981,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.ResultRetentionSettings>;
                 res = await this.rest.update<TestInterfaces.ResultRetentionSettings>(url, retentionSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.ResultRetentionSettings,
                                               false);
 
@@ -2027,7 +2027,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestCaseResult[]>;
                 res = await this.rest.create<TestInterfaces.TestCaseResult[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2081,7 +2081,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestCaseResult>;
                 res = await this.rest.get<TestInterfaces.TestCaseResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestCaseResult,
                                               false);
 
@@ -2141,7 +2141,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestCaseResult[]>;
                 res = await this.rest.get<TestInterfaces.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2187,7 +2187,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestCaseResult[]>;
                 res = await this.rest.update<TestInterfaces.TestCaseResult[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2230,7 +2230,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultsQuery>;
                 res = await this.rest.create<TestInterfaces.TestResultsQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultsQuery,
                                               false);
 
@@ -2291,7 +2291,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestInterfaces.ShallowTestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestInterfaces.ShallowTestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2355,7 +2355,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestInterfaces.ShallowTestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestInterfaces.ShallowTestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2413,7 +2413,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultSummary>;
                 res = await this.rest.get<TestInterfaces.TestResultSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultSummary,
                                               false);
 
@@ -2477,7 +2477,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultSummary>;
                 res = await this.rest.get<TestInterfaces.TestResultSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultSummary,
                                               false);
 
@@ -2518,7 +2518,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestResultSummary[]>;
                 res = await this.rest.create<TestInterfaces.TestResultSummary[]>(url, releases, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestResultSummary,
                                               true);
 
@@ -2566,7 +2566,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestSummaryForWorkItem[]>;
                 res = await this.rest.create<TestInterfaces.TestSummaryForWorkItem[]>(url, resultsContext, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestSummaryForWorkItem,
                                               true);
 
@@ -2607,7 +2607,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.AggregatedDataForResultTrend[]>;
                 res = await this.rest.create<TestInterfaces.AggregatedDataForResultTrend[]>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.AggregatedDataForResultTrend,
                                               true);
 
@@ -2648,7 +2648,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.AggregatedDataForResultTrend[]>;
                 res = await this.rest.create<TestInterfaces.AggregatedDataForResultTrend[]>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.AggregatedDataForResultTrend,
                                               true);
 
@@ -2692,7 +2692,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRunStatistic>;
                 res = await this.rest.get<TestInterfaces.TestRunStatistic>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRunStatistic,
                                               false);
 
@@ -2735,7 +2735,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRun>;
                 res = await this.rest.create<TestInterfaces.TestRun>(url, testRun, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRun,
                                               false);
 
@@ -2779,7 +2779,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2830,7 +2830,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRun>;
                 res = await this.rest.get<TestInterfaces.TestRun>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRun,
                                               false);
 
@@ -2899,7 +2899,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRun[]>;
                 res = await this.rest.get<TestInterfaces.TestRun[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRun,
                                               true);
 
@@ -2998,7 +2998,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestInterfaces.TestRun>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestInterfaces.TestRun>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRun,
                                               true);
 
@@ -3044,7 +3044,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestRun>;
                 res = await this.rest.update<TestInterfaces.TestRun>(url, runUpdateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestRun,
                                               false);
 
@@ -3095,7 +3095,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestSession>;
                 res = await this.rest.create<TestInterfaces.TestSession>(url, testSession, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestSession,
                                               false);
 
@@ -3163,7 +3163,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestSession[]>;
                 res = await this.rest.get<TestInterfaces.TestSession[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestSession,
                                               true);
 
@@ -3214,7 +3214,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestSession>;
                 res = await this.rest.update<TestInterfaces.TestSession>(url, testSession, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestSession,
                                               false);
 
@@ -3256,7 +3256,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3298,7 +3298,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3349,7 +3349,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.SuiteTestCase[]>;
                 res = await this.rest.create<TestInterfaces.SuiteTestCase[]>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3400,7 +3400,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.SuiteTestCase>;
                 res = await this.rest.get<TestInterfaces.SuiteTestCase>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3448,7 +3448,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.SuiteTestCase[]>;
                 res = await this.rest.get<TestInterfaces.SuiteTestCase[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3499,7 +3499,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3552,7 +3552,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.SuiteTestCase[]>;
                 res = await this.rest.update<TestInterfaces.SuiteTestCase[]>(url, suiteTestCaseUpdateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3596,7 +3596,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3639,7 +3639,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestHistoryQuery>;
                 res = await this.rest.create<TestInterfaces.TestHistoryQuery>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestHistoryQuery,
                                               false);
 
@@ -3680,7 +3680,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.create<number>(url, testSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3722,7 +3722,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3764,7 +3764,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestSettings>;
                 res = await this.rest.get<TestInterfaces.TestSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3805,7 +3805,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.WorkItemToTestLinks>;
                 res = await this.rest.create<TestInterfaces.WorkItemToTestLinks>(url, workItemToTestLinks, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.WorkItemToTestLinks,
                                               false);
 
@@ -3860,7 +3860,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.del<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3909,7 +3909,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.TestToWorkItemLinks>;
                 res = await this.rest.create<TestInterfaces.TestToWorkItemLinks>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestInterfaces.TypeInfo.TestToWorkItemLinks,
                                               false);
 
@@ -3973,7 +3973,7 @@ export class TestApi extends basem.ClientApiBase implements ITestApi {
                 let res: restm.IRestResponse<TestInterfaces.WorkItemReference[]>;
                 res = await this.rest.get<TestInterfaces.WorkItemReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 

--- a/api/TestPlanApi.ts
+++ b/api/TestPlanApi.ts
@@ -102,7 +102,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
                 res = await this.rest.create<TestPlanInterfaces.TestConfiguration>(url, testConfigurationCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestConfiguration,
                                               false);
 
@@ -153,7 +153,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -197,7 +197,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
                 res = await this.rest.get<TestPlanInterfaces.TestConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestConfiguration,
                                               false);
 
@@ -245,7 +245,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestConfiguration>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestConfiguration,
                                               true);
 
@@ -298,7 +298,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestConfiguration>;
                 res = await this.rest.update<TestPlanInterfaces.TestConfiguration>(url, testConfigurationCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestConfiguration,
                                               false);
 
@@ -362,7 +362,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestEntityCount[]>;
                 res = await this.rest.get<TestPlanInterfaces.TestEntityCount[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -405,7 +405,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
                 res = await this.rest.create<TestPlanInterfaces.TestPlan>(url, testPlanCreateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPlan,
                                               false);
 
@@ -449,7 +449,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -493,7 +493,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
                 res = await this.rest.get<TestPlanInterfaces.TestPlan>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPlan,
                                               false);
 
@@ -550,7 +550,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPlan,
                                               true);
 
@@ -596,7 +596,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestPlan>;
                 res = await this.rest.update<TestPlanInterfaces.TestPlan>(url, testPlanUpdateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPlan,
                                               false);
 
@@ -647,7 +647,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.SuiteEntry[]>;
                 res = await this.rest.get<TestPlanInterfaces.SuiteEntry[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.SuiteEntry,
                                               true);
 
@@ -693,7 +693,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.SuiteEntry[]>;
                 res = await this.rest.update<TestPlanInterfaces.SuiteEntry[]>(url, suiteEntries, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.SuiteEntry,
                                               true);
 
@@ -742,7 +742,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestSuite[]>;
                 res = await this.rest.create<TestPlanInterfaces.TestSuite[]>(url, testSuiteCreateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               true);
 
@@ -788,7 +788,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
                 res = await this.rest.create<TestPlanInterfaces.TestSuite>(url, testSuiteCreateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               false);
 
@@ -835,7 +835,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -889,7 +889,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
                 res = await this.rest.get<TestPlanInterfaces.TestSuite>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               false);
 
@@ -946,7 +946,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               true);
 
@@ -995,7 +995,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestSuite>;
                 res = await this.rest.update<TestPlanInterfaces.TestSuite>(url, testSuiteUpdateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               false);
 
@@ -1043,7 +1043,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestSuite[]>;
                 res = await this.rest.get<TestPlanInterfaces.TestSuite[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               true);
 
@@ -1092,7 +1092,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
                 res = await this.rest.create<TestPlanInterfaces.TestCase[]>(url, suiteTestCaseCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestCase,
                                               true);
 
@@ -1152,7 +1152,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
                 res = await this.rest.get<TestPlanInterfaces.TestCase[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestCase,
                                               true);
 
@@ -1227,7 +1227,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestCase>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestCase,
                                               true);
 
@@ -1284,7 +1284,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1341,7 +1341,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1390,7 +1390,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestCase[]>;
                 res = await this.rest.update<TestPlanInterfaces.TestCase[]>(url, suiteTestCaseCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestCase,
                                               true);
 
@@ -1431,7 +1431,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestCaseOperationInformation>;
                 res = await this.rest.create<TestPlanInterfaces.CloneTestCaseOperationInformation>(url, cloneRequestBody, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestCaseOperationInformation,
                                               false);
 
@@ -1475,7 +1475,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestCaseOperationInformation>;
                 res = await this.rest.get<TestPlanInterfaces.CloneTestCaseOperationInformation>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestCaseOperationInformation,
                                               false);
 
@@ -1554,7 +1554,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1602,7 +1602,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestPlan>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPlan,
                                               true);
 
@@ -1648,7 +1648,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, restoreModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1698,7 +1698,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestPlanOperationInformation>;
                 res = await this.rest.create<TestPlanInterfaces.CloneTestPlanOperationInformation>(url, cloneRequestBody, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestPlanOperationInformation,
                                               false);
 
@@ -1742,7 +1742,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestPlanOperationInformation>;
                 res = await this.rest.get<TestPlanInterfaces.CloneTestPlanOperationInformation>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestPlanOperationInformation,
                                               false);
 
@@ -1805,7 +1805,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestPoint[]>;
                 res = await this.rest.get<TestPlanInterfaces.TestPoint[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPoint,
                                               true);
 
@@ -1874,7 +1874,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestPoint>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPoint,
                                               true);
 
@@ -1933,7 +1933,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestPoint[]>;
                 res = await this.rest.update<TestPlanInterfaces.TestPoint[]>(url, testPointUpdateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestPoint,
                                               true);
 
@@ -1990,7 +1990,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               true);
 
@@ -2044,7 +2044,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestSuite>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestSuite,
                                               true);
 
@@ -2090,7 +2090,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, payload, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2140,7 +2140,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
                 res = await this.rest.create<TestPlanInterfaces.CloneTestSuiteOperationInformation>(url, cloneRequestBody, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestSuiteOperationInformation,
                                               false);
 
@@ -2184,7 +2184,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.CloneTestSuiteOperationInformation>;
                 res = await this.rest.get<TestPlanInterfaces.CloneTestSuiteOperationInformation>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.CloneTestSuiteOperationInformation,
                                               false);
 
@@ -2227,7 +2227,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
                 res = await this.rest.create<TestPlanInterfaces.TestVariable>(url, testVariableCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestVariable,
                                               false);
 
@@ -2271,7 +2271,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2315,7 +2315,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
                 res = await this.rest.get<TestPlanInterfaces.TestVariable>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestVariable,
                                               false);
 
@@ -2363,7 +2363,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TestPlanInterfaces.TestVariable>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestVariable,
                                               true);
 
@@ -2409,7 +2409,7 @@ export class TestPlanApi extends basem.ClientApiBase implements ITestPlanApi {
                 let res: restm.IRestResponse<TestPlanInterfaces.TestVariable>;
                 res = await this.rest.update<TestPlanInterfaces.TestVariable>(url, testVariableCreateUpdateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TestPlanInterfaces.TypeInfo.TestVariable,
                                               false);
 

--- a/api/TestResultsApi.ts
+++ b/api/TestResultsApi.ts
@@ -195,7 +195,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachmentReference>;
                 res = await this.rest.create<Contracts.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -242,7 +242,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachmentReference>;
                 res = await this.rest.create<Contracts.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -299,7 +299,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachmentReference>;
                 res = await this.rest.create<Contracts.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -347,7 +347,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -538,7 +538,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachment[]>;
                 res = await this.rest.get<Contracts.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestAttachment,
                                               true);
 
@@ -689,7 +689,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachment[]>;
                 res = await this.rest.get<Contracts.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestAttachment,
                                               true);
 
@@ -785,7 +785,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachmentReference>;
                 res = await this.rest.create<Contracts.TestAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -830,7 +830,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -911,7 +911,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestAttachment[]>;
                 res = await this.rest.get<Contracts.TestAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestAttachment,
                                               true);
 
@@ -995,7 +995,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.WorkItemReference[]>;
                 res = await this.rest.get<Contracts.WorkItemReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1044,7 +1044,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.SourceViewBuildCoverage[]>;
                 res = await this.rest.get<Contracts.SourceViewBuildCoverage[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.SourceViewBuildCoverage,
                                               true);
 
@@ -1099,7 +1099,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.BuildCoverage[]>;
                 res = await this.rest.get<Contracts.BuildCoverage[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.BuildCoverage,
                                               true);
 
@@ -1153,7 +1153,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.CodeCoverageSummary>;
                 res = await this.rest.get<Contracts.CodeCoverageSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.CodeCoverageSummary,
                                               false);
 
@@ -1206,7 +1206,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, coverageData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1258,7 +1258,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRunCoverage[]>;
                 res = await this.rest.get<Contracts.TestRunCoverage[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1301,7 +1301,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.CustomTestFieldDefinition[]>;
                 res = await this.rest.create<Contracts.CustomTestFieldDefinition[]>(url, newFields, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.CustomTestFieldDefinition,
                                               true);
 
@@ -1352,7 +1352,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.CustomTestFieldDefinition[]>;
                 res = await this.rest.get<Contracts.CustomTestFieldDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.CustomTestFieldDefinition,
                                               true);
 
@@ -1396,7 +1396,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1439,7 +1439,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.CustomTestFieldDefinition>;
                 res = await this.rest.update<Contracts.CustomTestFieldDefinition>(url, updateCustomTestField, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.CustomTestFieldDefinition,
                                               false);
 
@@ -1529,7 +1529,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.get<Contracts.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -1571,7 +1571,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.get<Contracts.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -1612,7 +1612,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultHistory>;
                 res = await this.rest.create<Contracts.TestResultHistory>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultHistory,
                                               false);
 
@@ -1656,7 +1656,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestMessageLogDetails[]>;
                 res = await this.rest.get<Contracts.TestMessageLogDetails[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestMessageLogDetails,
                                               true);
 
@@ -1722,7 +1722,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.PipelineTestMetrics>;
                 res = await this.rest.get<Contracts.PipelineTestMetrics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.PipelineTestMetrics,
                                               false);
 
@@ -1789,7 +1789,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsDetails>;
                 res = await this.rest.get<Contracts.TestResultsDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsDetails,
                                               false);
 
@@ -1862,7 +1862,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsDetails>;
                 res = await this.rest.get<Contracts.TestResultsDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsDetails,
                                               false);
 
@@ -1906,7 +1906,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultDocument>;
                 res = await this.rest.create<Contracts.TestResultDocument>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1967,7 +1967,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.FieldDetailsForTestResults>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.FieldDetailsForTestResults>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2031,7 +2031,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.FieldDetailsForTestResults>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.FieldDetailsForTestResults>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2081,7 +2081,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultMetaData[]>;
                 res = await this.rest.create<Contracts.TestResultMetaData[]>(url, testCaseReferenceIds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2127,7 +2127,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultMetaData>;
                 res = await this.rest.update<Contracts.TestResultMetaData>(url, testResultMetaDataUpdateInput, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2168,7 +2168,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsQuery>;
                 res = await this.rest.create<Contracts.TestResultsQuery>(url, query, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsQuery,
                                               false);
 
@@ -2225,7 +2225,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.create<Contracts.TestCaseResult[]>(url, queryModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2269,7 +2269,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.create<Contracts.TestCaseResult[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2321,7 +2321,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult>;
                 res = await this.rest.get<Contracts.TestCaseResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               false);
 
@@ -2382,7 +2382,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.get<Contracts.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2426,7 +2426,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.update<Contracts.TestCaseResult[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -2487,7 +2487,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2563,7 +2563,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2627,7 +2627,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.ShallowTestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2693,7 +2693,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsDetails>;
                 res = await this.rest.get<Contracts.TestResultsDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsDetails,
                                               false);
 
@@ -2751,7 +2751,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultSummary>;
                 res = await this.rest.get<Contracts.TestResultSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultSummary,
                                               false);
 
@@ -2814,7 +2814,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultSummary>;
                 res = await this.rest.get<Contracts.TestResultSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultSummary,
                                               false);
 
@@ -2878,7 +2878,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultSummary>;
                 res = await this.rest.get<Contracts.TestResultSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultSummary,
                                               false);
 
@@ -2919,7 +2919,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultSummary[]>;
                 res = await this.rest.create<Contracts.TestResultSummary[]>(url, releases, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultSummary,
                                               true);
 
@@ -2967,7 +2967,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestSummaryForWorkItem[]>;
                 res = await this.rest.create<Contracts.TestSummaryForWorkItem[]>(url, resultsContext, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestSummaryForWorkItem,
                                               true);
 
@@ -3008,7 +3008,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.AggregatedDataForResultTrend[]>;
                 res = await this.rest.create<Contracts.AggregatedDataForResultTrend[]>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.AggregatedDataForResultTrend,
                                               true);
 
@@ -3049,7 +3049,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.AggregatedDataForResultTrend[]>;
                 res = await this.rest.create<Contracts.AggregatedDataForResultTrend[]>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.AggregatedDataForResultTrend,
                                               true);
 
@@ -3090,7 +3090,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRun>;
                 res = await this.rest.create<Contracts.TestRun>(url, testRun, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRun,
                                               false);
 
@@ -3132,7 +3132,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3184,7 +3184,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRun>;
                 res = await this.rest.get<Contracts.TestRun>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRun,
                                               false);
 
@@ -3251,7 +3251,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRun[]>;
                 res = await this.rest.get<Contracts.TestRun[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRun,
                                               true);
 
@@ -3350,7 +3350,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestRun>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestRun>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRun,
                                               true);
 
@@ -3394,7 +3394,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRun>;
                 res = await this.rest.update<Contracts.TestRun>(url, runUpdateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRun,
                                               false);
 
@@ -3438,7 +3438,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRunStatistic>;
                 res = await this.rest.get<Contracts.TestRunStatistic>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRunStatistic,
                                               false);
 
@@ -3486,7 +3486,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsSettings>;
                 res = await this.rest.get<Contracts.TestResultsSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsSettings,
                                               false);
 
@@ -3529,7 +3529,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsSettings>;
                 res = await this.rest.update<Contracts.TestResultsSettings>(url, testResultsUpdateSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsSettings,
                                               false);
 
@@ -3596,7 +3596,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.get<Contracts.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -3640,7 +3640,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestRunStatistic>;
                 res = await this.rest.get<Contracts.TestRunStatistic>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestRunStatistic,
                                               false);
 
@@ -3694,7 +3694,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3745,7 +3745,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestTag[]>;
                 res = await this.rest.get<Contracts.TestTag[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3802,7 +3802,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestTag[]>;
                 res = await this.rest.get<Contracts.TestTag[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3848,7 +3848,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestTag[]>;
                 res = await this.rest.update<Contracts.TestTag[]>(url, testTagsUpdateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3899,7 +3899,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestTagSummary>;
                 res = await this.rest.get<Contracts.TestTagSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3956,7 +3956,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestTagSummary>;
                 res = await this.rest.get<Contracts.TestTagSummary>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4002,7 +4002,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4048,7 +4048,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreAttachmentReference>;
                 res = await this.rest.create<Contracts.TestLogStoreAttachmentReference>(url, attachmentRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4102,7 +4102,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4192,7 +4192,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreAttachment[]>;
                 res = await this.rest.get<Contracts.TestLogStoreAttachment[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreAttachment,
                                               true);
 
@@ -4281,7 +4281,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultFailureType>;
                 res = await this.rest.create<Contracts.TestResultFailureType>(url, testResultFailureType, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4325,7 +4325,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4366,7 +4366,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultFailureType[]>;
                 res = await this.rest.get<Contracts.TestResultFailureType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4409,7 +4409,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestHistoryQuery>;
                 res = await this.rest.create<Contracts.TestHistoryQuery>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestHistoryQuery,
                                               false);
 
@@ -4485,7 +4485,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestLog>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestLog>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLog,
                                               true);
 
@@ -4561,7 +4561,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestLog>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestLog>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLog,
                                               true);
 
@@ -4643,7 +4643,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestLog>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestLog>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLog,
                                               true);
 
@@ -4716,7 +4716,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestLog>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestLog>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLog,
                                               true);
 
@@ -4779,7 +4779,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.get<Contracts.TestLogStoreEndpointDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -4836,7 +4836,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.create<Contracts.TestLogStoreEndpointDetails>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -4899,7 +4899,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.get<Contracts.TestLogStoreEndpointDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -4968,7 +4968,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.get<Contracts.TestLogStoreEndpointDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -5037,7 +5037,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.create<Contracts.TestLogStoreEndpointDetails>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -5097,7 +5097,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.get<Contracts.TestLogStoreEndpointDetails>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -5157,7 +5157,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestLogStoreEndpointDetails>;
                 res = await this.rest.create<Contracts.TestLogStoreEndpointDetails>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestLogStoreEndpointDetails,
                                               false);
 
@@ -5200,7 +5200,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.create<number>(url, session, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5251,7 +5251,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultsSession[]>;
                 res = await this.rest.get<Contracts.TestResultsSession[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestResultsSession,
                                               true);
 
@@ -5295,7 +5295,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<any[]>;
                 res = await this.rest.get<any[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5341,7 +5341,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.update<number>(url, session, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5387,7 +5387,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.AnalysisFailureGroupReturn[]>;
                 res = await this.rest.create<Contracts.AnalysisFailureGroupReturn[]>(url, analysis, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5430,7 +5430,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, environments, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5476,7 +5476,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, sessionEnvironmentAndMachine, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5520,7 +5520,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<any[]>;
                 res = await this.rest.get<any[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5566,7 +5566,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number[]>;
                 res = await this.rest.create<number[]>(url, notifications, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5610,7 +5610,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestSessionNotification[]>;
                 res = await this.rest.get<Contracts.TestSessionNotification[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5656,7 +5656,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.create<Contracts.TestCaseResult[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -5717,7 +5717,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestCaseResult[]>;
                 res = await this.rest.get<Contracts.TestCaseResult[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -5763,7 +5763,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number[]>;
                 res = await this.rest.update<number[]>(url, results, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5809,7 +5809,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, testResultMachines, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -5853,7 +5853,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestResultMachine[]>;
                 res = await this.rest.get<Contracts.TestResultMachine[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -5929,7 +5929,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<Contracts.TestCaseResult>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<Contracts.TestCaseResult>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestCaseResult,
                                               true);
 
@@ -5973,7 +5973,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number[]>;
                 res = await this.rest.get<number[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -6019,7 +6019,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number[]>;
                 res = await this.rest.update<number[]>(url, testRunIds, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -6060,7 +6060,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<number>;
                 res = await this.rest.create<number>(url, testSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6109,7 +6109,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6158,7 +6158,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestSettings>;
                 res = await this.rest.get<Contracts.TestSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6199,7 +6199,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.WorkItemToTestLinks>;
                 res = await this.rest.create<Contracts.WorkItemToTestLinks>(url, workItemToTestLinks, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.WorkItemToTestLinks,
                                               false);
 
@@ -6254,7 +6254,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<boolean>;
                 res = await this.rest.del<boolean>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -6303,7 +6303,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.TestToWorkItemLinks>;
                 res = await this.rest.create<Contracts.TestToWorkItemLinks>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Contracts.TypeInfo.TestToWorkItemLinks,
                                               false);
 
@@ -6348,7 +6348,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.WorkItemReference[]>;
                 res = await this.rest.get<Contracts.WorkItemReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -6414,7 +6414,7 @@ export class TestResultsApi extends basem.ClientApiBase implements ITestResultsA
                 let res: restm.IRestResponse<Contracts.WorkItemReference[]>;
                 res = await this.rest.get<Contracts.WorkItemReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 

--- a/api/TfvcApi.ts
+++ b/api/TfvcApi.ts
@@ -95,7 +95,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcBranch>;
                 res = await this.rest.get<TfvcInterfaces.TfvcBranch>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcBranch,
                                               false);
 
@@ -152,7 +152,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcBranch[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcBranch[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcBranch,
                                               true);
 
@@ -209,7 +209,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcBranchRef[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcBranchRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcBranchRef,
                                               true);
 
@@ -260,7 +260,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<TfvcInterfaces.TfvcChange>>;
                 res = await this.rest.get<VSSInterfaces.PagedList<TfvcInterfaces.TfvcChange>>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChange,
                                               true);
 
@@ -303,7 +303,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcChangesetRef>;
                 res = await this.rest.create<TfvcInterfaces.TfvcChangesetRef>(url, changeset, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChangesetRef,
                                               false);
 
@@ -378,7 +378,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcChangeset>;
                 res = await this.rest.get<TfvcInterfaces.TfvcChangeset>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChangeset,
                                               false);
 
@@ -438,7 +438,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcChangesetRef[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcChangesetRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChangesetRef,
                                               true);
 
@@ -478,7 +478,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcChangesetRef[]>;
                 res = await this.rest.create<TfvcInterfaces.TfvcChangesetRef[]>(url, changesetsRequestData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChangesetRef,
                                               true);
 
@@ -519,7 +519,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.AssociatedWorkItem[]>;
                 res = await this.rest.get<TfvcInterfaces.AssociatedWorkItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -562,7 +562,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcItem[][]>;
                 res = await this.rest.create<TfvcInterfaces.TfvcItem[][]>(url, itemRequestData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcItem,
                                               true);
 
@@ -666,7 +666,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcItem>;
                 res = await this.rest.get<TfvcInterfaces.TfvcItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcItem,
                                               false);
 
@@ -784,7 +784,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcItem[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcItem,
                                               true);
 
@@ -957,7 +957,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcItem[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcItem,
                                               true);
 
@@ -1011,7 +1011,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcLabel>;
                 res = await this.rest.get<TfvcInterfaces.TfvcLabel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcLabel,
                                               false);
 
@@ -1068,7 +1068,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcLabelRef[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcLabelRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcLabelRef,
                                               true);
 
@@ -1122,7 +1122,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcChange[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcChange[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcChange,
                                               true);
 
@@ -1173,7 +1173,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcShelveset>;
                 res = await this.rest.get<TfvcInterfaces.TfvcShelveset>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcShelveset,
                                               false);
 
@@ -1224,7 +1224,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcShelvesetRef[]>;
                 res = await this.rest.get<TfvcInterfaces.TfvcShelvesetRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               TfvcInterfaces.TypeInfo.TfvcShelvesetRef,
                                               true);
 
@@ -1272,7 +1272,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.AssociatedWorkItem[]>;
                 res = await this.rest.get<TfvcInterfaces.AssociatedWorkItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1320,7 +1320,7 @@ export class TfvcApi extends basem.ClientApiBase implements ITfvcApi {
                 let res: restm.IRestResponse<TfvcInterfaces.TfvcStatistics>;
                 res = await this.rest.get<TfvcInterfaces.TfvcStatistics>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/WikiApi.ts
+++ b/api/WikiApi.ts
@@ -93,7 +93,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.CommentAttachment>;
                 res = await this.rest.uploadStream<Comments_Contracts.CommentAttachment>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.CommentAttachment,
                                               false);
 
@@ -187,7 +187,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.CommentReaction>;
                 res = await this.rest.replace<Comments_Contracts.CommentReaction>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.CommentReaction,
                                               false);
 
@@ -240,7 +240,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.CommentReaction>;
                 res = await this.rest.del<Comments_Contracts.CommentReaction>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.CommentReaction,
                                               false);
 
@@ -303,7 +303,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
                 res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -352,7 +352,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.Comment>;
                 res = await this.rest.create<Comments_Contracts.Comment>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.Comment,
                                               false);
 
@@ -402,7 +402,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -462,7 +462,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.Comment>;
                 res = await this.rest.get<Comments_Contracts.Comment>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.Comment,
                                               false);
 
@@ -531,7 +531,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.CommentList>;
                 res = await this.rest.get<Comments_Contracts.CommentList>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.CommentList,
                                               false);
 
@@ -583,7 +583,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<Comments_Contracts.Comment>;
                 res = await this.rest.update<Comments_Contracts.Comment>(url, comment, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               Comments_Contracts.TypeInfo.Comment,
                                               false);
 
@@ -838,7 +838,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<VSSInterfaces.PagedList<WikiInterfaces.WikiPageDetail>>;
                 res = await this.rest.create<VSSInterfaces.PagedList<WikiInterfaces.WikiPageDetail>>(url, pagesBatchRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiPageDetail,
                                               true);
 
@@ -892,7 +892,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiPageDetail>;
                 res = await this.rest.get<WikiInterfaces.WikiPageDetail>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiPageDetail,
                                               false);
 
@@ -955,7 +955,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiPageViewStats>;
                 res = await this.rest.create<WikiInterfaces.WikiPageViewStats>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiPageViewStats,
                                               false);
 
@@ -998,7 +998,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiV2>;
                 res = await this.rest.create<WikiInterfaces.WikiV2>(url, wikiCreateParams, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiV2,
                                               false);
 
@@ -1042,7 +1042,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiV2>;
                 res = await this.rest.del<WikiInterfaces.WikiV2>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiV2,
                                               false);
 
@@ -1083,7 +1083,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiV2[]>;
                 res = await this.rest.get<WikiInterfaces.WikiV2[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiV2,
                                               true);
 
@@ -1127,7 +1127,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiV2>;
                 res = await this.rest.get<WikiInterfaces.WikiV2>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiV2,
                                               false);
 
@@ -1173,7 +1173,7 @@ export class WikiApi extends basem.ClientApiBase implements IWikiApi {
                 let res: restm.IRestResponse<WikiInterfaces.WikiV2>;
                 res = await this.rest.update<WikiInterfaces.WikiV2>(url, updateParameters, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WikiInterfaces.TypeInfo.WikiV2,
                                               false);
 

--- a/api/WorkApi.ts
+++ b/api/WorkApi.ts
@@ -124,7 +124,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, ruleRequestModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -173,7 +173,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BacklogConfiguration>;
                 res = await this.rest.get<WorkInterfaces.BacklogConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.BacklogConfiguration,
                                               false);
 
@@ -225,7 +225,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BacklogLevelWorkItems>;
                 res = await this.rest.get<WorkInterfaces.BacklogLevelWorkItems>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -277,7 +277,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BacklogLevelConfiguration>;
                 res = await this.rest.get<WorkInterfaces.BacklogLevelConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.BacklogLevelConfiguration,
                                               false);
 
@@ -326,7 +326,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BacklogLevelConfiguration[]>;
                 res = await this.rest.get<WorkInterfaces.BacklogLevelConfiguration[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.BacklogLevelConfiguration,
                                               true);
 
@@ -388,7 +388,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardBadge>;
                 res = await this.rest.get<WorkInterfaces.BoardBadge>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -450,7 +450,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<string>;
                 res = await this.rest.get<string>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -491,7 +491,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardSuggestedValue[]>;
                 res = await this.rest.get<WorkInterfaces.BoardSuggestedValue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -556,7 +556,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.ParentChildWIMap[]>;
                 res = await this.rest.get<WorkInterfaces.ParentChildWIMap[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -597,7 +597,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardSuggestedValue[]>;
                 res = await this.rest.get<WorkInterfaces.BoardSuggestedValue[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -649,7 +649,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.Board>;
                 res = await this.rest.get<WorkInterfaces.Board>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.Board,
                                               false);
 
@@ -698,7 +698,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardReference[]>;
                 res = await this.rest.get<WorkInterfaces.BoardReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -752,7 +752,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<{ [key: string] : string; }>;
                 res = await this.rest.replace<{ [key: string] : string; }>(url, options, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -804,7 +804,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardUserSettings>;
                 res = await this.rest.get<WorkInterfaces.BoardUserSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -858,7 +858,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardUserSettings>;
                 res = await this.rest.update<WorkInterfaces.BoardUserSettings>(url, boardUserSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -910,7 +910,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamCapacity>;
                 res = await this.rest.get<WorkInterfaces.TeamCapacity>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamCapacity,
                                               false);
 
@@ -965,7 +965,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamMemberCapacityIdentityRef>;
                 res = await this.rest.get<WorkInterfaces.TeamMemberCapacityIdentityRef>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamMemberCapacityIdentityRef,
                                               false);
 
@@ -1019,7 +1019,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamMemberCapacityIdentityRef[]>;
                 res = await this.rest.replace<WorkInterfaces.TeamMemberCapacityIdentityRef[]>(url, capacities, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamMemberCapacityIdentityRef,
                                               true);
 
@@ -1076,7 +1076,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamMemberCapacityIdentityRef>;
                 res = await this.rest.update<WorkInterfaces.TeamMemberCapacityIdentityRef>(url, patch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamMemberCapacityIdentityRef,
                                               false);
 
@@ -1128,7 +1128,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardCardRuleSettings>;
                 res = await this.rest.get<WorkInterfaces.BoardCardRuleSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1182,7 +1182,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardCardRuleSettings>;
                 res = await this.rest.update<WorkInterfaces.BoardCardRuleSettings>(url, boardCardRuleSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1233,7 +1233,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, boardCardRuleSettings, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1285,7 +1285,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardCardSettings>;
                 res = await this.rest.get<WorkInterfaces.BoardCardSettings>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1339,7 +1339,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardCardSettings>;
                 res = await this.rest.replace<WorkInterfaces.BoardCardSettings>(url, boardCardSettingsToSave, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1390,7 +1390,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.replace<void>(url, boardCardSettingsToSave, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1445,7 +1445,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardChart>;
                 res = await this.rest.get<WorkInterfaces.BoardChart>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1497,7 +1497,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardChartReference[]>;
                 res = await this.rest.get<WorkInterfaces.BoardChartReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1554,7 +1554,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardChart>;
                 res = await this.rest.update<WorkInterfaces.BoardChart>(url, chart, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1606,7 +1606,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardColumn[]>;
                 res = await this.rest.get<WorkInterfaces.BoardColumn[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.BoardColumn,
                                               true);
 
@@ -1660,7 +1660,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardColumn[]>;
                 res = await this.rest.replace<WorkInterfaces.BoardColumn[]>(url, boardColumns, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.BoardColumn,
                                               true);
 
@@ -1717,7 +1717,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.DeliveryViewData>;
                 res = await this.rest.get<WorkInterfaces.DeliveryViewData>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.DeliveryViewData,
                                               false);
 
@@ -1761,7 +1761,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.IterationCapacity>;
                 res = await this.rest.get<WorkInterfaces.IterationCapacity>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1813,7 +1813,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1865,7 +1865,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSettingsIteration>;
                 res = await this.rest.get<WorkInterfaces.TeamSettingsIteration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSettingsIteration,
                                               false);
 
@@ -1921,7 +1921,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSettingsIteration[]>;
                 res = await this.rest.get<WorkInterfaces.TeamSettingsIteration[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSettingsIteration,
                                               true);
 
@@ -1972,7 +1972,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSettingsIteration>;
                 res = await this.rest.create<WorkInterfaces.TeamSettingsIteration>(url, iteration, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSettingsIteration,
                                               false);
 
@@ -2015,7 +2015,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.Plan>;
                 res = await this.rest.create<WorkInterfaces.Plan>(url, postedPlan, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.Plan,
                                               false);
 
@@ -2059,7 +2059,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2103,7 +2103,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.Plan>;
                 res = await this.rest.get<WorkInterfaces.Plan>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.Plan,
                                               false);
 
@@ -2144,7 +2144,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.Plan[]>;
                 res = await this.rest.get<WorkInterfaces.Plan[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.Plan,
                                               true);
 
@@ -2190,7 +2190,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.Plan>;
                 res = await this.rest.replace<WorkInterfaces.Plan>(url, updatedPlan, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.Plan,
                                               false);
 
@@ -2231,7 +2231,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.PredefinedQuery[]>;
                 res = await this.rest.get<WorkInterfaces.PredefinedQuery[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2285,7 +2285,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.PredefinedQuery>;
                 res = await this.rest.get<WorkInterfaces.PredefinedQuery>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2326,7 +2326,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.ProcessConfiguration>;
                 res = await this.rest.get<WorkInterfaces.ProcessConfiguration>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2378,7 +2378,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardRow[]>;
                 res = await this.rest.get<WorkInterfaces.BoardRow[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2432,7 +2432,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.BoardRow[]>;
                 res = await this.rest.replace<WorkInterfaces.BoardRow[]>(url, boardRows, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2479,7 +2479,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TaskboardColumns>;
                 res = await this.rest.get<WorkInterfaces.TaskboardColumns>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2528,7 +2528,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TaskboardColumns>;
                 res = await this.rest.replace<WorkInterfaces.TaskboardColumns>(url, updateColumns, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2578,7 +2578,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TaskboardWorkItemColumn[]>;
                 res = await this.rest.get<WorkInterfaces.TaskboardWorkItemColumn[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2633,7 +2633,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.update<void>(url, updateColumn, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2685,7 +2685,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSettingsDaysOff>;
                 res = await this.rest.get<WorkInterfaces.TeamSettingsDaysOff>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSettingsDaysOff,
                                               false);
 
@@ -2739,7 +2739,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSettingsDaysOff>;
                 res = await this.rest.update<WorkInterfaces.TeamSettingsDaysOff>(url, daysOffPatch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSettingsDaysOff,
                                               false);
 
@@ -2788,7 +2788,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamFieldValues>;
                 res = await this.rest.get<WorkInterfaces.TeamFieldValues>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2839,7 +2839,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamFieldValues>;
                 res = await this.rest.update<WorkInterfaces.TeamFieldValues>(url, patch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2888,7 +2888,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSetting>;
                 res = await this.rest.get<WorkInterfaces.TeamSetting>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSetting,
                                               false);
 
@@ -2939,7 +2939,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.TeamSetting>;
                 res = await this.rest.update<WorkInterfaces.TeamSetting>(url, teamSettingsPatch, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkInterfaces.TypeInfo.TeamSetting,
                                               false);
 
@@ -2991,7 +2991,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.IterationWorkItems>;
                 res = await this.rest.get<WorkInterfaces.IterationWorkItems>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3042,7 +3042,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.ReorderResult[]>;
                 res = await this.rest.update<WorkInterfaces.ReorderResult[]>(url, operation, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3096,7 +3096,7 @@ export class WorkApi extends basem.ClientApiBase implements IWorkApi {
                 let res: restm.IRestResponse<WorkInterfaces.ReorderResult[]>;
                 res = await this.rest.update<WorkInterfaces.ReorderResult[]>(url, operation, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 

--- a/api/WorkItemTrackingApi.ts
+++ b/api/WorkItemTrackingApi.ts
@@ -150,7 +150,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.AccountMyWorkResult>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.AccountMyWorkResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.AccountMyWorkResult,
                                               false);
 
@@ -188,7 +188,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.AccountRecentActivityWorkItemModel2[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.AccountRecentActivityWorkItemModel2[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.AccountRecentActivityWorkItemModel2,
                                               true);
 
@@ -226,7 +226,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.AccountRecentMentionWorkItemModel[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.AccountRecentMentionWorkItemModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.AccountRecentMentionWorkItemModel,
                                               true);
 
@@ -264,7 +264,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkArtifactLink[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkArtifactLink[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -307,7 +307,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ArtifactUriQueryResult>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.ArtifactUriQueryResult>(url, artifactUriQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -369,7 +369,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.AttachmentReference>;
                 res = await this.rest.uploadStream<WorkItemTrackingInterfaces.AttachmentReference>("POST", url, contentStream, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -517,7 +517,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemClassificationNode[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemClassificationNode[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode,
                                               true);
 
@@ -565,7 +565,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemClassificationNode[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemClassificationNode[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode,
                                               true);
 
@@ -614,7 +614,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemClassificationNode>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItemClassificationNode>(url, postedNode, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode,
                                               false);
 
@@ -668,7 +668,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -722,7 +722,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemClassificationNode>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemClassificationNode>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode,
                                               false);
 
@@ -771,7 +771,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemClassificationNode>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.WorkItemClassificationNode>(url, postedNode, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemClassificationNode,
                                               false);
 
@@ -831,7 +831,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<VSSInterfaces.IdentityRef[]>;
                 res = await this.rest.get<VSSInterfaces.IdentityRef[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -877,7 +877,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.Comment>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.Comment>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -924,7 +924,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -981,7 +981,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.Comment>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.Comment>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -1044,7 +1044,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentList>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.CommentList>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentList,
                                               false);
 
@@ -1104,7 +1104,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentList>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.CommentList>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentList,
                                               false);
 
@@ -1153,7 +1153,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.Comment>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.Comment>(url, request, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.Comment,
                                               false);
 
@@ -1203,7 +1203,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentReaction>;
                 res = await this.rest.replace<WorkItemTrackingInterfaces.CommentReaction>(url, null, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentReaction,
                                               false);
 
@@ -1253,7 +1253,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentReaction>;
                 res = await this.rest.del<WorkItemTrackingInterfaces.CommentReaction>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentReaction,
                                               false);
 
@@ -1300,7 +1300,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentReaction[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.CommentReaction[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentReaction,
                                               true);
 
@@ -1348,7 +1348,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentVersion>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.CommentVersion>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentVersion,
                                               false);
 
@@ -1393,7 +1393,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.CommentVersion[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.CommentVersion[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.CommentVersion,
                                               true);
 
@@ -1436,7 +1436,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemField>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItemField>(url, workItemField, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemField,
                                               false);
 
@@ -1480,7 +1480,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1524,7 +1524,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemField>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemField>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemField,
                                               false);
 
@@ -1572,7 +1572,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemField[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemField[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemField,
                                               true);
 
@@ -1618,7 +1618,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemField>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.WorkItemField>(url, payload, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemField,
                                               false);
 
@@ -1661,7 +1661,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ProcessMigrationResultModel>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.ProcessMigrationResultModel>(url, newProcess, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1714,7 +1714,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItem>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.QueryHierarchyItem>(url, postedQuery, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem,
                                               false);
 
@@ -1758,7 +1758,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1812,7 +1812,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItem[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.QueryHierarchyItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem,
                                               true);
 
@@ -1872,7 +1872,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItem>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.QueryHierarchyItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem,
                                               false);
 
@@ -1932,7 +1932,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItemsResult>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.QueryHierarchyItemsResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItemsResult,
                                               false);
 
@@ -1985,7 +1985,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItem>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.QueryHierarchyItem>(url, queryUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem,
                                               false);
 
@@ -2028,7 +2028,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.QueryHierarchyItem[]>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.QueryHierarchyItem[]>(url, queryGetRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.QueryHierarchyItem,
                                               true);
 
@@ -2072,7 +2072,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2116,7 +2116,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemDelete>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemDelete>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2167,7 +2167,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemDeleteReference[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemDeleteReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2208,7 +2208,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemDeleteShallowReference[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemDeleteShallowReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2254,7 +2254,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemDelete>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.WorkItemDelete>(url, payload, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2308,7 +2308,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2365,7 +2365,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2408,7 +2408,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.create<void>(url, body, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2450,7 +2450,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2492,7 +2492,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTagDefinition>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTagDefinition>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2531,7 +2531,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTagDefinition[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTagDefinition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2575,7 +2575,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTagDefinition>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.WorkItemTagDefinition>(url, tagData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2626,7 +2626,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTemplate>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItemTemplate>(url, template, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2682,7 +2682,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTemplateReference[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTemplateReference[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2734,7 +2734,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2786,7 +2786,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTemplate>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTemplate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2840,7 +2840,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTemplate>;
                 res = await this.rest.replace<WorkItemTrackingInterfaces.WorkItemTemplate>(url, templateContent, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2887,7 +2887,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemUpdate>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemUpdate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemUpdate,
                                               false);
 
@@ -2941,7 +2941,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemUpdate[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemUpdate[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemUpdate,
                                               true);
 
@@ -3002,7 +3002,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemQueryResult>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItemQueryResult>(url, wiql, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemQueryResult,
                                               false);
 
@@ -3064,7 +3064,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemQueryResult>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemQueryResult>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingInterfaces.TypeInfo.WorkItemQueryResult,
                                               false);
 
@@ -3115,7 +3115,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemIcon>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemIcon>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3153,7 +3153,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemIcon[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemIcon[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3296,7 +3296,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ReportingWorkItemLinksBatch>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.ReportingWorkItemLinksBatch>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3337,7 +3337,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemRelationType>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemRelationType>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3375,7 +3375,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemRelationType[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemRelationType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3453,7 +3453,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3509,7 +3509,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>(url, filter, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3558,7 +3558,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.ReportingWorkItemRevisionsBatch>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3625,7 +3625,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItem>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3682,7 +3682,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3733,7 +3733,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemDelete>;
                 res = await this.rest.del<WorkItemTrackingInterfaces.WorkItemDelete>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3790,7 +3790,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItem>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3853,7 +3853,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItem[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -3920,7 +3920,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem>;
                 res = await this.rest.update<WorkItemTrackingInterfaces.WorkItem>(url, document, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -3963,7 +3963,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItem[]>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.WorkItem[]>(url, workItemGetRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4003,7 +4003,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ProjectWorkItemStateColors[]>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.ProjectWorkItemStateColors[]>(url, projectNames, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4054,7 +4054,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemNextStateOnTransition[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemNextStateOnTransition[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4095,7 +4095,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTypeCategory[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTypeCategory[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4139,7 +4139,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTypeCategory>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTypeCategory>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4179,7 +4179,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<{ key: string; value: WorkItemTrackingInterfaces.WorkItemTypeColor[] }[]>;
                 res = await this.rest.create<{ key: string; value: WorkItemTrackingInterfaces.WorkItemTypeColor[] }[]>(url, projectNames, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4219,7 +4219,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<{ key: string; value: WorkItemTrackingInterfaces.WorkItemTypeColorAndIcon[] }[]>;
                 res = await this.rest.create<{ key: string; value: WorkItemTrackingInterfaces.WorkItemTypeColorAndIcon[] }[]>(url, projectNames, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4263,7 +4263,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemType>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemType>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4304,7 +4304,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemType[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4355,7 +4355,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTypeFieldWithReferences[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTypeFieldWithReferences[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4409,7 +4409,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTypeFieldWithReferences>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTypeFieldWithReferences>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4453,7 +4453,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemStateColor[]>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemStateColor[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -4504,7 +4504,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.WorkItemTypeTemplate>;
                 res = await this.rest.get<WorkItemTrackingInterfaces.WorkItemTypeTemplate>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -4547,7 +4547,7 @@ export class WorkItemTrackingApi extends basem.ClientApiBase implements IWorkIte
                 let res: restm.IRestResponse<WorkItemTrackingInterfaces.ProvisioningResult>;
                 res = await this.rest.create<WorkItemTrackingInterfaces.ProvisioningResult>(url, updateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/WorkItemTrackingProcessApi.ts
+++ b/api/WorkItemTrackingProcessApi.ts
@@ -113,7 +113,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
                                               false);
 
@@ -157,7 +157,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -208,7 +208,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
                                               false);
 
@@ -256,7 +256,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessBehavior[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
                                               true);
 
@@ -302,7 +302,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessBehavior>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.ProcessBehavior>(url, behaviorData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessBehavior,
                                               false);
 
@@ -351,7 +351,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -410,7 +410,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -460,7 +460,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -512,7 +512,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -558,7 +558,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
                                               false);
 
@@ -602,7 +602,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
                                               true);
 
@@ -656,7 +656,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
                                               false);
 
@@ -703,7 +703,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -752,7 +752,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessWorkItemTypeField>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemTypeField,
                                               false);
 
@@ -804,7 +804,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -875,7 +875,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -940,7 +940,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -993,7 +993,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1048,7 +1048,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Group>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1092,7 +1092,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.FormLayout>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.FormLayout>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.FormLayout,
                                               false);
 
@@ -1132,7 +1132,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.PickList>(url, picklist, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1173,7 +1173,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1214,7 +1214,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.PickList>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1252,7 +1252,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickListMetadata[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.PickListMetadata[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1295,7 +1295,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.PickList>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.PickList>(url, picklist, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1341,7 +1341,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Page>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.Page>(url, page, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.Page,
                                               false);
 
@@ -1388,7 +1388,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1434,7 +1434,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Page>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.Page>(url, page, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.Page,
                                               false);
 
@@ -1474,7 +1474,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, createRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
@@ -1515,7 +1515,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1558,7 +1558,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, updateRequest, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
@@ -1603,7 +1603,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessInfo[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               true);
 
@@ -1651,7 +1651,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessInfo>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessInfo>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessInfo,
                                               false);
 
@@ -1697,7 +1697,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessRule>(url, processRuleCreate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               false);
 
@@ -1744,7 +1744,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1791,7 +1791,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessRule>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               false);
 
@@ -1835,7 +1835,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessRule[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               true);
 
@@ -1884,7 +1884,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessRule>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.ProcessRule>(url, processRule, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessRule,
                                               false);
 
@@ -1930,7 +1930,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, stateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               false);
 
@@ -1977,7 +1977,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2024,7 +2024,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               false);
 
@@ -2068,7 +2068,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               true);
 
@@ -2117,7 +2117,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.replace<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, hideStateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               false);
 
@@ -2166,7 +2166,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.WorkItemStateResultModel>(url, stateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.WorkItemStateResultModel,
                                               false);
 
@@ -2213,7 +2213,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control[]>;
                 res = await this.rest.del<WorkItemTrackingProcessInterfaces.Control[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2257,7 +2257,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.Control[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2306,7 +2306,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.Control>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2349,7 +2349,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, workItemType, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               false);
 
@@ -2393,7 +2393,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2444,7 +2444,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               false);
 
@@ -2492,7 +2492,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.ProcessWorkItemType[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               true);
 
@@ -2538,7 +2538,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.ProcessWorkItemType>(url, workItemTypeUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessInterfaces.TypeInfo.ProcessWorkItemType,
                                               false);
 
@@ -2584,7 +2584,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.create<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2631,7 +2631,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2675,7 +2675,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>;
                 res = await this.rest.get<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -2722,7 +2722,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2768,7 +2768,7 @@ export class WorkItemTrackingProcessApi extends basem.ClientApiBase implements I
                 let res: restm.IRestResponse<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.update<WorkItemTrackingProcessInterfaces.WorkItemTypeBehavior>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 

--- a/api/WorkItemTrackingProcessDefinitionsApi.ts
+++ b/api/WorkItemTrackingProcessDefinitionsApi.ts
@@ -102,7 +102,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -146,7 +146,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -190,7 +190,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -231,7 +231,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -277,7 +277,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.BehaviorModel>(url, behaviorData, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -326,7 +326,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Control>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -378,7 +378,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Control>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -428,7 +428,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -487,7 +487,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Control>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.Control>(url, control, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -530,7 +530,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.FieldModel>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.FieldModel>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.FieldModel,
                                               false);
 
@@ -573,7 +573,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.FieldModel>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.FieldModel>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.FieldModel,
                                               false);
 
@@ -625,7 +625,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Group>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -680,7 +680,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Group>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -733,7 +733,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -804,7 +804,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Group>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -869,7 +869,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Group>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.Group>(url, group, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -913,7 +913,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.FormLayout>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.FormLayout>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.FormLayout,
                                               false);
 
@@ -951,7 +951,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.PickListMetadataModel[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.PickListMetadataModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -991,7 +991,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>(url, picklist, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1032,7 +1032,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1073,7 +1073,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1116,7 +1116,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.PickListModel>(url, picklist, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1162,7 +1162,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Page>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.Page>(url, page, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.Page,
                                               false);
 
@@ -1208,7 +1208,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.Page>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.Page>(url, page, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.Page,
                                               false);
 
@@ -1255,7 +1255,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1301,7 +1301,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>(url, stateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1348,7 +1348,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1395,7 +1395,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1439,7 +1439,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1488,7 +1488,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.replace<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>(url, hideStateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1537,7 +1537,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemStateResultModel>(url, stateModel, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1583,7 +1583,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1630,7 +1630,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1674,7 +1674,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               true);
 
@@ -1721,7 +1721,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1767,7 +1767,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeBehavior>(url, behavior, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1810,7 +1810,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>(url, workItemType, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeModel,
                                               false);
 
@@ -1854,7 +1854,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -1905,7 +1905,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeModel,
                                               false);
 
@@ -1953,7 +1953,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeModel,
                                               true);
 
@@ -1999,7 +1999,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeModel>(url, workItemTypeUpdate, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeModel,
                                               false);
 
@@ -2045,7 +2045,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
                 res = await this.rest.create<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               false);
 
@@ -2092,7 +2092,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               false);
 
@@ -2136,7 +2136,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>;
                 res = await this.rest.get<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2[]>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               true);
 
@@ -2183,7 +2183,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<void>;
                 res = await this.rest.del<void>(url, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               null,
                                               false);
 
@@ -2229,7 +2229,7 @@ export class WorkItemTrackingProcessDefinitionsApi extends basem.ClientApiBase i
                 let res: restm.IRestResponse<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>;
                 res = await this.rest.update<WorkItemTrackingProcessDefinitionsInterfaces.WorkItemTypeFieldModel2>(url, field, options);
 
-                let ret = this.formatResponse(res.result,
+                let ret = this.formatResponse(res,
                                               WorkItemTrackingProcessDefinitionsInterfaces.TypeInfo.WorkItemTypeFieldModel2,
                                               false);
 


### PR DESCRIPTION
When the x-ms-continuationtoken header is present in the response it will be returned in the response object.

Fixes #646 #634 #623 #609 #548 #521 #415 #493 #232 