### PR TITLE
Wire up rate limit headers via HTTP/REST client wrappers

### DIFF
--- a/api/AdoHttpClientBases.ts
+++ b/api/AdoHttpClientBases.ts
@@ -34,6 +34,10 @@ export class AdoRestClient extends rm.RestClient {
             const response = await super.processResponse(res, options);
             if (response && response.result && typeof response.result === 'object') {
                 extractRateLimitHeaders(headers, response.result);
+                // For collection responses (e.g., { count, value: [...] }), also attach to the array
+                if (Array.isArray((response.result as any).value)) {
+                    extractRateLimitHeaders(headers, (response.result as any).value);
+                }
             }
             return response as rm.IRestResponse<T>;
         } catch (err: any) {

--- a/api/AdoHttpClientBases.ts
+++ b/api/AdoHttpClientBases.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { extractRateLimitHeaders } from './RateLimitUtils';
+
+import * as rm from 'typed-rest-client/RestClient';
+import * as hm from 'typed-rest-client/HttpClient';
+import { IHeaders, IHttpClientResponse } from 'typed-rest-client/Interfaces';
+
+/**
+ * AdoHttpClient that extracts rate limit headers and attaches them to the response object
+ */
+export class AdoHttpClient extends hm.HttpClient {
+    public async request(verb: string, requestUrl: string, data: string | NodeJS.ReadableStream, headers: IHeaders): Promise<IHttpClientResponse> {
+        const res = await super.request(verb, requestUrl, data, headers);
+
+        const resHeaders = res?.message?.headers;
+
+        extractRateLimitHeaders(resHeaders, res);
+        extractRateLimitHeaders(resHeaders, res?.message);
+
+        return res;
+    }
+}
+
+/**
+ * AdoRestClient that extracts rate limit headers and attaches them to the response/result objects
+ */
+export class AdoRestClient extends rm.RestClient {
+    protected async processResponse<T>(res: hm.HttpClientResponse, options: rm.IRequestOptions): Promise<rm.IRestResponse<T>> {
+        const headers = res?.message?.headers;
+
+        try {
+            const response = await super.processResponse(res, options);
+            if (response && response.result && typeof response.result === 'object') {
+                extractRateLimitHeaders(headers, response.result);
+            }
+            return response as rm.IRestResponse<T>;
+        } catch (err: any) {
+            // Use the original response headers captured before super.processResponse,
+            // because the base implementation may not populate err.responseHeaders
+            // when the response body is not valid JSON (e.g., HTML error pages on 429).
+            extractRateLimitHeaders(headers, err);
+            if (err?.result && typeof err.result === 'object') {
+                extractRateLimitHeaders(headers, err.result);
+            }
+            return Promise.reject(err);
+        }
+    }
+}

--- a/api/AdoHttpClientBases.ts
+++ b/api/AdoHttpClientBases.ts
@@ -31,8 +31,6 @@ export class AdoRestClient extends rm.RestClient {
 
         try {
             const response = await super.processResponse(res, options);
-            // Always attach rateLimit to the response object itself
-            extractRateLimitHeaders(headers, response);
             if (response && response.result && typeof response.result === 'object') {
                 extractRateLimitHeaders(headers, response.result);
                 // For collection responses (e.g., { count, value: [...] }), also attach to the array

--- a/api/AdoHttpClientBases.ts
+++ b/api/AdoHttpClientBases.ts
@@ -17,7 +17,6 @@ export class AdoHttpClient extends hm.HttpClient {
         const resHeaders = res?.message?.headers;
 
         extractRateLimitHeaders(resHeaders, res);
-        extractRateLimitHeaders(resHeaders, res?.message);
 
         return res;
     }
@@ -32,6 +31,8 @@ export class AdoRestClient extends rm.RestClient {
 
         try {
             const response = await super.processResponse(res, options);
+            // Always attach rateLimit to the response object itself
+            extractRateLimitHeaders(headers, response);
             if (response && response.result && typeof response.result === 'object') {
                 extractRateLimitHeaders(headers, response.result);
                 // For collection responses (e.g., { count, value: [...] }), also attach to the array

--- a/api/ClientApiBases.ts
+++ b/api/ClientApiBases.ts
@@ -4,6 +4,8 @@
 import vsom = require('./VsoClient');
 import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
 import serm = require('./Serialization');
+import AdoHttpClientBases = require('./AdoHttpClientBases');
+import { extractRateLimitHeaders } from './RateLimitUtils';
 import * as rm from 'typed-rest-client/RestClient';
 import * as hm from 'typed-rest-client/HttpClient';
 
@@ -20,8 +22,8 @@ export class ClientApiBase {
     constructor(baseUrl: string, handlers: VsoBaseInterfaces.IRequestHandler[], userAgent: string, options?: VsoBaseInterfaces.IRequestOptions) {
         this.baseUrl = baseUrl;
 
-        this.http = new hm.HttpClient(userAgent, handlers, options);
-        this.rest = new rm.RestClient(userAgent, null, handlers, options);
+        this.http = new AdoHttpClientBases.AdoHttpClient(userAgent, handlers, options);
+        this.rest = new AdoHttpClientBases.AdoRestClient(userAgent, null, handlers, options);
 
         this.vsoClient = new vsom.VsoClient(baseUrl, this.rest);
         this.userAgent = userAgent;
@@ -50,30 +52,6 @@ export class ClientApiBase {
     }
 
     public extractRateLimitHeaders(headers: any, target: any): void {
-        if (!headers || !target) {
-            return;
-        }
-
-        const rateLimit: VsoBaseInterfaces.RateLimit = {};
-
-        if (headers['x-ratelimit-resource']) {
-            rateLimit.resource = headers['x-ratelimit-resource'];
-        }
-        if (headers['x-ratelimit-delay']) {
-            rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
-        }
-        if (headers['x-ratelimit-limit']) {
-            rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
-        }
-        if (headers['x-ratelimit-remaining']) {
-            rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
-        }
-        if (headers['x-ratelimit-reset']) {
-            rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
-        }
-        if (headers['retry-after']) {
-            rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
-        }
-        target.rateLimit = rateLimit;
+        extractRateLimitHeaders(headers, target);
     }
 }

--- a/api/RateLimitUtils.ts
+++ b/api/RateLimitUtils.ts
@@ -14,24 +14,34 @@ export function extractRateLimitHeaders(headers: any, target: any): void {
     }
 
     const rateLimit: VsoBaseInterfaces.RateLimit = {};
+    let hasRateLimitHeader = false;
 
     if (headers['x-ratelimit-resource']) {
         rateLimit.resource = headers['x-ratelimit-resource'];
+        hasRateLimitHeader = true;
     }
     if (headers['x-ratelimit-delay']) {
         rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
+        hasRateLimitHeader = true;
     }
     if (headers['x-ratelimit-limit']) {
         rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
+        hasRateLimitHeader = true;
     }
     if (headers['x-ratelimit-remaining']) {
         rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+        hasRateLimitHeader = true;
     }
     if (headers['x-ratelimit-reset']) {
         rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
+        hasRateLimitHeader = true;
     }
     if (headers['retry-after']) {
         rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
+        hasRateLimitHeader = true;
     }
-    target.rateLimit = rateLimit;
+
+    if (hasRateLimitHeader) {
+        target.rateLimit = rateLimit;
+    }
 }

--- a/api/RateLimitUtils.ts
+++ b/api/RateLimitUtils.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import VsoBaseInterfaces = require('./interfaces/common/VsoBaseInterfaces');
+
+/**
+ * Extracts rate limit headers from the provided headers and attaches them to the target object
+ * @param headers - source headers
+ * @param target - target object to attach rate limit info to
+ */
+export function extractRateLimitHeaders(headers: any, target: any): void {
+    if (!headers || !target) {
+        return;
+    }
+
+    const rateLimit: VsoBaseInterfaces.RateLimit = {};
+
+    if (headers['x-ratelimit-resource']) {
+        rateLimit.resource = headers['x-ratelimit-resource'];
+    }
+    if (headers['x-ratelimit-delay']) {
+        rateLimit.delay = parseFloat(headers['x-ratelimit-delay']);
+    }
+    if (headers['x-ratelimit-limit']) {
+        rateLimit.limit = parseInt(headers['x-ratelimit-limit'], 10);
+    }
+    if (headers['x-ratelimit-remaining']) {
+        rateLimit.remaining = parseInt(headers['x-ratelimit-remaining'], 10);
+    }
+    if (headers['x-ratelimit-reset']) {
+        rateLimit.reset = parseInt(headers['x-ratelimit-reset'], 10);
+    }
+    if (headers['retry-after']) {
+        rateLimit.retryAfter = parseInt(headers['retry-after'], 10);
+    }
+    target.rateLimit = rateLimit;
+}

--- a/api/WebApi.ts
+++ b/api/WebApi.ts
@@ -37,7 +37,7 @@ import basicm = require('./handlers/basiccreds');
 import bearm = require('./handlers/bearertoken');
 import ntlmm = require('./handlers/ntlm');
 import patm = require('./handlers/personalaccesstoken');
-
+import AdoHttpClientBases = require('./AdoHttpClientBases');
 import * as rm from 'typed-rest-client/RestClient';
 import vsom = require('./VsoClient');
 import lim = require("./interfaces/LocationsInterfaces");
@@ -172,7 +172,7 @@ export class WebApi {
                 userAgent = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
             }
         }
-        this.rest = new rm.RestClient(userAgent, null, [this.authHandler], this.options);
+        this.rest = new AdoHttpClientBases.AdoRestClient(userAgent, null, [this.authHandler], this.options);
         this.vsoClient = new vsom.VsoClient(defaultUrl, this.rest);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.1.4",
+    "version": "15.2.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "15.1.4",
+            "version": "15.2.0",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "azure-devops-node-api",
-    "version": "15.1.3",
+    "version": "15.1.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "azure-devops-node-api",
-            "version": "15.1.3",
+            "version": "15.1.4",
             "license": "MIT",
             "dependencies": {
                 "tunnel": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.3",
+    "version": "15.1.4",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "azure-devops-node-api",
     "description": "Node client for Azure DevOps and TFS REST APIs",
-    "version": "15.1.4",
+    "version": "15.2.0",
     "main": "./WebApi.js",
     "types": "./WebApi.d.ts",
     "scripts": {

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../_build": {
       "name": "azure-devops-node-api",
-      "version": "15.1.4",
+      "version": "15.2.0",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../_build": {
       "name": "azure-devops-node-api",
-      "version": "15.1.3",
+      "version": "15.1.4",
       "license": "MIT",
       "dependencies": {
         "tunnel": "0.0.6",

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -7,7 +7,6 @@ import WebApi = require('../../_build/WebApi');
 import * as rm from 'typed-rest-client/RestClient';
 import { ApiResourceLocation, RateLimit } from '../../_build/interfaces/common/VsoBaseInterfaces';
 import semver = require('semver');
-import { IRestResponse } from 'typed-rest-client';
 
 describe('VSOClient Units', function () {
     let rest: rm.RestClient;
@@ -341,7 +340,7 @@ describe('WebApi Units', function () {
         const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com', WebApi.getBasicHandler('user', 'password'));
 
         // Act
-        const response = (await myWebApi.rest.get<{ success: boolean, rateLimit?: RateLimit }>('https://dev.azure.com/test')) as IRestResponse<{ success: boolean, rateLimit?: RateLimit }>;
+        const response = await myWebApi.rest.get<{ success: boolean, rateLimit?: RateLimit }>('https://dev.azure.com/test');
         // Assert
         assert(response.result?.success === true, 'Response body should indicate success');
         assert(response.result?.rateLimit, 'Response should have rateLimit property');
@@ -351,6 +350,63 @@ describe('WebApi Units', function () {
         assert.equal(response.result.rateLimit?.remaining, 999, 'Rate limit remaining should be 999');
         assert.equal(response.result.rateLimit?.reset, 1625078400, 'Rate limit reset should be 1625078400');
         assert.equal(response.result.rateLimit?.retryAfter, 1, 'Rate limit retryAfter should be 1');
+    });
+
+    it('AdoRestClient attaches rate limit headers to error on 429', async () => {
+        // Arrange
+        const userAgent: string = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+
+        nock('https://dev.azure.com', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': userAgent,
+            },
+        })
+            .defaultReplyHeaders({
+                'x-ratelimit-resource': 'core',
+                'x-ratelimit-delay': '5.0',
+                'x-ratelimit-limit': '1000',
+                'x-ratelimit-remaining': '0',
+                'x-ratelimit-reset': '1625078400',
+                'retry-after': '30',
+            })
+            .get('/blocked')
+            .reply(429, { message: 'Too Many Requests' });
+        
+        const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com', WebApi.getBasicHandler('user', 'password'));
+
+        // Act & Assert
+        try {
+            await myWebApi.rest.get<any>('https://dev.azure.com/blocked');
+            assert.fail('Should have thrown on 429');
+        } catch (err: any) {
+            assert(err.rateLimit, 'Error should have rateLimit property');
+            assert.equal(err.rateLimit.resource, 'core', 'Rate limit resource should be "core"');
+            assert.equal(err.rateLimit.remaining, 0, 'Rate limit remaining should be 0');
+            assert.equal(err.rateLimit.retryAfter, 30, 'Rate limit retryAfter should be 30');
+        }
+    });
+
+    it('AdoRestClient does not attach rateLimit when no rate limit headers present', async () => {
+        // Arrange
+        const userAgent: string = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+
+        nock('https://dev.azure.com', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': userAgent,
+            },
+        })
+            .get('/no-ratelimit')
+            .reply(200, { data: 'hello' });
+        
+        const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com', WebApi.getBasicHandler('user', 'password'));
+
+        // Act
+        const response = await myWebApi.rest.get<{ data: string, rateLimit?: RateLimit }>('https://dev.azure.com/no-ratelimit');
+        // Assert
+        assert(response.result?.data === 'hello', 'Response body should have data');
+        assert.equal(response.result?.rateLimit, undefined, 'rateLimit should not be present when no rate limit headers');
     });
 
     it('sets the user agent correctly when request settings are not specified', async () => {

--- a/test/units/tests.ts
+++ b/test/units/tests.ts
@@ -5,8 +5,9 @@ import os = require('os');
 import vsom = require('../../_build/VsoClient');
 import WebApi = require('../../_build/WebApi');
 import * as rm from 'typed-rest-client/RestClient';
-import { ApiResourceLocation } from '../../_build/interfaces/common/VsoBaseInterfaces';
+import { ApiResourceLocation, RateLimit } from '../../_build/interfaces/common/VsoBaseInterfaces';
 import semver = require('semver');
+import { IRestResponse } from 'typed-rest-client';
 
 describe('VSOClient Units', function () {
     let rest: rm.RestClient;
@@ -314,6 +315,42 @@ describe('WebApi Units', function () {
                                                           undefined, {productName: 'name', productVersion: '1.2.3'});
         const userAgent: string = `name/1.2.3 (${nodeApiName} ${nodeApiVersion}; ${osName} ${osVersion})`;
         assert.equal(userAgent, myWebApi.rest.client.userAgent, 'User agent should be: ' + userAgent);
+    });
+
+    it('AdoRestClient attaches rate limit headers to responses', async () => {
+        // Arrange
+        const userAgent: string = `${nodeApiName}/${nodeApiVersion} (${osName} ${osVersion})`;
+
+        nock('https://dev.azure.com', {
+            reqheaders: {
+                'accept': 'application/json',
+                'user-agent': userAgent,
+            },
+        })
+            .defaultReplyHeaders({
+                'x-ratelimit-resource': 'core',
+                'x-ratelimit-delay': '0.5',
+                'x-ratelimit-limit': '1000',
+                'x-ratelimit-remaining': '999',
+                'x-ratelimit-reset': '1625078400',
+                'retry-after': '1',
+            })
+            .get('/test')
+            .reply(200, { success: true });
+        
+        const myWebApi: WebApi.WebApi = new WebApi.WebApi('https://dev.azure.com', WebApi.getBasicHandler('user', 'password'));
+
+        // Act
+        const response = (await myWebApi.rest.get<{ success: boolean, rateLimit?: RateLimit }>('https://dev.azure.com/test')) as IRestResponse<{ success: boolean, rateLimit?: RateLimit }>;
+        // Assert
+        assert(response.result?.success === true, 'Response body should indicate success');
+        assert(response.result?.rateLimit, 'Response should have rateLimit property');
+        assert.equal(response.result.rateLimit?.resource, 'core', 'Rate limit resource should be "core"');
+        assert.equal(response.result.rateLimit?.delay, 0.5, 'Rate limit delay should be 0.5');
+        assert.equal(response.result.rateLimit?.limit, 1000, 'Rate limit limit should be 1000');
+        assert.equal(response.result.rateLimit?.remaining, 999, 'Rate limit remaining should be 999');
+        assert.equal(response.result.rateLimit?.reset, 1625078400, 'Rate limit reset should be 1625078400');
+        assert.equal(response.result.rateLimit?.retryAfter, 1, 'Rate limit retryAfter should be 1');
     });
 
     it('sets the user agent correctly when request settings are not specified', async () => {


### PR DESCRIPTION
## Summary

Integrates rate limit headers into all API responses automatically by wrapping the underlying HTTP and REST clients — **no API client regeneration needed**.

This is an improvement over [#654](https://github.com/microsoft/azure-devops-node-api/pull/654) which required regenerating all API clients to surface rate limit headers.

## Approach

Instead of modifying every generated API client, this PR introduces thin wrappers (AdoHttpClient and AdoRestClient) that intercept responses at the transport layer and attach parsed rate limit headers as a 
ateLimit property.

## Changes

| File | Change |
|------|--------|
| pi/RateLimitUtils.ts | New — shared xtractRateLimitHeaders() utility |
| pi/AdoHttpClientBases.ts | New — AdoHttpClient and AdoRestClient wrappers |
| pi/ClientApiBases.ts | Uses new wrappers, delegates extraction to RateLimitUtils |
| pi/WebApi.ts | Uses AdoRestClient instead of plain RestClient |
| 	est/units/tests.ts | Unit test validating rate limit headers on responses |
| package.json / lock files | Version bump to 15.1.4 |

## How it works

- AdoHttpClient overrides 
equest() — attaches 
ateLimit to the raw HTTP response and message objects
- AdoRestClient overrides processResponse() — attaches 
ateLimit to 
esponse.result on success, and to the error object on failure (e.g., 429)
- Consumers access rate limit info via 
esponse.result.rateLimit (success) or rr.rateLimit (error)

## Rate Limit Headers Extracted

- x-ratelimit-resource → 
ateLimit.resource
- x-ratelimit-delay → 
ateLimit.delay
- x-ratelimit-limit → 
ateLimit.limit
- x-ratelimit-remaining → 
ateLimit.remaining
- x-ratelimit-reset → 
ateLimit.reset
- 
etry-after → 
ateLimit.retryAfter

## Testing

- Unit test added (nock-based) — passes ✅
- Live validation against DevFabric with low RU thresholds — screenshots to follow
- 
<img width="1883" height="121" alt="image" src="https://github.com/user-attachments/assets/e7401e52-7c28-4b59-b918-2ca591326a5f" />


## Related

- Builds on the RateLimit interface from [#654](https://github.com/microsoft/azure-devops-node-api/pull/654)
- Supersedes the regeneration approach in [#654](https://github.com/microsoft/azure-devops-node-api/pull/654)