### PR TITLE
Fix the npm registry issue in release pipeline

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -44,11 +44,11 @@ extends:
           inputs:
             versionSpec: '16.x'
           displayName: Install node
-        - script: npm install -g npm@8
-          displayName: Upgrade npm
         - task: NpmAuthenticate@0
           inputs:
             workingFile: .npmrc
+        - script: npm install -g npm@8
+          displayName: Upgrade npm    
         - script: npm install
           displayName: npm install
         - script: npm run build

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -49,8 +49,6 @@ extends:
         - task: NpmAuthenticate@0
           inputs:
             workingFile: .npmrc
-        - script: npm install -g npm@8
-          displayName: Upgrade npm    
         - script: npm install
           displayName: npm install
         - script: npm run build

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -42,13 +42,22 @@ extends:
         dependsOn: BuildAndTest
         condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
         steps:
-        - task: NodeTool@0
+        - task: UseNode@1
           inputs:
-            versionSpec: '16.x'
+            version: '16.x'
           displayName: Install node
         - task: NpmAuthenticate@0
           inputs:
             workingFile: .npmrc
+        - script: |
+            CURRENT_MAJOR=$(npm --version | cut -d. -f1)
+            if [ "$CURRENT_MAJOR" -lt 8 ]; then
+              echo "Required npm 8 not present (current: $CURRENT_MAJOR). Installing..."
+              npm install -g npm@8 --userconfig=$(Build.SourcesDirectory)/.npmrc
+            else
+              echo "Required npm 8 is already present (current: $CURRENT_MAJOR). Skipping."
+            fi
+          displayName: Upgrade npm (if needed)
         - script: npm install
           displayName: npm install
         - script: npm run build
@@ -84,9 +93,9 @@ extends:
         steps:
         - checkout: self
           clean: true
-        - task: NodeTool@0
+        - task: UseNode@1
           inputs:
-            versionSpec: 16.x
+            version: 16.x
           displayName: Install node
         - task: NpmAuthenticate@0
           inputs:

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -17,6 +17,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    settings:
+      networkIsolationPolicy: Preferred,CFSClean,NodeTool
     sdl:
       sbom:
         enabled: false

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -25,13 +25,22 @@ jobs:
   strategy:
     matrix: ${{ parameters.nodeVersions }}
   steps:
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: $(versionSpec)
+      version: $(versionSpec)
     displayName: Install node
   - task: NpmAuthenticate@0
     inputs:
       workingFile: .npmrc
+  - script: |
+      CURRENT_MAJOR=$(npm --version | cut -d. -f1)
+      if [ "$CURRENT_MAJOR" -lt "$(npmVersion)" ]; then
+        echo "Required npm $(npmVersion) not present (current: $CURRENT_MAJOR). Installing..."
+        npm install -g npm@$(npmVersion) --userconfig=$(Build.SourcesDirectory)/.npmrc
+      else
+        echo "Required npm $(npmVersion) is already present (current: $CURRENT_MAJOR). Skipping."
+      fi
+    displayName: Upgrade npm (if needed)
   - script: npm install
     displayName: npm install
   - script: npm run build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -29,11 +29,11 @@ jobs:
     inputs:
       versionSpec: $(versionSpec)
     displayName: Install node
-  - script: npm install -g npm@$(npmVersion)
-    displayName: Upgrade npm
   - task: NpmAuthenticate@0
     inputs:
       workingFile: .npmrc
+  - script: npm install -g npm@$(npmVersion)
+    displayName: Upgrade npm    
   - script: npm install
     displayName: npm install
   - script: npm run build

--- a/.azure-pipelines/build-template.yml
+++ b/.azure-pipelines/build-template.yml
@@ -32,8 +32,6 @@ jobs:
   - task: NpmAuthenticate@0
     inputs:
       workingFile: .npmrc
-  - script: npm install -g npm@$(npmVersion)
-    displayName: Upgrade npm    
   - script: npm install
     displayName: npm install
   - script: npm run build


### PR DESCRIPTION
 Problem

  The node-api-release [pipeline ](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31541191&view=results)is failing due to 1ES Network Isolation (Enforce mode) blocking outbound connections:

   1. NodeTool@0 step fails for Node 16.x, 18.x — Network Isolation blocks connections to nodejs.org, preventing Node binary downloads.
   2. Upgrade npm step fails for Node 20.x, 22.x, 24.x — Network Isolation (CFSClean policy) blocks connections to registry.npmjs.org, preventing npm install -g npm@8.

  Root Cause

   - The pipeline's Network Isolation policy (Preferred,CFSClean) does not include the NodeTool shared policy, which is required to allow downloads from nodejs.org.
   - The CFSClean policy intentionally blocks all public package registries (including registry.npmjs.org) for SFI compliance. The Upgrade npm step (npm install -g npm@8) attempts to download from registry.npmjs.org, which is blocked.

  Fix

   1. Added NodeTool to the network isolation policy — Allows nodejs.org access so NodeTool@0 can download Node binaries.
   2.  Made npm upgrade conditional — Instead of always running npm install -g npm@(npmversion) (which fails under CFSClean), the step now checks the bundled npm major version and only upgrades if below the required version. Uses --userconfig to read auth from the project .npmrc (set by NpmAuthenticate).
   3.  Upgraded NodeTool@0 to UseNode@1 — NodeTool@0 is deprecated; replaced with UseNode@1 (updated versionSpec → version input accordingly).

  Testing

   - Verified that the pipeline runs successfully with the NodeTool policy added and the Upgrade npm step removed.
   https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31616938&view=results
