### PR TITLE
Update network isolation policy in release pipeline configuration

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -18,7 +18,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Preferred,CFSClean,NodeTool
+      networkIsolationPolicy: Preferred,Npm,NodeTool
     sdl:
       sbom:
         enabled: false


### PR DESCRIPTION
## Summary

Removes `CFSClean` in the release pipeline's `networkIsolationPolicy` so that `npm publish` can reach `registry.npmjs.org`.

## Problem

The "Publish azure-devops-node-api to npm" step in the release pipeline was failing with:

```
npm ERR! FetchError: request to https://registry.npmjs.org/azure-devops-node-api failed,
         reason: connect EPERM 192.0.2.14:443 - Local (0.0.0.0:0)
```

1ES network isolation uses to blackhole DNS lookups for non-allow-listed hostnames.
The pipeline opts into the `CFSClean` shared deny policy, which explicitly blocks `registry.npmjs.org`.
The publish step therefore could never reach npm.

- **Removed `CFSClean`** — keeping it would override the `Npm` allow rule and continue to block the publish. Since this pipeline's purpose is to publish a public npm package, `CFSClean` is not appropriate here.
