### PR TITLE
Update network isolation mode

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -18,7 +18,7 @@ extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
-      networkIsolationPolicy: Preferred,CFSClean,NodeTool,Npm
+      networkIsolationMode: Audit
     sdl:
       sbom:
         enabled: false


### PR DESCRIPTION
 Problem

  The [publish step](https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31617405&view=logs&j=717f0d41-eb34-5bd2-8cb0-f731fa91171b&t=9481b0de-accb-5891-7eb3-2cd41f2971ca) in the node-api-release pipeline is failing because CFSClean blocks outbound connections to registry.npmjs.org:

   FetchError: request to https://registry.npmjs.org/azure-devops-node-api failed,
   reason: connect EPERM 192.0.2.14:443

  Fix
   Added `networkIsolationMode: Audit`  and removed `networkIsolationPolicy: Preferred,CFSClean,NodeTool,Npm` created in https://github.com/microsoft/azure-devops-node-api/pull/670

Test 
https://dev.azure.com/mseng/AzureDevOps/_build/results?buildId=31629793&view=results