### PR TITLE
Migrate npm publishing to ESRP Release

### DIFF
--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -72,8 +72,8 @@ extends:
               echo "Required npm 8 is already present (current: $CURRENT_MAJOR). Skipping."
             fi
           displayName: Upgrade npm (if needed)
-        - script: npm install
-          displayName: npm install
+        - script: npm ci
+          displayName: npm ci
         - script: npm run build
           displayName: npm run build
         - script: npm run units

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -102,40 +102,41 @@ extends:
             done
           displayName: Verify SBOM is outside npm package
 
-    - stage: PublishToNpmViaESRP
-      displayName: Publish to npm via ESRP
-      dependsOn: BuildAndPack
-      condition: and(succeeded(), eq('${{ parameters.dryRun }}', 'false'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-      jobs:
-      - job: esrp
-        displayName: Publish npm package
-        pool:
-          name: 1ES-ABTT-Shared-Pool
-          image: abtt-windows-2025
-          os: windows
-        templateContext:
-          type: releaseJob
-          isProduction: true
-          inputs:
-          - input: pipelineArtifact
-            artifactName: npm-packages
-            targetPath: $(Pipeline.Workspace)/npm-packages
-        steps:
-        - task: EsrpRelease@12
-          displayName: Publish package to npm via ESRP
-          inputs:
-            connectedservicename: '$(EsrpServiceConnection)'
-            usemanagedidentity: true
-            keyvaultname: '$(EsrpKeyVault)'
-            signcertname: '$(EsrpSignCert)'
-            clientid: '$(EsrpClientId)'
-            intent: 'PackageDistribution'
-            contenttype: 'npm'
-            contentsource: 'Folder'
-            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
-            waitforreleasecompletion: true
-            owners: '$(EsrpOwners)'
-            approvers: '$(EsrpApprovers)'
-            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
-            mainpublisher: '$(EsrpMainPublisher)'
-            domaintenantid: '$(EsrpDomainTenantId)'
+    - ${{ if eq(parameters.dryRun, false) }}:
+      - stage: PublishToNpmViaESRP
+        displayName: Publish to npm via ESRP
+        dependsOn: BuildAndPack
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+        jobs:
+        - job: esrp
+          displayName: Publish npm package
+          pool:
+            name: 1ES-ABTT-Shared-Pool
+            image: abtt-windows-2025
+            os: windows
+          templateContext:
+            type: releaseJob
+            isProduction: true
+            inputs:
+            - input: pipelineArtifact
+              artifactName: npm-packages
+              targetPath: $(Pipeline.Workspace)/npm-packages
+          steps:
+          - task: EsrpRelease@12
+            displayName: Publish package to npm via ESRP
+            inputs:
+              connectedservicename: '$(EsrpServiceConnection)'
+              usemanagedidentity: true
+              keyvaultname: '$(EsrpKeyVault)'
+              signcertname: '$(EsrpSignCert)'
+              clientid: '$(EsrpClientId)'
+              intent: 'PackageDistribution'
+              contenttype: 'npm'
+              contentsource: 'Folder'
+              folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+              waitforreleasecompletion: true
+              owners: '$(EsrpOwners)'
+              approvers: '$(EsrpApprovers)'
+              serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+              mainpublisher: '$(EsrpMainPublisher)'
+              domaintenantid: '$(EsrpDomainTenantId)'

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -1,12 +1,25 @@
-# Release Pipeline - Build, Test, and Release
-# This pipeline will be extended to the OneESPT template
+# Manual release pipeline: build and pack, then publish to npm through ESRP.
+name: $(Date:yyyyMMdd)$(Rev:.r)
+
 trigger: none
+pr: none
 
 parameters:
 - name: dryRun
-  displayName: 'Dry Run (test publish without actually publishing)'
+  displayName: 'Dry run (build and pack without publishing)'
   type: boolean
   default: false
+
+variables:
+- group: esrp-npm-release
+- name: EsrpMainPublisher
+  value: 'ESRPRELPACMAN'
+- name: EsrpServiceEndpointUrl
+  value: 'https://api.esrp.microsoft.com'
+- name: EsrpDomainTenantId
+  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+- name: nodeVersion
+  value: '16.x'
 
 resources:
   repositories:
@@ -14,37 +27,38 @@ resources:
     type: git
     name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
+
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     settings:
       networkIsolationMode: Audit
     sdl:
-      sbom:
-        enabled: false
       sourceAnalysisPool:
         name: 1ES-ABTT-Shared-Pool
         image: abtt-windows-2025
         os: windows
-    pool:
-      name: 1ES-ABTT-Shared-Pool
-      image: abtt-ubuntu-2404
-      os: linux
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
-    - stage: Build
-      displayName: Build and Prerelease
+    - stage: BuildAndPack
+      displayName: Build, test, and pack
       jobs:
-      - template: .azure-pipelines/build-template.yml@self
-      - job: PublishPrerelease
-        displayName: Publish Prerelease
-        dependsOn: BuildAndTest
-        condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'))
+      - job: pack
+        displayName: Build and pack npm package
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-ubuntu-2404
+          os: linux
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            targetPath: $(Build.ArtifactStagingDirectory)/npm-packages
+            artifactName: npm-packages
         steps:
         - task: UseNode@1
           inputs:
-            version: '16.x'
+            version: $(nodeVersion)
           displayName: Install node
         - task: NpmAuthenticate@0
           inputs:
@@ -62,71 +76,66 @@ extends:
           displayName: npm install
         - script: npm run build
           displayName: npm run build
-        - ${{ if eq(parameters.dryRun, true) }}:
-          - task: Npm@1
-            displayName: Publish azure-devops-node-api to npm (dry run)
-            inputs:
-              command: custom
-              customCommand: publish --tag prerelease --dry-run
-              workingDir: '_build'
-              publishRegistry: useExternalRegistry
-              customEndpoint: btt-npm-publish-token
-              publishEndpoint: btt-npm-publish-token
-            continueOnError: true
-        - ${{ if eq(parameters.dryRun, false) }}:
-          - task: Npm@1
-            displayName: Publish azure-devops-node-api to npm
-            inputs:
-              command: custom
-              customCommand: publish --tag prerelease
-              workingDir: '_build'
-              publishRegistry: useExternalRegistry
-              customEndpoint: btt-npm-publish-token
-              publishEndpoint: btt-npm-publish-token
-            continueOnError: true
-    - stage: Release
-      displayName: Release to Latest
-      trigger: manual
+        - script: npm run units
+          displayName: Run unit tests
+        - script: |
+            set -e
+            mkdir -p "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+            npm pack --pack-destination "$(Build.ArtifactStagingDirectory)/npm-packages/packages"
+          workingDirectory: _build
+          displayName: Pack npm package
+        - script: |
+            count=$(ls -1 "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz 2>/dev/null | wc -l)
+            echo "Found $count .tgz file(s)."
+            if [ "$count" -eq 0 ]; then
+              echo "ERROR: npm pack produced no .tgz"
+              exit 1
+            fi
+          displayName: Verify npm package exists
+        - script: |
+            set -e
+            for tgz in "$(Build.ArtifactStagingDirectory)/npm-packages/packages"/*.tgz; do
+              if tar -tzf "$tgz" | grep -E '(^|/)_manifest/'; then
+                echo "ERROR: $tgz contains an SBOM _manifest/ folder"
+                exit 1
+              fi
+            done
+          displayName: Verify SBOM is outside npm package
+
+    - stage: PublishToNpmViaESRP
+      displayName: Publish to npm via ESRP
+      dependsOn: BuildAndPack
+      condition: and(succeeded(), eq('${{ parameters.dryRun }}', 'false'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
       jobs:
-      - job: Release
-        displayName: Release to Latest
+      - job: esrp
+        displayName: Publish npm package
+        pool:
+          name: 1ES-ABTT-Shared-Pool
+          image: abtt-windows-2025
+          os: windows
+        templateContext:
+          type: releaseJob
+          isProduction: true
+          inputs:
+          - input: pipelineArtifact
+            artifactName: npm-packages
+            targetPath: $(Pipeline.Workspace)/npm-packages
         steps:
-        - checkout: self
-          clean: true
-        - task: UseNode@1
+        - task: EsrpRelease@12
+          displayName: Publish package to npm via ESRP
           inputs:
-            version: 16.x
-          displayName: Install node
-        - task: NpmAuthenticate@0
-          inputs:
-            workingFile: .npmrc
-        - script: npm install
-          displayName: npm install
-        - script: npm run build
-          displayName: npm run build
-        - bash: |
-            package_name=$(npm pkg get name version | jq -r '"\(.name)@\(.version)"')
-            echo "Package name and version: $package_name"
-            echo "##vso[task.setvariable variable=npm_package]$package_name"
-          workingDirectory: '_build'
-          displayName: Get package name and version
-        - task: Npm@1
-          displayName: Remove prerelease tag for azure-devops-node-api in Npm
-          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'), eq('${{ parameters.dryRun }}', 'false'))
-          inputs:
-            command: custom
-            customCommand: dist-tag remove "$(npm_package)" prerelease
-            workingDir: '_build'
-            publishRegistry: useExternalRegistry
-            customEndpoint: btt-npm-publish-token
-            publishEndpoint: btt-npm-publish-token
-        - task: Npm@1
-          displayName: Add latest tag for azure-devops-node-api in Npm
-          condition: and(succeeded(), in(variables['build.reason'], 'IndividualCI', 'BatchedCI', 'Manual'), eq(variables['build.sourcebranchname'], 'master'), eq('${{ parameters.dryRun }}', 'false'))
-          inputs:
-            command: custom
-            customCommand: dist-tag add "$(npm_package)" latest
-            workingDir: '_build'
-            publishRegistry: useExternalRegistry
-            customEndpoint: btt-npm-publish-token
-            publishEndpoint: btt-npm-publish-token
+            connectedservicename: '$(EsrpServiceConnection)'
+            usemanagedidentity: true
+            keyvaultname: '$(EsrpKeyVault)'
+            signcertname: '$(EsrpSignCert)'
+            clientid: '$(EsrpClientId)'
+            intent: 'PackageDistribution'
+            contenttype: 'npm'
+            contentsource: 'Folder'
+            folderlocation: '$(Pipeline.Workspace)/npm-packages/packages'
+            waitforreleasecompletion: true
+            owners: '$(EsrpOwners)'
+            approvers: '$(EsrpApprovers)'
+            serviceendpointurl: '$(EsrpServiceEndpointUrl)'
+            mainpublisher: '$(EsrpMainPublisher)'
+            domaintenantid: '$(EsrpDomainTenantId)'

--- a/.azure-pipelines/azure-pipelines-release.yml
+++ b/.azure-pipelines/azure-pipelines-release.yml
@@ -12,12 +12,6 @@ parameters:
 
 variables:
 - group: esrp-npm-release
-- name: EsrpMainPublisher
-  value: 'ESRPRELPACMAN'
-- name: EsrpServiceEndpointUrl
-  value: 'https://api.esrp.microsoft.com'
-- name: EsrpDomainTenantId
-  value: '975f013f-7f24-47e8-a7d3-abc4752bf346'
 - name: nodeVersion
   value: '16.x'
 


### PR DESCRIPTION
## Summary

- replace direct `Npm@1` publishing with a two-stage 1ES Official ESRP release flow
- build, test, and pack fresh `_build` output into the `npm-packages/packages` artifact contract
- publish through `EsrpRelease@12` directly to npm's default `latest` dist-tag
- remove the legacy `btt-npm-publish-token` and prerelease-to-latest promotion steps
- keep `dryRun` as build-and-pack-only by omitting the ESRP stage

> [!IMPORTANT]
> Releases now publish directly to `latest`. There is no prerelease staging or prerelease soak window, so consumers receive each ESRP-published version as the current release immediately.

## Build and release contract

`BuildAndPack` runs `npm ci`, `npm run build`, unit tests, and `npm pack` in one job. The tarball is written beneath the `packages/` subfolder of the pipeline artifact named exactly `npm-packages`. Built-in guards fail when no tarball is produced or when a tarball contains an SBOM `_manifest/` directory.

`PublishToNpmViaESRP` is a production `releaseJob` that consumes the same-run artifact and publishes only from `master`. No `productstate` override is supplied, so ESRP uses npm's default `latest` tag. There is no longer a prerelease tag or promotion step.

When `dryRun` is enabled, the pipeline still builds, tests, packs, and runs both tarball guards. A compile-time conditional omits the entire `PublishToNpmViaESRP` production stage and `EsrpRelease@12` task from the expanded pipeline, so nothing is published.

## Manual ESRP onboarding prerequisites

These prerequisites are intentionally referenced but not provisioned by this PR:

- install the ESRP Release Azure DevOps extension
- register and approve the ESRP publisher identity
- create a Key Vault, import the signing certificate, and grant the publisher identity `Key Vault Certificate User`
- create an Azure Resource Manager service connection using Workload Identity Federation/OIDC for that identity
- confirm `azure-devops-node-api` is on ESRP's npm publisher allow-list and the publisher has npm publish rights
- create and authorize the `esrp-npm-release` variable group with `EsrpServiceConnection`, `EsrpKeyVault`, `EsrpSignCert`, `EsrpClientId`, `EsrpOwners`, and `EsrpApprovers`

## Validation

- `npm ci`
- `npm run build`
- `npm run units` (31 passing)
- packed `azure-devops-node-api-16.0.0.tgz` from `_build`
- verified one tarball was produced and it contains no `_manifest/` path
- parsed the YAML with `dryRun: false` and confirmed `BuildAndPack` plus `PublishToNpmViaESRP`
- parsed the YAML with `dryRun: true` and confirmed only `BuildAndPack`, with no `EsrpRelease@12` or `isProduction` metadata
- verified no `Npm@1`, `npm publish`, npm `dist-tag`, `btt-npm-publish-token`, or npm publish-token variable remains in pipeline configuration

No package was published during validation.

---
Related work item: [AB#2440593](https://dev.azure.com/mseng/b924d696-3eae-4116-8443-9a18392d8544/_workitems/edit/2440593)